### PR TITLE
feat: notify fallback self-test results

### DIFF
--- a/worker/README.md
+++ b/worker/README.md
@@ -137,6 +137,7 @@ curl "https://pinpoint-worker-shadow.2296744453m.workers.dev/admin/run?secret=$A
 - `secret=<ADMIN_SECRET>`：必填
 - `date=YYYY-MM-DD`：可选，默认今天
 - `mode=auto|local|competitor`：可选，默认 `auto`
+- `notify=1`：可选，测完后把结果发到已配置的飞书 / Slack webhook
 
 模式含义：
 
@@ -152,6 +153,7 @@ export ADMIN_SECRET='<your-admin-secret>'
 curl "https://pinpoint-worker.2296744453m.workers.dev/admin/test-fallback?secret=$ADMIN_SECRET"
 curl "https://pinpoint-worker.2296744453m.workers.dev/admin/test-fallback?secret=$ADMIN_SECRET&mode=local&date=2026-03-15"
 curl "https://pinpoint-worker.2296744453m.workers.dev/admin/test-fallback?secret=$ADMIN_SECRET&mode=competitor"
+curl "https://pinpoint-worker.2296744453m.workers.dev/admin/test-fallback?secret=$ADMIN_SECRET&mode=competitor&notify=1"
 ```
 
 返回含义：
@@ -159,6 +161,10 @@ curl "https://pinpoint-worker.2296744453m.workers.dev/admin/test-fallback?secret
 - 返回 `200` + JSON：兜底链路当前可用，会带上 `source` 和前 5 个答案词
 - 返回 `500` + JSON：这条兜底模式当前不可用，看 `error`
 - 返回 `401 unauthorized`：`secret` 不对
+- 如果带了 `notify=1`，返回里还会带 `notifyRequested` / `notified`
+- 飞书示例文案：
+  - 成功：`✅ Worker 本地兜底自测正常`
+  - 失败：`❌ Worker 竞争对手兜底自测异常`
 
 ---
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -328,6 +328,26 @@ function normalizeFallbackMode(raw: unknown): FallbackMode {
   return "auto";
 }
 
+function hasNotifyWebhook(env: Env): boolean {
+  return Boolean(
+    String(env.FEISHU_WEBHOOK_URL || env.ALERT_WEBHOOK_URL || "").trim() ||
+    String(env.SLACK_WEBHOOK_URL || "").trim(),
+  );
+}
+
+function getFallbackModeLabel(mode: FallbackMode): string {
+  if (mode === "local") return "本地兜底自测";
+  if (mode === "competitor") return "竞争对手兜底自测";
+  return "兜底自测";
+}
+
+function getFallbackSourceLabel(source: DocSource): string {
+  if (source === "fallback-local") return "本地兜底";
+  if (source === "fallback-competitor") return "竞争对手兜底";
+  if (source === "fallback-webhook") return "fallback webhook";
+  return "官方抓取";
+}
+
 function getPublicSiteBaseUrl(env: Env): string {
   return normalizeBaseUrl(env.NEW_SITE_URL, "https://pinpointanswertoday.app");
 }
@@ -2730,6 +2750,8 @@ export default {
       const requestedDate = String(url.searchParams.get("date") || "").trim();
       const probeDate = requestedDate || new Date().toISOString().slice(0, 10);
       const mode = normalizeFallbackMode(url.searchParams.get("mode"));
+      const shouldNotify = envFlag(url.searchParams.get("notify") || undefined, false);
+      const canNotify = hasNotifyWebhook(env);
       const startedAt = Date.now();
 
       try {
@@ -2738,6 +2760,19 @@ export default {
           .map((item) => String(item?.word || "").trim())
           .filter((item) => item.length > 0)
           .slice(0, 5);
+        const durationMs = Date.now() - startedAt;
+        const notified = shouldNotify && canNotify;
+
+        if (notified) {
+          await notifyCron(env, `✅ Worker ${getFallbackModeLabel(mode)}正常`, [
+            `日期: ${probeDate}`,
+            `模式: ${mode}`,
+            `实际来源: ${getFallbackSourceLabel(doc.source)}`,
+            `主题: ${doc.mainAnswer || doc.theme || "（空）"}`,
+            `答案: ${words.join(" | ") || "（空）"}`,
+            `耗时(ms): ${durationMs}`,
+          ]);
+        }
 
         return new Response(JSON.stringify({
           ok: true,
@@ -2749,19 +2784,37 @@ export default {
           theme: doc.theme || null,
           mainAnswer: doc.mainAnswer || doc.theme || null,
           checkedAt: new Date().toISOString(),
-          durationMs: Date.now() - startedAt,
+          durationMs,
+          notifyRequested: shouldNotify,
+          notified,
+          ...(shouldNotify && !canNotify ? { notifySkipped: "no webhook configured" } : {}),
         }), {
           headers: { "content-type": "application/json; charset=utf-8" },
         });
       } catch (e: unknown) {
         const message = e instanceof Error ? e.message : String(e);
+        const durationMs = Date.now() - startedAt;
+        const notified = shouldNotify && canNotify;
+
+        if (notified) {
+          await notifyCron(env, `❌ Worker ${getFallbackModeLabel(mode)}异常`, [
+            `日期: ${probeDate}`,
+            `模式: ${mode}`,
+            `错误: ${message}`,
+            `耗时(ms): ${durationMs}`,
+          ]);
+        }
+
         return new Response(JSON.stringify({
           ok: false,
           probeDate,
           mode,
           error: message,
           checkedAt: new Date().toISOString(),
-          durationMs: Date.now() - startedAt,
+          durationMs,
+          notifyRequested: shouldNotify,
+          notified,
+          ...(shouldNotify && !canNotify ? { notifySkipped: "no webhook configured" } : {}),
         }), {
           status: 500,
           headers: { "content-type": "application/json; charset=utf-8" },


### PR DESCRIPTION
## What changed
- add optional `notify=1` support to the Worker admin endpoint `/admin/test-fallback`
- send a clearer success or failure webhook message based on the tested mode (`auto`, `local`, `competitor`)
- include `notifyRequested` and `notified` in the JSON response so manual runs are easy to confirm
- document the new notify flag in the Worker README

## Verification
- `npm run typecheck` in `worker/`
- deployed Worker production successfully
- production request:
  - `/admin/test-fallback?...&mode=competitor&notify=1`
  - returned `{"notifyRequested":true,"notified":true,...}`
  - sent a real webhook notification for competitor fallback success
