### PR TITLE
fix(seo): add en and x-default hreflang alternates

### DIFF
--- a/lib/seo/metadata.ts
+++ b/lib/seo/metadata.ts
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { defaultLocale } from "@/i18n.config";
 import { defaultSocialImagePath, siteName } from "@/lib/site/config";
 
 export const HOME_SEO_TITLE = "LinkedIn Pinpoint Answer Today - Daily Answers & Solutions";
@@ -18,6 +19,18 @@ export function getSiteUrl(): string {
 
 export function absoluteUrl(path: string): string {
   return new URL(path, getSiteUrl()).toString();
+}
+
+function buildCanonicalAlternates(path: string): Metadata["alternates"] {
+  const url = absoluteUrl(path);
+
+  return {
+    canonical: url,
+    languages: {
+      [defaultLocale]: url,
+      "x-default": url,
+    },
+  };
 }
 
 function normalizeSeoClues(clues: string[]): string[] {
@@ -206,9 +219,7 @@ export function buildSiteMetadata({
         google: verificationCode,
       },
     }),
-    alternates: {
-      canonical: absoluteUrl("/"),
-    },
+    alternates: buildCanonicalAlternates("/"),
     openGraph: {
       title,
       description,
@@ -250,9 +261,7 @@ export function buildPageMetadata({
     ...buildIconMetadata(),
     title,
     description,
-    alternates: {
-      canonical: url,
-    },
+    alternates: buildCanonicalAlternates(path),
     robots: {
       index: !noIndex,
       follow: true,


### PR DESCRIPTION
## What changed

- add `en` and `x-default` hreflang alternates to canonical site pages
- keep the current English-only canonical strategy unchanged

## Why

Production was missing hreflang tags, so SEO tools showed no alternate language and default entries even though canonical tags were present.

This PR restores the minimal hreflang setup that is consistent with the current English-only site strategy.

## Validation

- confirmed homepage HTML includes:
  - `rel="canonical"`
  - `rel="alternate" hreflang="en"`
  - `rel="alternate" hreflang="x-default"`
- confirmed detail page HTML includes the same hreflang pattern
- `npm run typecheck` passes
