### PR TITLE
Align sitemap and redirect rules with production SEO

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -9,6 +9,10 @@ const ARCHIVE_LAST_MODIFIED = new Date("2026-03-13T00:00:00.000Z");
 const ABOUT_LAST_MODIFIED = new Date("2026-03-12T00:00:00.000Z");
 const LEGAL_LAST_MODIFIED = new Date("2026-01-01T00:00:00.000Z");
 
+function withTrailingSlash(path: string): string {
+  return path.endsWith("/") ? path : `${path}/`;
+}
+
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3004";
   const primaryRoutes = [
@@ -41,7 +45,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
   const detailItems = await getSitemapDetailEntries();
   const detailEntries = detailItems.map((item, index) => ({
-    url: `${siteUrl}${routes.detail(item.slug)}`,
+    url: `${siteUrl}${withTrailingSlash(routes.detail(item.slug))}`,
     lastModified: new Date(item.updatedAt),
     changeFrequency: "daily" as const,
     priority: index < 10 ? 0.9 : index < 50 ? 0.8 : 0.6,

--- a/middleware.ts
+++ b/middleware.ts
@@ -4,10 +4,39 @@ import { NextResponse } from "next/server";
 const DETAIL_WITHOUT_SLASH = /^\/linkedin-pinpoint-answers\/[^/]+$/;
 const DETAIL_WITH_SLASH = /^\/linkedin-pinpoint-answers\/[^/]+\/$/;
 const PUBLIC_FILE = /\.[^/]+$/;
+const WWW_HOST = "www.pinpointanswertoday.app";
+const APEX_HOST = "pinpointanswertoday.app";
+
+function normalizePathForCanonical(pathname: string): string {
+  if (pathname === "/") {
+    return pathname;
+  }
+
+  if (DETAIL_WITHOUT_SLASH.test(pathname)) {
+    return `${pathname}/`;
+  }
+
+  if (DETAIL_WITH_SLASH.test(pathname)) {
+    return pathname;
+  }
+
+  return pathname.endsWith("/") ? pathname.slice(0, -1) : pathname;
+}
 
 export function middleware(request: NextRequest) {
   const currentUrl = new URL(request.url);
   const { pathname } = currentUrl;
+  const hostname = (request.headers.get("x-forwarded-host")
+    ?? request.headers.get("host")
+    ?? currentUrl.hostname)
+    .replace(/:\d+$/, "");
+
+  if (hostname === WWW_HOST) {
+    const url = new URL(request.url);
+    url.hostname = APEX_HOST;
+    url.pathname = normalizePathForCanonical(pathname);
+    return Response.redirect(url, 308);
+  }
 
   if (
     pathname === "/" ||


### PR DESCRIPTION
## What
- add trailing slashes to detail URLs emitted from sitemap.xml
- normalize www requests to the apex domain in middleware
- keep canonical redirect behavior aligned with the live SEO setup

## Validation
- npm run typecheck
- npm run validate:data
- npx next build
- local smoke: www detail request returns 308 to apex + trailing slash
- local smoke: sitemap detail entries emit trailing-slash URLs