### PR TITLE
fix: restore worker fallback webhook

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,15 @@ REVALIDATE_SECRET=
 FEEDBACK_WEBHOOK_URL=
 FEEDBACK_WEBHOOK_SECRET=
 
+# Worker fallback webhook auth for /api/fallback/worker-pinpoint
+FALLBACK_WEBHOOK_SECRET=
+
+# Optional competitor-source fetch tuning for /api/fallback/worker-pinpoint
+# PINPOINT_BASE_URL=https://pinpointanswer.today/
+# COMPETITOR_FETCH_TIMEOUT_MS=30000
+# PINPOINT_FETCH_UA=
+# PINPOINT_FETCH_LANG=en-US,en;q=0.9
+
 # Optional anti-abuse controls for /api/feedback
 # FEEDBACK_RATE_LIMIT_MAX=5
 # FEEDBACK_RATE_LIMIT_WINDOW_MS=600000

--- a/app/api/fallback/worker-pinpoint/route.ts
+++ b/app/api/fallback/worker-pinpoint/route.ts
@@ -1,0 +1,84 @@
+import { NextResponse } from "next/server";
+import {
+  loadBundledWorkerFallback,
+  loadCompetitorWorkerFallback,
+} from "@/lib/puzzles/worker-fallback";
+
+type WorkerRequestBody = {
+  date?: unknown;
+};
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+function normalizeRequestedDate(input: unknown): string | null {
+  if (typeof input !== "string") return null;
+  const value = input.trim();
+  return /^\d{4}-\d{2}-\d{2}$/.test(value) ? value : null;
+}
+
+function buildNoStoreHeaders(extra?: HeadersInit): HeadersInit {
+  return {
+    "Cache-Control": "no-store",
+    ...extra,
+  };
+}
+
+export async function POST(req: Request) {
+  try {
+    const expectedSecret = String(process.env.FALLBACK_WEBHOOK_SECRET || "").trim();
+    const providedSecret = String(req.headers.get("x-webhook-secret") || "").trim();
+
+    if (expectedSecret && providedSecret !== expectedSecret) {
+      return new NextResponse("unauthorized", { status: 401 });
+    }
+
+    const today = new Date().toISOString().slice(0, 10);
+    let requestedDate = today;
+
+    try {
+      const body = (await req.json()) as WorkerRequestBody;
+      requestedDate = normalizeRequestedDate(body?.date) || today;
+    } catch {
+      requestedDate = today;
+    }
+
+    const localPayload = await loadBundledWorkerFallback(requestedDate);
+    if (localPayload) {
+      return NextResponse.json(localPayload, {
+        status: 200,
+        headers: buildNoStoreHeaders(),
+      });
+    }
+
+    if (requestedDate !== today) {
+      return NextResponse.json(
+        { error: "not found", date: requestedDate },
+        { status: 404, headers: buildNoStoreHeaders() },
+      );
+    }
+
+    try {
+      const competitorPayload = await loadCompetitorWorkerFallback();
+      return NextResponse.json(competitorPayload, {
+        status: 200,
+        headers: buildNoStoreHeaders(),
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error ?? "unknown");
+      return NextResponse.json(
+        { error: "not ready", date: requestedDate, detail: message },
+        {
+          status: 503,
+          headers: buildNoStoreHeaders({ "Retry-After": "300" }),
+        },
+      );
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error ?? "unknown");
+    return NextResponse.json(
+      { error: "internal error", detail: message },
+      { status: 500, headers: buildNoStoreHeaders() },
+    );
+  }
+}

--- a/docs/final-cutover-gap-list-2026-03-13.md
+++ b/docs/final-cutover-gap-list-2026-03-13.md
@@ -27,6 +27,13 @@
 
 ### 2. ✅ 明确 `/api/graphql` 与 `/api/fallback/worker-pinpoint` 的最终归属（2026-03-13 已完成）
 
+2026-03-15 更新：
+
+- 新仓库现已补回 `app/api/fallback/worker-pinpoint/route.ts`
+- Worker 默认 `FALLBACK_WEBHOOK` 也已重新指向 `https://pinpointanswertoday.app/api/fallback/worker-pinpoint`
+- 当前口径应理解为：这条 gap 在 `2026-03-13` 时真实存在，但已于 `2026-03-15` 修复
+- `api/graphql` 仍未在新仓库恢复；当前主抓取继续直接打 LinkedIn Voyager GraphQL
+
 原始问题：
 
 - 处理前，新仓库 Worker 配置曾指向：

--- a/lib/puzzles/worker-fallback.ts
+++ b/lib/puzzles/worker-fallback.ts
@@ -1,0 +1,168 @@
+import { getPuzzleBySlug, getPuzzleSlugByPublishDate } from "@/lib/puzzles/data";
+
+export type WorkerFallbackAnswer = {
+  rank: number;
+  word: string;
+};
+
+export type WorkerFallbackPayload = {
+  source: "fallback-local" | "fallback-competitor";
+  theme: string;
+  mainAnswer: string;
+  answers: WorkerFallbackAnswer[];
+};
+
+type CompetitorSnapshot = {
+  clue1?: unknown;
+  clue2?: unknown;
+  clue3?: unknown;
+  clue4?: unknown;
+  clue5?: unknown;
+  answer?: unknown;
+};
+
+const COMPETITOR_CLUE_KEYS = ["clue1", "clue2", "clue3", "clue4", "clue5"] as const;
+const COMPETITOR_TODAY_BLOCK_MARKER = '\\"todayPinpointData\\":{';
+const DEFAULT_COMPETITOR_URL = "https://pinpointanswer.today/";
+
+function normalizeAnswerWords(words: string[]): WorkerFallbackAnswer[] {
+  return words.map((word, index) => ({
+    rank: index + 1,
+    word,
+  }));
+}
+
+function normalizeDate(date: string): string | null {
+  return /^\d{4}-\d{2}-\d{2}$/.test(date) ? date : null;
+}
+
+export async function loadBundledWorkerFallback(date: string): Promise<WorkerFallbackPayload | null> {
+  const isoDate = normalizeDate(date);
+  if (!isoDate) return null;
+
+  const slug = await getPuzzleSlugByPublishDate(isoDate);
+  if (!slug) return null;
+
+  const puzzle = await getPuzzleBySlug(slug);
+  if (!puzzle) return null;
+
+  const words = puzzle.clues
+    .map((word) => String(word || "").trim())
+    .filter((word) => word.length > 0);
+
+  if (words.length !== 5 || !puzzle.answer.trim()) return null;
+
+  return {
+    source: "fallback-local",
+    theme: puzzle.answer.trim(),
+    mainAnswer: puzzle.answer.trim(),
+    answers: normalizeAnswerWords(words),
+  };
+}
+
+function normalizeCompetitorUrl(input: string | undefined): string {
+  const raw = String(input || "").trim() || DEFAULT_COMPETITOR_URL;
+  return raw.endsWith("/") ? raw : `${raw}/`;
+}
+
+function extractCompetitorTodayBlock(html: string): CompetitorSnapshot {
+  const markerIndex = html.indexOf(COMPETITOR_TODAY_BLOCK_MARKER);
+  if (markerIndex === -1) {
+    throw new Error("todayPinpointData block not found");
+  }
+
+  const jsonStart = markerIndex + COMPETITOR_TODAY_BLOCK_MARKER.length - 1;
+  let depth = 0;
+  let endIndex = -1;
+
+  for (let index = jsonStart; index < html.length; index += 1) {
+    const char = html[index];
+    if (char === "{") depth += 1;
+    if (char === "}") {
+      depth -= 1;
+      if (depth === 0) {
+        endIndex = index;
+        break;
+      }
+    }
+  }
+
+  if (endIndex === -1) {
+    throw new Error("todayPinpointData block was not closed properly");
+  }
+
+  const rawObject = html.slice(jsonStart, endIndex + 1);
+  const candidates = [
+    rawObject,
+    rawObject.replace(/\\\\\"/g, '\\"'),
+    rawObject.replace(/\\\\\"/g, '\\"').replace(/\\"/g, '"'),
+    rawObject.replace(/\\"/g, '"'),
+  ];
+
+  for (const candidate of candidates) {
+    try {
+      return JSON.parse(candidate) as CompetitorSnapshot;
+    } catch {
+      // Try the next escape-normalization candidate.
+    }
+  }
+
+  throw new Error("todayPinpointData JSON could not be parsed");
+}
+
+function extractCompetitorClues(snapshot: CompetitorSnapshot): string[] {
+  return COMPETITOR_CLUE_KEYS.map((key) => snapshot[key])
+    .map((value) => (typeof value === "string" ? value.trim() : String(value ?? "").trim()))
+    .filter((value) => value.length > 0);
+}
+
+export async function loadCompetitorWorkerFallback(): Promise<WorkerFallbackPayload> {
+  const targetUrl = normalizeCompetitorUrl(process.env.PINPOINT_BASE_URL);
+  const timeoutMs = Number.parseInt(process.env.COMPETITOR_FETCH_TIMEOUT_MS ?? "30000", 10);
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetch(targetUrl, {
+      signal: controller.signal,
+      headers: {
+        "User-Agent":
+          process.env.PINPOINT_FETCH_UA ||
+          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125 Safari/537.36",
+        "Accept-Language": process.env.PINPOINT_FETCH_LANG || "en-US,en;q=0.9",
+        Accept: "text/html,application/xhtml+xml",
+      },
+      cache: "no-store",
+    });
+
+    if (!response.ok) {
+      throw new Error(`competitor fetch failed with status ${response.status}`);
+    }
+
+    const html = await response.text();
+    const snapshot = extractCompetitorTodayBlock(html);
+    const answers = extractCompetitorClues(snapshot);
+    const mainAnswer =
+      typeof snapshot.answer === "string" ? snapshot.answer.trim() : String(snapshot.answer ?? "").trim();
+
+    if (answers.length !== 5 || !mainAnswer) {
+      throw new Error(
+        `competitor snapshot invalid (answers=${answers.length}, theme=${mainAnswer ? "ok" : "missing"})`,
+      );
+    }
+
+    return {
+      source: "fallback-competitor",
+      theme: mainAnswer,
+      mainAnswer,
+      answers: normalizeAnswerWords(answers),
+    };
+  } catch (error) {
+    if (error instanceof Error && error.name === "AbortError") {
+      throw new Error(`competitor fetch timeout after ${timeoutMs}ms`);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}

--- a/worker/README.md
+++ b/worker/README.md
@@ -40,7 +40,7 @@ wrangler deploy --env staging --name pinpoint-worker-staging  # 受控演练（�
 | `GITHUB_TOKEN_NEW_SITE` | GitHub fine-grained PAT，`contents:write` on `elng12/pinpoint-answer-today-new` | ❌ | ✅ |
 | `NEW_SITE_REVALIDATE_SECRET` | 必须与 Vercel `REVALIDATE_SECRET` 值完全一致 | ❌ | ✅ |
 | `FEISHU_WEBHOOK_URL` | 飞书告警 webhook URL | ❌ | ✅ |
-| `FALLBACK_WEBHOOK_SECRET` | Playwright fallback webhook HMAC 签名密钥（`FALLBACK_WEBHOOK` 已清空，此密钥暂不生效） | ❌ | ❌ |
+| `FALLBACK_WEBHOOK_SECRET` | Worker 调站点 `/api/fallback/worker-pinpoint` 的 HMAC 签名密钥 | ❌ | ✅ |
 | `ADMIN_SECRET` | 受保护管理接口的密钥 | 可选 | ✅ |
 | `WORKER_ADMIN_SECRET` | 预留的 Worker 管理接口独立密钥；当前 `/admin/run` 仍使用 `ADMIN_SECRET` | 可选 | ✅ |
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -11,7 +11,7 @@ export interface Env {
   GRAPHQL_COOKIE?: string;     // optional: raw cookie string, e.g. "li_at=...; other=..."
   VOYAGER_GRAPHQL_ENDPOINT?: string; // LinkedIn Voyager GraphQL upstream, e.g. https://www.linkedin.com/voyager/api/graphql
   ADMIN_SECRET?: string;       // admin secret for protected endpoints
-  FALLBACK_WEBHOOK?: string;   // optional: Playwright 回退 webhook URL
+  FALLBACK_WEBHOOK?: string;   // optional: fallback webhook URL
   FALLBACK_WEBHOOK_SECRET?: string; // optional: webhook shared secret
 
   ADMIN_PUT_DOC_ENABLED?: string; // 'true' 才启用
@@ -46,11 +46,12 @@ export interface Env {
 }
 
 type Answer = { rank: number; word: string; confidence?: number };
+type DocSource = "graphql" | "fallback-webhook" | "fallback-local" | "fallback-competitor";
 type Doc = {
   version: 1;
   puzzleDate: string;
   answers: Answer[];
-  source: "graphql" | "playwright";
+  source: DocSource;
   fetchedAt: string
   checksum: string;
   theme?: string;
@@ -105,6 +106,7 @@ type FallbackPayload = {
   answers?: GraphQLAnswer[];
   theme?: unknown;
   mainAnswer?: unknown;
+  source?: unknown;
 };
 
 type GraphQLProxyBody = {
@@ -304,6 +306,14 @@ function normalizeBaseUrl(input: string | undefined, fallback: string): string {
     ? raw
     : `https://${raw.replace(/^\/+/g, "")}`;
   return withProtocol.replace(/\/+$/, "");
+}
+
+function normalizeFallbackSource(raw: unknown): DocSource {
+  const source = typeof raw === "string" ? raw.trim() : "";
+  if (source === "fallback-local" || source === "fallback-competitor") {
+    return source;
+  }
+  return "fallback-webhook";
 }
 
 function getPublicSiteBaseUrl(env: Env): string {
@@ -2523,9 +2533,10 @@ async function callPlaywrightFallback(env: Env, date: string): Promise<Doc> {
   const answers = toAnswers(j?.answers);
   const theme = typeof j?.theme === "string" ? j.theme.trim() : undefined;
   const mainAnswer = typeof j?.mainAnswer === "string" ? j.mainAnswer.trim() : theme;
+  const source = normalizeFallbackSource(j?.source);
   const fetchedAt = new Date().toISOString();
   const checksum = `sha256:${await sha256Hex(JSON.stringify(answers))}`;
-  return { version: 1, puzzleDate: date, answers, source: "playwright", fetchedAt, checksum, theme, mainAnswer };
+  return { version: 1, puzzleDate: date, answers, source, fetchedAt, checksum, theme, mainAnswer };
 }
 
 export default {
@@ -3068,7 +3079,7 @@ export default {
           version: 1,
           puzzleDate: date,
           answers,
-          source: 'playwright',
+          source: "fallback-webhook",
           fetchedAt: new Date().toISOString(),
           checksum,
           theme,

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -26,7 +26,7 @@ crons = ["1,3,7,10,15,20 8 * * *"]
 [vars]
 GRAPHQL_ENDPOINT            = ""
 VOYAGER_GRAPHQL_ENDPOINT    = "https://www.linkedin.com/voyager/api/graphql"
-FALLBACK_WEBHOOK            = ""
+FALLBACK_WEBHOOK            = "https://pinpointanswertoday.app/api/fallback/worker-pinpoint"
 ALLOW_SELF_GRAPHQL          = "false"
 
 # New-site direct publish (GitHub)
@@ -64,7 +64,7 @@ SITE_BASE_URL               = ""
 # GITHUB_TOKEN_NEW_SITE        — Fine-grained PAT: contents:write on new repo
 # NEW_SITE_REVALIDATE_SECRET   — Must match REVALIDATE_SECRET in Vercel env
 # FEISHU_WEBHOOK_URL           — Feishu webhook URL for cron alerts
-# FALLBACK_WEBHOOK_SECRET      — HMAC signing secret for fallback webhook (unused; FALLBACK_WEBHOOK cleared)
+# FALLBACK_WEBHOOK_SECRET      — HMAC signing secret for fallback webhook
 # ADMIN_SECRET                 — Admin secret for protected endpoints
 # WORKER_ADMIN_SECRET          — Worker admin secret (separate from ADMIN_SECRET)
 
@@ -91,7 +91,7 @@ preview_id = "pp_data_dev"
 [env.shadow.vars]
 GRAPHQL_ENDPOINT            = ""
 VOYAGER_GRAPHQL_ENDPOINT    = "https://www.linkedin.com/voyager/api/graphql"
-FALLBACK_WEBHOOK            = ""
+FALLBACK_WEBHOOK            = "https://pinpointanswertoday.app/api/fallback/worker-pinpoint"
 ALLOW_SELF_GRAPHQL          = "false"
 GITHUB_REPO_NEW_SITE        = "elng12/pinpoint-answer-today-new"
 GITHUB_BRANCH_NEW_SITE      = "main"
@@ -126,7 +126,7 @@ binding = "AI"
 [env.staging.vars]
 GRAPHQL_ENDPOINT            = ""
 VOYAGER_GRAPHQL_ENDPOINT    = "https://www.linkedin.com/voyager/api/graphql"
-FALLBACK_WEBHOOK            = ""
+FALLBACK_WEBHOOK            = "https://pinpointanswertoday.app/api/fallback/worker-pinpoint"
 ALLOW_SELF_GRAPHQL          = "false"
 GITHUB_REPO_NEW_SITE        = "elng12/pinpoint-answer-today-new"
 GITHUB_BRANCH_NEW_SITE      = "main"


### PR DESCRIPTION
## What changed
- restore `/api/fallback/worker-pinpoint` in the new site repo
- let the fallback route read bundled puzzle data first, then use competitor clues for today when official fetch has not produced local JSON yet
- re-enable `FALLBACK_WEBHOOK` in the Worker defaults and preserve fallback source labels in Worker logs/alerts
- update env/docs so future deploys keep the fallback chain intact

## Verification
- `npm run typecheck`
- `npm run build`
- local POST to `/api/fallback/worker-pinpoint` returned today's #684 payload
- production POST to `/api/fallback/worker-pinpoint` now returns `401 unauthorized` without the shared secret
- deployed Vercel production and Cloudflare Worker production successfully
