### PR TITLE
Fix Vercel build failure in metadata helper

### DIFF
--- a/lib/seo/metadata.ts
+++ b/lib/seo/metadata.ts
@@ -22,18 +22,6 @@ export function absoluteUrl(path: string): string {
   return new URL(path, getSiteUrl()).toString();
 }
 
-function buildCanonicalAlternates(path: string): Metadata["alternates"] {
-  const url = absoluteUrl(path);
-
-  return {
-    canonical: url,
-    languages: {
-      [defaultLocale]: url,
-      "x-default": url,
-    },
-  };
-}
-
 function normalizeSeoClues(clues: string[]): string[] {
   return clues.map((clue) => clue.replace(/\s+/g, " ").trim()).filter(Boolean);
 }


### PR DESCRIPTION
## What changed
- remove the duplicate  definition in 
- keep the typed helper that is used by site metadata builders

## Verification
- 
> new-pinpoint-site@0.1.0 build
> npm run validate:data && next build


> new-pinpoint-site@0.1.0 validate:data
> node scripts/validate-data.mjs

Validated 230 registry records successfully.
   ▲ Next.js 15.0.5

   Creating an optimized production build ...
 ✓ Compiled successfully
   Linting and checking validity of types ...
   Collecting page data ...
   Generating static pages (0/70) ...
   Generating static pages (17/70) 
   Generating static pages (34/70) 
   Generating static pages (52/70) 
 ✓ Generating static pages (70/70)
   Finalizing page optimization ...
   Collecting build traces ...

Route (app)                                            Size     First Load JS
┌ ○ /                                                  2.37 kB         111 kB
├ ○ /_not-found                                        171 B           100 kB
├ ○ /about-us                                          178 B           109 kB
├ ƒ /api/admin/generate-draft                          171 B           100 kB
├ ○ /api/archive-groups                                171 B           100 kB
├ ƒ /api/fallback/worker-pinpoint                      171 B           100 kB
├ ƒ /api/feedback                                      171 B           100 kB
├ ƒ /api/indexnow-key                                  171 B           100 kB
├ ƒ /api/puzzles/summary                               171 B           100 kB
├ ƒ /api/revalidate                                    171 B           100 kB
├ ○ /contact-us                                        1.37 kB         101 kB
├ ○ /disclaimer                                        171 B           100 kB
├ ○ /linkedin-pinpoint-answers                         171 B           100 kB
├ ● /linkedin-pinpoint-answers/[slug]                  2.46 kB         111 kB
├   ├ /linkedin-pinpoint-answers/pinpoint-answer-687
├   ├ /linkedin-pinpoint-answers/pinpoint-answer-686
├   ├ /linkedin-pinpoint-answers/pinpoint-answer-685
├   └ [+47 more paths]
├ ƒ /linkedin-pinpoint-answers/[slug]/opengraph-image  0 B                0 B
├ ○ /next-pinpoint-preview                             1.05 kB         110 kB
├ ƒ /opengraph-image                                   0 B                0 B
├ ƒ /pinpoint/[value]                                  171 B           100 kB
├ ○ /pinpoint/archive                                  171 B           100 kB
├ ○ /privacy                                           171 B           100 kB
├ ƒ /puzzles                                           2.25 kB         111 kB
├ ƒ /puzzles/[puzzleNumber]                            171 B           100 kB
├ ○ /robots.txt                                        0 B                0 B
├ ○ /sitemap.xml                                       0 B                0 B
└ ○ /terms                                             171 B           100 kB
+ First Load JS shared by all                          100 kB
  ├ chunks/422f47fa-6c17a2f7a3d9caf9.js                52.5 kB
  ├ chunks/83-9e2843033eeb1608.js                      45.6 kB
  └ other shared chunks (total)                        1.91 kB


○  (Static)   prerendered as static content
●  (SSG)      prerendered as static HTML (uses generateStaticParams)
ƒ  (Dynamic)  server-rendered on demand