### PR TITLE
Refine homepage and detail SEO copy

### DIFF
--- a/app/(detail)/detail.css
+++ b/app/(detail)/detail.css
@@ -481,6 +481,7 @@
   margin: 10px 0 0;
   font-size: 18px;
   font-weight: 700;
+  line-height: 1.22;
   color: var(--brand);
 }
 
@@ -842,6 +843,13 @@
   text-underline-offset: 2px;
   font-size: 16px;
   line-height: 1.65;
+}
+
+.legacy-next-link-title {
+  margin: 0;
+  font-size: 16px;
+  line-height: 1.65;
+  font-weight: 600;
 }
 
 .legacy-next-link:hover {

--- a/app/globals.css
+++ b/app/globals.css
@@ -597,6 +597,13 @@ summary:focus-visible {
   gap: 14px;
 }
 
+.reveal-clue-title {
+  margin: 18px 0 14px;
+  font-size: clamp(20px, 2.4vw, 30px);
+  line-height: 1.25;
+  text-align: center;
+}
+
 .reveal-clue-card {
   display: flex;
   min-height: 86px;

--- a/components/detail/PuzzleAnswerReveal.tsx
+++ b/components/detail/PuzzleAnswerReveal.tsx
@@ -127,9 +127,9 @@ export function PuzzleAnswerReveal({
   };
 
   return (
-    <section className="legacy-reveal-shell" aria-labelledby="answer-reveal-label">
+    <section className="legacy-reveal-shell" aria-labelledby="pinpoint-answer-title">
       <p className="legacy-reveal-tip" id={revealTipId}>
-        Hover (desktop) or tap (mobile) each clue to see how it connects to the answer
+        Hover (desktop) or tap (mobile) each clue before you reveal the Pinpoint answer
       </p>
 
       <div className="legacy-reveal-clue-grid">
@@ -160,10 +160,10 @@ export function PuzzleAnswerReveal({
         ) : null}
       </div>
 
-      <div className="legacy-answer-panel" id="answer-reveal">
-        <p className="legacy-answer-label" id="answer-reveal-label">
-          {`LinkedIn Pinpoint #${puzzleNumber} Answer:`}
-        </p>
+      <div className="legacy-answer-panel" id="answer-reveal" aria-labelledby="pinpoint-answer-title">
+        <h2 className="legacy-answer-label" id="pinpoint-answer-title">
+          {`Pinpoint Answer for LinkedIn Pinpoint ${puzzleNumber}`}
+        </h2>
         {revealed ? (
           <p className="legacy-answer-title" aria-live="polite">
             {answer}
@@ -171,17 +171,17 @@ export function PuzzleAnswerReveal({
         ) : null}
         <div className="legacy-answer-actions">
           <button className="button-primary legacy-answer-button" type="button" onClick={handleRevealToggle}>
-            {revealed ? "Hide the Answer" : "Reveal the Answer"}
+            {revealed ? "Hide Pinpoint Answer" : "Reveal Pinpoint Answer"}
           </button>
           {revealed ? (
             <button className="button-secondary legacy-answer-button" type="button" onClick={handleCopy}>
-              {copied ? "Copied" : "Copy answer"}
+              {copied ? "Copied" : "Copy Pinpoint Answer"}
             </button>
           ) : null}
         </div>
         <p className="legacy-answer-note">
           <span aria-hidden="true">ℹ️</span>
-          <span>Detailed breakdown continues just below - keep scrolling</span>
+          <span>Detailed Pinpoint answer breakdown continues just below - keep scrolling</span>
         </p>
       </div>
     </section>

--- a/components/detail/PuzzleDetail.tsx
+++ b/components/detail/PuzzleDetail.tsx
@@ -49,7 +49,7 @@ export function PuzzleDetail({
           <span>{`Pinpoint #${puzzle.number}`}</span>
         </nav>
 
-        <p className="eyebrow legacy-detail-kicker">Permanent answer &amp; walkthrough (Pinpoint Today archive)</p>
+        <p className="eyebrow legacy-detail-kicker">Permanent Pinpoint answer &amp; walkthrough (Pinpoint Today archive)</p>
         <h1 className="legacy-detail-title">{`LinkedIn Pinpoint #${puzzle.number} Answer & Walkthrough`}</h1>
         <p className="legacy-detail-published">{`Published on ${formatLegacyDate(puzzle.isoDate)}`}</p>
         <div className="legacy-detail-verified">
@@ -57,15 +57,15 @@ export function PuzzleDetail({
           <span>Verified by Human Editor</span>
         </div>
         <p className="copy legacy-detail-summary">
-          {`Pinpoint Answer Today asks: what links ${formatClueList(puzzle.clues)} - and what story do they share? Follow the spoiler-safe hints one by one, then reveal the final connection and see how each clue fits together.`}
+          {`This Pinpoint answer guide asks: what links ${formatClueList(puzzle.clues)} - and what story do they share? Follow the spoiler-safe hints one by one, then reveal the final connection and see how each clue fits together.`}
         </p>
 
         <div className="legacy-detail-actions">
           <a className="button-primary" href="#analysis">
-            Jump to full Pinpoint walkthrough
+            Jump to full Pinpoint answer walkthrough
           </a>
           <Link className="button-secondary" href={routes.archive}>
-            Browse all LinkedIn Pinpoint answers
+            Browse all Pinpoint answer pages
           </Link>
         </div>
 

--- a/components/detail/PuzzleFullAnalysis.tsx
+++ b/components/detail/PuzzleFullAnalysis.tsx
@@ -15,6 +15,9 @@ function parseLesson(lesson: LessonItem): { title: string | null; body: string }
   return { title: null, body: lesson };
 }
 
+function buildRecentLinkTitle(entry: ArchiveEntry) {
+  return `LinkedIn Pinpoint ${entry.number}: ${entry.clues.join(", ")}`;
+}
 export function PuzzleFullAnalysis({
   puzzle,
   recentPuzzles,
@@ -38,7 +41,7 @@ export function PuzzleFullAnalysis({
           <header className="legacy-analysis-header">
             <div className="legacy-analysis-header-inner">
               <Star className="legacy-section-icon" aria-hidden />
-              <h2 className="legacy-analysis-title">{`Pinpoint #${puzzle.number} Walkthrough & Analysis`}</h2>
+              <h2 className="legacy-analysis-title">{`Pinpoint Answer Walkthrough & Analysis for #${puzzle.number}`}</h2>
             </div>
           </header>
 
@@ -159,8 +162,8 @@ export function PuzzleFullAnalysis({
           </section>
         </section>
 
-        <aside className="legacy-next-shell" aria-label="Recent Pinpoint answers">
-          <h2 className="legacy-next-title">Recent Pinpoint answers</h2>
+        <aside className="legacy-next-shell" aria-label="Recent Pinpoint answer pages">
+          <h2 className="legacy-next-title">Recent Pinpoint answer pages</h2>
           {nextPreview ? (
             <Link className="legacy-next-link" href={routes.preview}>
               {`Preview Puzzle #${nextPreview.number} - expected ${nextPreview.expectedDate}`}
@@ -169,15 +172,19 @@ export function PuzzleFullAnalysis({
           <ul className="legacy-next-list">
             {recentPuzzles.map((entry) => (
               <li key={entry.slug}>
-                <Link className="legacy-next-link" href={routes.detail(entry.slug)}>
-                  {`LinkedIn Pinpoint #${entry.number} answer - clues: ${entry.clues.join(", ")}`}
+                <Link
+                  className="legacy-next-link"
+                  href={routes.detail(entry.slug)}
+                  aria-label={`Open ${buildRecentLinkTitle(entry)}`}
+                >
+                  <h3 className="legacy-next-link-title">{buildRecentLinkTitle(entry)}</h3>
                 </Link>
               </li>
             ))}
           </ul>
           <div className="legacy-next-actions">
             <Link className="button-secondary" href={routes.archive}>
-              View all Pinpoint answers &amp; solutions
+              View all Pinpoint answer pages
             </Link>
           </div>
         </aside>

--- a/components/home/HomeBenefitsFaq.tsx
+++ b/components/home/HomeBenefitsFaq.tsx
@@ -5,7 +5,7 @@ const benefits = [
     icon: "bolt",
     title: "Instant Answers",
     description:
-      "Get today’s Pinpoint solution quickly, then open the detail page when you want the full Pinpoint reasoning.",
+      "Start with spoiler-safe hints, then open the detail page when you want the full reasoning behind today's answer.",
   },
   {
     icon: "brain",
@@ -17,7 +17,7 @@ const benefits = [
     icon: "calendar",
     title: "Daily updates",
     description:
-      "Fresh Pinpoint solution pages, next-puzzle timing, and archive updates all stay inside one English-only structure.",
+      "Fresh Pinpoint answer pages, next-puzzle timing, and archive updates all stay inside one English-only structure.",
   },
   {
     icon: "bookmark",
@@ -80,11 +80,11 @@ function getFaqItems(puzzle: PuzzleDetail) {
   return [
     {
       question: "When does the daily Pinpoint solution become available?",
-      answer: `New LinkedIn Pinpoint boards usually unlock on a daily cycle. We update the live Pinpoint page for Puzzle ${puzzle.number} as soon as the latest verified Pinpoint board is ready.`,
+      answer: `LinkedIn Pinpoint usually unlocks on a daily cycle. We update the live Pinpoint page for Puzzle ${puzzle.number} as soon as the latest verified board is ready.`,
     },
     {
       question: "Can I browse historical Pinpoint boards here?",
-      answer: "Yes. The Pinpoint archive keeps recent and older boards in one place so you can review old connections, clue sets, and solution patterns without hunting around.",
+      answer: "Yes. The Pinpoint archive keeps recent and older boards in one place so you can review old connections, clue sets, and answer patterns without hunting around.",
     },
     {
       question: "What happens if I miss a day’s puzzle?",
@@ -92,7 +92,7 @@ function getFaqItems(puzzle: PuzzleDetail) {
     },
     {
       question: "Is this an official LinkedIn resource?",
-      answer: "No. This is an independent Pinpoint guide built to help players check the solution, review the clue logic, and browse older boards more easily.",
+      answer: "No. This is an independent Pinpoint guide built to help players check the answer, review clue logic, and browse older boards more easily.",
     },
     {
       question: "How do the clue explanations work?",
@@ -115,7 +115,8 @@ export function HomeBenefitsFaq({ puzzle }: { puzzle: PuzzleDetail }) {
           <p className="eyebrow">Why Pinpoint players use us</p>
           <h2 className="section-title benefit-guide-title">Why Use Our Pinpoint Guide?</h2>
           <p className="copy benefits-intro">
-            Everything you need for faster Pinpoint solving.
+            Players use this guide when they want today&apos;s answer, spoiler-safe hints, and a
+            clean archive path in one place.
           </p>
         </div>
         <div className="benefit-guide-grid">

--- a/components/home/HomeBookmarkStrip.tsx
+++ b/components/home/HomeBookmarkStrip.tsx
@@ -7,8 +7,8 @@ export function HomeBookmarkStrip() {
       <div className="home-bookmark-copy">
         <p className="home-bookmark-title">Bookmark this page for the daily Pinpoint drop</p>
         <p className="copy" style={{ margin: 0 }}>
-          Keep the hub close. It is the fastest way back to today&apos;s Pinpoint solution, the next
-          Pinpoint preview, and the full Pinpoint archive.
+          Keep the hub close. Today&apos;s answer, the next preview, and the full archive stay one
+          click away.
         </p>
       </div>
       <div className="home-bookmark-tip">

--- a/components/home/HomeCtaFooter.tsx
+++ b/components/home/HomeCtaFooter.tsx
@@ -16,15 +16,15 @@ export function HomeCtaFooter({
         </p>
         <p className="home-cta-title">Start your journey to becoming a Pinpoint champion today.</p>
         <p className="home-cta-copy">
-          Start with today&apos;s Pinpoint solution, then build confidence with the Pinpoint archive,
-          preview drills, and cleaner clue-by-clue recaps.
+          Start with today&apos;s answer, then open older answer pages and the archive from one
+          place.
         </p>
         <div className="button-row" style={{ justifyContent: "center" }}>
           <Link href={routes.detail(currentSlug)} className="button-secondary home-cta-primary" prefetch={false}>
-            Reveal Today&apos;s Pinpoint Solution
+            Reveal Today&apos;s Answer
           </Link>
           <Link href={routes.archive} className="button-secondary home-cta-secondary" prefetch={false}>
-            Explore Pinpoint archive
+            Explore Full Archive
           </Link>
         </div>
       </div>

--- a/components/home/HomeHero.tsx
+++ b/components/home/HomeHero.tsx
@@ -18,14 +18,14 @@ export function HomeHero({
     <section className="home-hero">
       <div className="home-hero-inner">
         <span className="home-status-badge">Live now</span>
-        <p className="home-hero-kicker">Today&apos;s Pinpoint hints, Pinpoint recap, and Pinpoint archive</p>
-        <h1 className="home-hero-title">Today&apos;s LinkedIn Pinpoint #{puzzle.number} Solution</h1>
+        <p className="home-hero-kicker">Today&apos;s Pinpoint hints, yesterday&apos;s answer, and the archive</p>
+        <h1 className="home-hero-title">{`Today's LinkedIn Pinpoint #${puzzle.number} Answer`}</h1>
         <p className="home-hero-subtitle">
-          {`Use this Pinpoint hub for spoiler-safe Pinpoint clues, the verified Pinpoint solution, and fast access to older Pinpoint boards. ${puzzle.shortSummary}`}
+          {`If you need LinkedIn Pinpoint answer today, this page keeps today's answer, spoiler-safe hints, yesterday's answer, and the full archive in one place for Puzzle #${puzzle.number}.`}
         </p>
         <div className="button-row home-hero-actions">
           <Link className="button-primary home-hero-primary" href={routes.detail(puzzle.slug)} prefetch={false}>
-            Open today&apos;s Pinpoint breakdown
+            Open today&apos;s answer
           </Link>
           <a
             className="button-secondary home-hero-secondary"
@@ -36,12 +36,11 @@ export function HomeHero({
             Play on LinkedIn
           </a>
           <Link className="button-secondary home-hero-tertiary" href={routes.archive} prefetch={false}>
-            Browse Pinpoint archive
+            Open full archive
           </Link>
         </div>
         <p className="home-hero-detail">
-          Today&apos;s Pinpoint clues: {cluePreview}. Open the full Pinpoint breakdown when
-          you&apos;re ready for the verified solution.
+          Today&apos;s clue preview for Puzzle #{puzzle.number}: {cluePreview}. Open today&apos;s answer whenever you&apos;re ready.
         </p>
       </div>
     </section>

--- a/components/home/HomeNextUnlock.tsx
+++ b/components/home/HomeNextUnlock.tsx
@@ -12,15 +12,15 @@ export function HomeNextUnlock({ preview }: { preview: NextPreview | null }) {
 
   const targetIso = toUnlockIso(preview.isoDate);
   const targetLabel = `Puzzle ${preview.number} unlocks on ${preview.expectedDate} at GMT+8 16:00`;
-  const headline = `Puzzle ${preview.number} unlocks in`;
+  const headline = `When Does LinkedIn Pinpoint ${preview.number} Unlock?`;
 
   return (
     <section className="home-next-unlock">
       <div className="home-next-unlock-inner">
         <div className="home-next-unlock-heading">
-          <p className="home-next-unlock-title">{headline}</p>
+          <h2 className="home-next-unlock-title">{headline}</h2>
           <p className="home-next-unlock-copy">
-            {`Next unlock at ${preview.expectedDate} 16:00 (Asia/Shanghai). Times shown in your local time zone below.`}
+            {`Next unlock at ${preview.expectedDate} 16:00 (Asia/Shanghai). For Pinpoint, LinkedIn's daily schedule, this gives you the next reset at a glance. Times shown in your local time zone below.`}
           </p>
         </div>
         <Countdown targetIso={targetIso} targetLabel={targetLabel} />

--- a/components/home/HomeRecentAnswers.tsx
+++ b/components/home/HomeRecentAnswers.tsx
@@ -9,9 +9,9 @@ export function HomeRecentAnswers({ entries }: { entries: ArchiveEntry[] }) {
     <section className="surface surface-block">
       <div className="home-search-heading recent-answers-heading">
         <SectionHeading
-          eyebrow="Recent Pinpoint boards"
-          title="Recent LinkedIn Pinpoint Clues & Solutions"
-          description="Open any recent Pinpoint recap to review the clue-by-clue solution and move fast into the full Pinpoint archive."
+          eyebrow="Recent answers"
+          title="Recent LinkedIn Pinpoint Answers"
+          description="Open recent LinkedIn Pinpoint answer pages, compare clue patterns, and jump into the full archive without digging through clutter."
         />
       </div>
       <div className="recent-answer-grid recent-answer-grid-compact">
@@ -21,12 +21,7 @@ export function HomeRecentAnswers({ entries }: { entries: ArchiveEntry[] }) {
       </div>
       <div className="button-row recent-answer-actions recent-answer-actions-bottom">
         <Link href={routes.archive} className="button-secondary" prefetch={false}>
-          View All Pinpoint Boards and Solutions
-        </Link>
-      </div>
-      <div className="recent-answer-bottom-link">
-        <Link href={routes.archive} className="home-inline-link" prefetch={false}>
-          Explore the full historical Pinpoint archive
+          Open Full Archive
         </Link>
       </div>
     </section>

--- a/components/home/HomeRevealSection.tsx
+++ b/components/home/HomeRevealSection.tsx
@@ -25,15 +25,15 @@ export function HomeRevealSection({
     previousEntry
       ? {
           badge: "Previous",
-          label: `Yesterday's Pinpoint recap (Puzzle ${previousEntry.number})`,
-          description: "Open yesterday's full Pinpoint breakdown.",
+          label: `Yesterday's answer (Puzzle ${previousEntry.number})`,
+          description: "Open yesterday's full answer and breakdown.",
           href: routes.detail(previousEntry.slug),
         }
       : null,
     {
       badge: "Today",
-      label: `Today's LinkedIn Pinpoint board (Puzzle ${puzzle.number})`,
-      description: "Open the live Pinpoint solution, hints, and full breakdown.",
+      label: `Today's LinkedIn Pinpoint answer (Puzzle ${puzzle.number})`,
+      description: "Open today's answer, hints, and full breakdown together.",
       href: routes.detail(puzzle.slug),
     },
     preview
@@ -45,8 +45,8 @@ export function HomeRevealSection({
         }
       : {
           badge: "Archive",
-          label: "Browse older Pinpoint boards",
-          description: "Jump into the full Pinpoint archive of recent and past boards.",
+          label: "Browse older answers",
+          description: "Jump into the full archive of recent and past answers.",
           href: routes.archive,
         },
   ].filter(Boolean) as Array<{
@@ -61,11 +61,12 @@ export function HomeRevealSection({
       <div className="home-reveal-heading">
         <p className="eyebrow">Reveal</p>
         <h2 className="home-reveal-title">
-          {`Today's LinkedIn Pinpoint clues, hints, and solution (${formatCompactDate(puzzle.isoDate)})`}
+          {`Today's LinkedIn Pinpoint clues, hints, and answer (${formatCompactDate(puzzle.isoDate)})`}
         </h2>
         <p className="copy home-reveal-description">
-          Reveal spoiler-safe Pinpoint hints first, then open today&apos;s verified Pinpoint
-          solution or jump to yesterday&apos;s Pinpoint board and the Pinpoint archive.
+          Reveal spoiler-safe hints first, then open today&apos;s verified answer. Many players who
+          search LinkedIn Pinpoint answer today start here before moving to yesterday&apos;s
+          answer or the full archive.
         </p>
       </div>
       <div className="reveal-section-body">

--- a/components/home/HomeWhatIs.tsx
+++ b/components/home/HomeWhatIs.tsx
@@ -14,9 +14,8 @@ export function HomeWhatIs() {
         <h2 className="section-title">What is LinkedIn Pinpoint?</h2>
         <p className="copy home-what-is-copy">
           LinkedIn Pinpoint is a daily word puzzle where five clues all point to one hidden
-          connection. Pinpoint Answer Today helps you move through each Pinpoint board with
-          spoiler-safe clues, a clean solution recap, and a faster archive path without getting
-          buried in the old-site clutter.
+          connection. People checking LinkedIn Pinpoint answer today usually test a few
+          patterns first, then check the answer recap and archive when they get stuck.
         </p>
       </div>
 

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -17,8 +17,8 @@ export function Footer({ recentEntries, isDetailPage = false }: FooterProps) {
         { label: "About", href: routes.about },
       ]
     : [
-        { label: "Next Pinpoint Preview", href: routes.preview },
-        { label: "View All Pinpoint Boards and Solutions", href: routes.archive },
+        { label: "Next Preview", href: routes.preview },
+        { label: "Open Full Archive", href: routes.archive },
       ];
   const supportLinks = [
     { label: "Email Support", href: supportMailto },
@@ -40,17 +40,17 @@ export function Footer({ recentEntries, isDetailPage = false }: FooterProps) {
             <p className="eyebrow">Pinpoint Answer Today</p>
             <p className="footer-copy">
               {isDetailPage
-                ? "Pinpoint Answer Today is a fan-built companion for the daily LinkedIn puzzle. We deliver rapid solutions, thoughtful analysis, and strategy guides while operating independently from any organization."
-                : "Fast daily Pinpoint solutions, deeper Pinpoint explanations, and a cleaner English-only Pinpoint archive built for people who want today's board without wading through legacy clutter."}
+                ? "Pinpoint Answer Today is a fan-built companion for the daily LinkedIn puzzle. Each daily Pinpoint answer comes with rapid verification, thoughtful analysis, and strategy notes, and every Pinpoint answer page is built independently from any organization."
+                : "Pinpoint Answer Today is built for people who want today's answer, clearer explanations, and a cleaner archive path without wading through old clutter."}
             </p>
           </div>
 
           <div className="footer-block">
-            <p className="eyebrow">{isDetailPage ? "Recent answers" : "Recent Pinpoint Boards"}</p>
+            <p className="eyebrow">{isDetailPage ? "Recent Pinpoint answer pages" : "Recent answers"}</p>
             <ul className="footer-link-list footer-link-list-compact">
               {recentEntries.map((entry) => (
                 <li key={entry.slug}>
-                  <Link href={routes.detail(entry.slug)} prefetch={false}>{`LinkedIn Pinpoint #${entry.number}`}</Link>
+                  <Link href={routes.detail(entry.slug)} prefetch={false}>{`#${entry.number}`}</Link>
                 </li>
               ))}
             </ul>

--- a/components/shared/AnswerReveal.tsx
+++ b/components/shared/AnswerReveal.tsx
@@ -45,7 +45,6 @@ export function AnswerReveal({
   const [activeHint, setActiveHint] = useState<{ clue: string; text: string } | null>(null);
   const hintTimerRef = useRef<number | null>(null);
   const revealTipId = useId();
-
   const normalizedHints = useMemo(() => buildHintMap(hintMap), [hintMap]);
 
   useEffect(() => {
@@ -172,17 +171,15 @@ export function AnswerReveal({
             : `LinkedIn Pinpoint ${puzzleNumber} solution is hidden until you press the reveal button.`}
         </p>
         <p className="eyebrow">Pinpoint solution</p>
-        <h3 className="reveal-answer-title">
-          {revealed ? answer : `LinkedIn Pinpoint ${puzzleNumber} solution`}
-        </h3>
+        <h3 className="reveal-answer-title">{revealed ? answer : `Pinpoint Answer for Puzzle ${puzzleNumber}`}</h3>
         <p className="reveal-answer-copy">
           {revealed
             ? ""
-            : "Use the button below if you want today's Pinpoint solution now. If you prefer the Pinpoint logic first, keep scrolling and read the full explanation."}
+            : "Use the button below if you want todays Pinpoint answer. Pinpoint today answer logic stays below if you keep scrolling for the full explanation."}
         </p>
         <div className="button-row reveal-answer-actions">
           <button className="button-primary reveal-primary-button" type="button" onClick={handleRevealToggle}>
-            {revealed ? "Hide the solution" : "Reveal Pinpoint solution"}
+            {revealed ? "Hide the answer" : "Reveal Pinpoint answer"}
           </button>
           {showDetailLink && detailHref ? (
             <Link
@@ -202,7 +199,7 @@ export function AnswerReveal({
           ) : null}
           {revealed ? (
             <button className="button-secondary reveal-secondary-button" type="button" onClick={handleCopy}>
-              {copied ? "Copied" : "Copy solution"}
+              {copied ? "Copied" : "Copy Pinpoint answer"}
             </button>
           ) : null}
         </div>

--- a/components/shared/RecentAnswerCard.tsx
+++ b/components/shared/RecentAnswerCard.tsx
@@ -4,8 +4,7 @@ import { routes } from "@/lib/paths/routes";
 import { formatShortDate } from "@/lib/utils/date";
 
 function buildCluePreview(clues: string[]) {
-  const preview = clues.slice(0, 3).join(", ");
-  return clues.length > 3 ? `${preview}, ...` : preview;
+  return clues.join(", ");
 }
 
 export function RecentAnswerCard({
@@ -25,23 +24,20 @@ export function RecentAnswerCard({
       href={routes.detail(entry.slug)}
       className={`recent-answer-card recent-answer-card-compact${isLatest ? " recent-answer-card-current" : ""}`}
       prefetch={false}
+      aria-label={`Open puzzle ${entry.number} for clues ${cluePreview}`}
     >
       <div className="recent-answer-top">
         <div className="recent-answer-number-wrap">
           <span className="recent-answer-number">{entry.number}</span>
-          <div>
-            <p className="recent-answer-label">Puzzle {entry.number}</p>
-          </div>
         </div>
         {isLatest ? <span className="recent-answer-badge">Latest</span> : null}
       </div>
-      <p className="recent-answer-title">{cluePreview}</p>
+      <h3 className="recent-answer-title">{`LinkedIn Pinpoint ${entry.number}: ${cluePreview}`}</h3>
       {answerText ? (
         <p className="recent-answer-answer">Solution: {answerText}</p>
       ) : null}
       <div className="recent-answer-footer">
         <span className="recent-answer-meta">{shortDate}</span>
-        <span className="recent-answer-cta">View Recap</span>
       </div>
     </Link>
   );

--- a/lib/seo/metadata.ts
+++ b/lib/seo/metadata.ts
@@ -2,9 +2,9 @@ import type { Metadata } from "next";
 import { defaultLocale } from "@/i18n.config";
 import { defaultSocialImagePath, siteName } from "@/lib/site/config";
 
-export const HOME_SEO_TITLE = "LinkedIn Pinpoint Answer Today - Daily Answers & Solutions";
+export const HOME_SEO_TITLE = "LinkedIn Pinpoint Answer Today | Clues, Walkthrough & Archive";
 export const HOME_SEO_DESCRIPTION =
-  "Find today's LinkedIn Pinpoint answer instantly - updated daily with clear solutions, clue explanations, and tips that help protect your streak every day.";
+  "Get today's LinkedIn Pinpoint answer with spoiler-safe hints, clear clue-by-clue walkthroughs, yesterday's answer, and the full archive, all in one place.";
 export const ARCHIVE_SEO_TITLE = "LinkedIn Pinpoint Archive & Guides | Pinpoint Answer Today";
 export const ARCHIVE_SEO_DESCRIPTION =
   "Browse LinkedIn Pinpoint walkthroughs, clue guides, archive pages, and past answers. Open the latest recap fast or revisit older puzzles in one place.";
@@ -178,6 +178,18 @@ function buildSocialImage(imagePath: string, alt: string) {
     width: 1200,
     height: 630,
     alt,
+  };
+}
+
+function buildCanonicalAlternates(path: string): NonNullable<Metadata["alternates"]> {
+  const url = absoluteUrl(path);
+
+  return {
+    canonical: url,
+    languages: {
+      [defaultLocale]: url,
+      "x-default": url,
+    },
   };
 }
 


### PR DESCRIPTION
## What
- refine homepage SEO copy to focus on answer-intent wording instead of noisy keyword chaining
- simplify recent answer cards and footer labels so density tools stop stitching awkward board/open phrases together
- keep detail-page SEO updates for answer headings and clue-style recent links
- polish shared metadata and supporting styles for the updated copy

## Validation
- npm run typecheck
- node scripts/validate-data.mjs (run by the push hook)