### PR TITLE
fix(seo): polish social metadata and puzzle 681 phrasing

### DIFF
--- a/data/puzzles/pinpoint-answer-681.json
+++ b/data/puzzles/pinpoint-answer-681.json
@@ -29,6 +29,36 @@
       "body": "'Cat and 🐭' looks playful rather than literal, but it maps cleanly to the fixed idiom 'cat-and-mouse'. Pinpoint sometimes mixes words with visual symbols to point at a set phrase. If a clue feels half-written, check whether an icon is supplying the missing word."
     }
   ],
+  "display": {
+    "connectorSummary": "a phrase pattern built around mouse",
+    "clueTableRows": [
+      {
+        "clue": "House",
+        "examplePhrase": "House mouse",
+        "connectionExplained": "House mouse is a common household rodent — a familiar phrase that confirms the pattern early."
+      },
+      {
+        "clue": "Field",
+        "examplePhrase": "Field mouse",
+        "connectionExplained": "Field mouse refers to small rodents found in open countryside; the compound is a real species name."
+      },
+      {
+        "clue": "Optical",
+        "examplePhrase": "Optical mouse",
+        "connectionExplained": "Optical mouse is the standard name for the computer peripheral that uses light sensors instead of a rolling ball."
+      },
+      {
+        "clue": "Mickey",
+        "examplePhrase": "Mickey Mouse",
+        "connectionExplained": "Mickey Mouse is the Disney cartoon character created in 1928 — one of the most recognized compound names in the world."
+      },
+      {
+        "clue": "Cat and 🐭",
+        "examplePhrase": "Cat-and-mouse",
+        "connectionExplained": "Cat-and-mouse is a fixed English idiom for a pursuit or power game; the mouse icon completes the visual clue and points straight to the idiom."
+      }
+    ]
+  },
   "faqs": [
     {
       "question": "What is the answer to LinkedIn Pinpoint #681?",

--- a/lib/seo/metadata.ts
+++ b/lib/seo/metadata.ts
@@ -12,6 +12,7 @@ const TITLE_MAX_LENGTH = 60;
 const TITLE_MIN_LENGTH = 55;
 const DESCRIPTION_MAX_LENGTH = 160;
 const DESCRIPTION_MIN_LENGTH = 150;
+const SITE_LOCALE = "en_US";
 
 export function getSiteUrl(): string {
   return process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3004";
@@ -226,13 +227,14 @@ export function buildSiteMetadata({
       type: "website",
       url: absoluteUrl("/"),
       siteName,
+      locale: SITE_LOCALE,
       images: [socialImage],
     },
     twitter: {
       card: "summary_large_image",
       title,
       description,
-      images: [socialImage.url],
+      images: [socialImage],
     },
   };
 }
@@ -272,13 +274,14 @@ export function buildPageMetadata({
       type,
       url,
       siteName,
+      locale: SITE_LOCALE,
       images: [socialImage],
     },
     twitter: {
       card: "summary_large_image",
       title,
       description,
-      images: [socialImage.url],
+      images: [socialImage],
     },
   };
 }


### PR DESCRIPTION
## What changed

- add `og:locale` and `twitter:image:alt` to shared site metadata
- keep existing canonical and hreflang behavior unchanged
- add a display override for puzzle `#681` so the clue table shows `Cat-and-mouse` instead of the awkward auto-built phrase

## Why

The site already had the core SEO signals in place, but two small social metadata fields were still missing.

Puzzle #681 also had a wording issue in the clue table that could look low quality if a crawler or SEO tool surfaced that section.

## Validation

- `npm run typecheck` passes
- `npm run validate:data` passes
- verified local rendered HTML includes:
  - `og:locale="en_US"`
  - `twitter:image:alt`
- verified the `#681` clue table renders `Cat-and-mouse`
