### PR TITLE
feat: add manual fallback self-test

### DIFF
--- a/app/api/fallback/worker-pinpoint/route.ts
+++ b/app/api/fallback/worker-pinpoint/route.ts
@@ -2,10 +2,13 @@ import { NextResponse } from "next/server";
 import {
   loadBundledWorkerFallback,
   loadCompetitorWorkerFallback,
+  normalizeWorkerFallbackMode,
+  type WorkerFallbackMode,
 } from "@/lib/puzzles/worker-fallback";
 
 type WorkerRequestBody = {
   date?: unknown;
+  mode?: unknown;
 };
 
 export const runtime = "nodejs";
@@ -35,17 +38,66 @@ export async function POST(req: Request) {
 
     const today = new Date().toISOString().slice(0, 10);
     let requestedDate = today;
+    let requestedMode: WorkerFallbackMode = "auto";
 
     try {
       const body = (await req.json()) as WorkerRequestBody;
       requestedDate = normalizeRequestedDate(body?.date) || today;
+      requestedMode = normalizeWorkerFallbackMode(body?.mode);
     } catch {
       requestedDate = today;
+      requestedMode = "auto";
+    }
+
+    if (requestedMode === "local") {
+      const localPayload = await loadBundledWorkerFallback(requestedDate);
+      if (!localPayload) {
+        return NextResponse.json(
+          { error: "not found", mode: requestedMode, date: requestedDate },
+          { status: 404, headers: buildNoStoreHeaders() },
+        );
+      }
+
+      return NextResponse.json(
+        { ...localPayload, mode: requestedMode, date: requestedDate },
+        { status: 200, headers: buildNoStoreHeaders() },
+      );
+    }
+
+    if (requestedMode === "competitor") {
+      if (requestedDate !== today) {
+        return NextResponse.json(
+          {
+            error: "competitor mode only supports today",
+            mode: requestedMode,
+            date: requestedDate,
+            today,
+          },
+          { status: 400, headers: buildNoStoreHeaders() },
+        );
+      }
+
+      try {
+        const competitorPayload = await loadCompetitorWorkerFallback();
+        return NextResponse.json(
+          { ...competitorPayload, mode: requestedMode, date: requestedDate },
+          { status: 200, headers: buildNoStoreHeaders() },
+        );
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error ?? "unknown");
+        return NextResponse.json(
+          { error: "not ready", mode: requestedMode, date: requestedDate, detail: message },
+          {
+            status: 503,
+            headers: buildNoStoreHeaders({ "Retry-After": "300" }),
+          },
+        );
+      }
     }
 
     const localPayload = await loadBundledWorkerFallback(requestedDate);
     if (localPayload) {
-      return NextResponse.json(localPayload, {
+      return NextResponse.json({ ...localPayload, mode: requestedMode, date: requestedDate }, {
         status: 200,
         headers: buildNoStoreHeaders(),
       });
@@ -60,7 +112,7 @@ export async function POST(req: Request) {
 
     try {
       const competitorPayload = await loadCompetitorWorkerFallback();
-      return NextResponse.json(competitorPayload, {
+      return NextResponse.json({ ...competitorPayload, mode: requestedMode, date: requestedDate }, {
         status: 200,
         headers: buildNoStoreHeaders(),
       });

--- a/lib/puzzles/worker-fallback.ts
+++ b/lib/puzzles/worker-fallback.ts
@@ -5,6 +5,8 @@ export type WorkerFallbackAnswer = {
   word: string;
 };
 
+export type WorkerFallbackMode = "auto" | "local" | "competitor";
+
 export type WorkerFallbackPayload = {
   source: "fallback-local" | "fallback-competitor";
   theme: string;
@@ -34,6 +36,12 @@ function normalizeAnswerWords(words: string[]): WorkerFallbackAnswer[] {
 
 function normalizeDate(date: string): string | null {
   return /^\d{4}-\d{2}-\d{2}$/.test(date) ? date : null;
+}
+
+export function normalizeWorkerFallbackMode(input: unknown): WorkerFallbackMode {
+  const value = typeof input === "string" ? input.trim().toLowerCase() : "";
+  if (value === "local" || value === "competitor") return value;
+  return "auto";
 }
 
 export async function loadBundledWorkerFallback(date: string): Promise<WorkerFallbackPayload | null> {

--- a/worker/README.md
+++ b/worker/README.md
@@ -125,6 +125,43 @@ curl "https://pinpoint-worker-shadow.2296744453m.workers.dev/admin/run?secret=$A
 
 ---
 
+## 手动兜底自测
+
+当前兜底自测入口是 Worker 管理接口 `/admin/test-fallback`。
+
+- 生产地址：`https://pinpoint-worker.2296744453m.workers.dev/admin/test-fallback`
+- 这个接口只做检查，不写 KV、不发 GitHub、不触发 revalidate
+
+常用参数：
+
+- `secret=<ADMIN_SECRET>`：必填
+- `date=YYYY-MM-DD`：可选，默认今天
+- `mode=auto|local|competitor`：可选，默认 `auto`
+
+模式含义：
+
+- `auto`：按真实线上兜底顺序测试，先看站点本地当天数据，没有再看竞争对手
+- `local`：只测“本地当天 JSON 是否能接住”
+- `competitor`：只测“竞争对手兜底是否还能抓到今天线索”；这个模式只支持今天
+
+推荐命令：
+
+```bash
+export ADMIN_SECRET='<your-admin-secret>'
+
+curl "https://pinpoint-worker.2296744453m.workers.dev/admin/test-fallback?secret=$ADMIN_SECRET"
+curl "https://pinpoint-worker.2296744453m.workers.dev/admin/test-fallback?secret=$ADMIN_SECRET&mode=local&date=2026-03-15"
+curl "https://pinpoint-worker.2296744453m.workers.dev/admin/test-fallback?secret=$ADMIN_SECRET&mode=competitor"
+```
+
+返回含义：
+
+- 返回 `200` + JSON：兜底链路当前可用，会带上 `source` 和前 5 个答案词
+- 返回 `500` + JSON：这条兜底模式当前不可用，看 `error`
+- 返回 `401 unauthorized`：`secret` 不对
+
+---
+
 ## 关键配置
 
 | 配置项 | 值 |

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -107,7 +107,11 @@ type FallbackPayload = {
   theme?: unknown;
   mainAnswer?: unknown;
   source?: unknown;
+  mode?: unknown;
+  date?: unknown;
 };
+
+type FallbackMode = "auto" | "local" | "competitor";
 
 type GraphQLProxyBody = {
   query?: unknown;
@@ -314,6 +318,14 @@ function normalizeFallbackSource(raw: unknown): DocSource {
     return source;
   }
   return "fallback-webhook";
+}
+
+function normalizeFallbackMode(raw: unknown): FallbackMode {
+  const mode = typeof raw === "string" ? raw.trim().toLowerCase() : "";
+  if (mode === "local" || mode === "competitor") {
+    return mode;
+  }
+  return "auto";
 }
 
 function getPublicSiteBaseUrl(env: Env): string {
@@ -2502,7 +2514,7 @@ class FallbackNotReadyError extends Error {
   }
 }
 
-async function callPlaywrightFallback(env: Env, date: string): Promise<Doc> {
+async function callPlaywrightFallback(env: Env, date: string, mode: FallbackMode = "auto"): Promise<Doc> {
   const url = (env.FALLBACK_WEBHOOK || "").trim();
   if (!url) throw new Error("FALLBACK_WEBHOOK not set");
   const res = await fetch(url, {
@@ -2511,7 +2523,7 @@ async function callPlaywrightFallback(env: Env, date: string): Promise<Doc> {
       "content-type": "application/json",
       ...(env.FALLBACK_WEBHOOK_SECRET ? { "x-webhook-secret": (env.FALLBACK_WEBHOOK_SECRET || "").trim() } : {}),
     },
-    body: JSON.stringify({ date }),
+    body: JSON.stringify({ date, mode }),
   });
   if (!res.ok) {
     let remoteError = "";
@@ -2699,6 +2711,54 @@ export default {
         return new Response(JSON.stringify({
           ok: false,
           probeDate,
+          error: message,
+          checkedAt: new Date().toISOString(),
+          durationMs: Date.now() - startedAt,
+        }), {
+          status: 500,
+          headers: { "content-type": "application/json; charset=utf-8" },
+        });
+      }
+    }
+
+    if (url.pathname === "/admin/test-fallback") {
+      const adminSecret = getAdminSecret(env);
+      if (!adminSecret) return new Response("admin secret not configured", { status: 503 });
+      const secret = url.searchParams.get("secret");
+      if (secret !== adminSecret) return new Response("unauthorized", { status: 401 });
+
+      const requestedDate = String(url.searchParams.get("date") || "").trim();
+      const probeDate = requestedDate || new Date().toISOString().slice(0, 10);
+      const mode = normalizeFallbackMode(url.searchParams.get("mode"));
+      const startedAt = Date.now();
+
+      try {
+        const doc = await callPlaywrightFallback(env, probeDate, mode);
+        const words = doc.answers
+          .map((item) => String(item?.word || "").trim())
+          .filter((item) => item.length > 0)
+          .slice(0, 5);
+
+        return new Response(JSON.stringify({
+          ok: true,
+          probeDate,
+          mode,
+          source: doc.source,
+          answersCount: words.length,
+          words,
+          theme: doc.theme || null,
+          mainAnswer: doc.mainAnswer || doc.theme || null,
+          checkedAt: new Date().toISOString(),
+          durationMs: Date.now() - startedAt,
+        }), {
+          headers: { "content-type": "application/json; charset=utf-8" },
+        });
+      } catch (e: unknown) {
+        const message = e instanceof Error ? e.message : String(e);
+        return new Response(JSON.stringify({
+          ok: false,
+          probeDate,
+          mode,
           error: message,
           checkedAt: new Date().toISOString(),
           durationMs: Date.now() - startedAt,


### PR DESCRIPTION
## What changed
- extend the new-site fallback route to support manual test modes: `auto`, `local`, and `competitor`
- add a protected Worker admin endpoint `/admin/test-fallback` for non-destructive fallback checks
- document the new manual fallback self-test commands in the Worker README

## Verification
- `npm run typecheck` in the site repo
- `npm run typecheck` in `worker/`
- `npm run build`
- local route checks:
  - `mode=auto` returned `fallback-local`
  - `mode=local` returned `fallback-local`
  - `mode=competitor` returned `fallback-competitor`
- production Worker checks:
  - `/admin/test-fallback?...&mode=auto` returned `fallback-local`
  - `/admin/test-fallback?...&mode=local` returned `fallback-local`
  - `/admin/test-fallback?...&mode=competitor` returned `fallback-competitor`
