### PR TITLE
chore(worker): isolate shadow/staging branches and KV

### DIFF
--- a/docs/next-day-pinpoint-launch-observation-checklist-2026-03-28.md
+++ b/docs/next-day-pinpoint-launch-observation-checklist-2026-03-28.md
@@ -1,0 +1,186 @@
+# Next-Day Pinpoint Launch Observation Checklist
+
+适用场景：
+
+- 新版详情页、worker 状态机、`/pinpoint/today` 发布中占位已经上线
+- 想在第二天首发后，用 2 分钟确认“今天这题有没有正常发布”
+
+一句话目标：
+
+- 先看“今天这题是不是已经对外可见”
+- 再看“worker 有没有卡住”
+- 最后看“详情页正文是不是和当天答案一致”
+
+---
+
+## 1. 先看公开口径是否一致
+
+### 1.1 看摘要接口
+
+```bash
+curl -sS https://pinpointanswertoday.app/api/puzzles/summary
+```
+
+通过标准：
+
+- `latest.slug` 是今天那一题
+- `status` 是 `live`
+
+如果不对，白话就是：
+
+- 首页和详情页对外口径还没切到今天这题
+
+### 1.2 看 `/pinpoint/today`
+
+```bash
+curl -sSI https://pinpointanswertoday.app/pinpoint/today
+```
+
+通过标准分两种：
+
+- 已正式发布：返回 `307`，并跳到今天那题的详情页
+- 还在发布中：返回 `503`，并带 `retry-after`
+
+如果看到别的结果，白话就是：
+
+- 当天入口逻辑不对，可能跳错题、提前露出、或者没切换成功
+
+---
+
+## 2. 看 worker 有没有正常拿到今天题目
+
+### 2.1 看健康页
+
+```bash
+curl -sS https://pinpoint-worker.2296744453m.workers.dev/health
+```
+
+通过标准：
+
+- `puzzleDate` 是今天
+- `answers` 有 5 个词
+- `source` 正常情况下优先看见 `graphql`
+
+如果这里不对，白话就是：
+
+- worker 还没抓到今天题，或者抓到了但数据不完整
+
+### 2.2 看监控页
+
+```bash
+curl -sS https://pinpoint-worker.2296744453m.workers.dev/monitor/cron-status
+```
+
+重点看这 4 个位置：
+
+- `latest.outcome`
+- `latest.quickPublish.status`
+- `latest.enrich.status`
+- `alerts`
+
+通过标准：
+
+- `latest.outcome = "succeeded"`
+- `alerts` 是空数组
+
+正常但不一定代表有问题的情况：
+
+- `quickPublish.status = "skipped"` 且原因是今天已经发过
+- `enrich.status = "skipped"` 且原因是今天已经 enrich 完成
+
+需要警惕的情况：
+
+- `alerts` 不是空
+- `detailState` 长时间停在 `generating` 或 `validated`
+- `outcome = "failed"`
+
+---
+
+## 3. 看今天详情页正文是不是对上
+
+先把今天的 slug 从摘要接口里拿出来，比如 `pinpoint-answer-697`。
+
+### 3.1 最低人工检查
+
+直接打开：
+
+- `https://pinpointanswertoday.app/linkedin-pinpoint-answers/<today-slug>/`
+
+至少看这 5 件事：
+
+- 标题是不是今天那题
+- 5 个 clue 对不对
+- 答案是不是今天那题的答案
+- 正文有没有明显跑题、重复段、空白段
+- FAQ 和 clue 表是不是还能读通
+
+### 3.2 这轮新版最该多看两项
+
+如果今天这题是新版详情结构，还要顺手确认：
+
+- 页面里有没有 `Solve path snapshot`
+- 页面里有没有 `Clue-by-clue evidence`
+
+如果没有，白话就是：
+
+- 详情页可能退回了旧壳子，或者 v2 字段没被正确消费
+
+---
+
+## 4. 快速判断结果
+
+### 绿色
+
+满足下面这些就算正常：
+
+- 摘要接口是今天那题
+- `/pinpoint/today` 正常跳今天详情页
+- worker `/health` 是今天这题，且 5 个 clue 完整
+- `/monitor/cron-status` 没告警
+- 详情页正文、答案、FAQ、证据表都对得上
+
+### 黄色
+
+可以先观察，但要记一笔：
+
+- `quickPublish` / `enrich` 显示 `skipped`
+- 监控里是成功，但今天详情页看起来还是旧正文
+- 页面能打开，但 `Solve path snapshot` 或 `Clue-by-clue evidence` 没出现
+
+### 红色
+
+需要立刻处理：
+
+- `/api/puzzles/summary` 不是今天这题
+- `/pinpoint/today` 既不是 `307` 也不是 `503`
+- `/health` 不是今天题，或者 clue 不满 5 个
+- `alerts` 非空
+- 详情页答案或正文明显错题
+
+---
+
+## 5. 推荐的最短执行顺序
+
+如果你只想花 2 分钟，按这个顺序看：
+
+1. `summary`
+2. `/pinpoint/today`
+3. `worker /health`
+4. `worker /monitor/cron-status`
+5. 今天详情页人工看一眼
+
+---
+
+## 6. `2026-03-28` 基线参考
+
+这次上线后，正常状态长这样：
+
+- `summary.latest.slug = pinpoint-answer-697`
+- `/pinpoint/today` 返回 `307` 到 `pinpoint-answer-697`
+- worker `/health` 返回 `2026-03-28`，`source = "graphql"`
+- `/monitor/cron-status` 的 `alerts = []`
+- 最新详情页已出现：
+  - `Solve path snapshot`
+  - `Clue-by-clue evidence`
+
+如果下次你看到的结果和这组基线差很远，优先按异常处理，而不是先猜“是不是缓存没刷新”。

--- a/docs/pinpoint-detail-generation-prd-2026-03-26.md
+++ b/docs/pinpoint-detail-generation-prd-2026-03-26.md
@@ -1,0 +1,1398 @@
+# Pinpoint 详情页生成重构 PRD（2026-03-26）
+
+## 一句话结论
+
+要让我们的详情页生成内容不比对手差，核心不是继续修几句文案，而是把整条链路从“字段拼装 + 临时兜底”改成“题型分流 + 模式分流 + 文章优先 + 统一保底 + 发布验收”。
+
+如果只做一句产品决策，就是：
+
+- 没有正式详情内容时，不要伪装成完整分析页
+- 有正式详情内容时，正文必须来自文章块，不再靠旧模板说明文拼出来
+
+---
+
+## 背景
+
+过去几天的真实页面暴露出一组连续问题：
+
+- `#690`：答案对，但正文像旧模板说明文
+- `#691`：一度连答案方向都写窄了
+- `#693`：明显题被硬写成“有转折的复盘长文”
+- `#694`：短版页是对的，但通知和构建规则把“合理降级”描述成“失败保底”
+- `#695`：short mode 页面可用，但像系统帮助卡，不像内容页
+
+这些问题说明，我们当前的瓶颈不是“模型不够聪明”，而是产品和生成架构没有对齐。
+
+---
+
+## 当前系统架构现状
+
+### 代码仓库结构
+
+```
+new-pinpoint-site/
+├── data/puzzles/                          # puzzle JSON 数据源（#458 ~ #695）
+│   ├── pinpoint-answer-{N}.json           # 每道题一个 JSON 文件
+│   └── registry.json                      # 全局题目注册表
+├── lib/
+│   ├── puzzle-generation.ts               # AI 生成核心（2277 行），含 prompt、API 调用、slot→正文组装
+│   └── puzzles/
+│       ├── content-contract.ts            # 内容契约验证（332 行），定义字段最低标准和语义检查
+│       ├── semantic-lint.ts               # 语义质检规则（569 行），18 条 PUBLISH_BLOCKING 规则
+│       ├── slot-contract.ts               # 槽位契约验证（297 行），校验 AI 回传的结构化字段
+│       ├── fallback-copy.ts               # 统一 fallback 正文/lessons/FAQ 生成器（153 行）
+│       ├── schema.ts                      # Zod schema 定义（puzzleDetailContentSchema 等）
+│       ├── schema.shared.mjs              # 跨 worker/site 共享的 schema
+│       └── worker-fallback.ts             # Worker 侧 fallback 逻辑
+├── worker/src/index.ts                    # Cloudflare Worker 主入口（170K+），cron 调度 + 发布链
+├── scripts/
+│   ├── check-pinpoint-guardrails.ts       # 预提交卡口脚本
+│   ├── run-pinpoint-regression.mjs        # 回归测试运行器
+│   └── release-production.mjs             # 生产发布脚本
+└── components/detail/                     # 详情页前端组件
+    ├── PuzzleDetail.tsx                   # 详情页总入口
+    ├── PuzzleFullAnalysis.tsx             # Full Analysis 渲染（15K+）
+    ├── PuzzleAnswerReveal.tsx             # 答案揭晓卡片
+    └── DetailAnalysis.tsx                 # 分析区块渲染
+```
+
+### 当前 Puzzle JSON 数据结构（以 #693 为例）
+
+```jsonc
+{
+  "puzzleNumber": 693,
+  "slug": "pinpoint-answer-693",
+  "bodyMode": "short",                     // ← 新增字段，部分旧题没有
+  "publishDate": "2026-03-24",
+  "clues": ["Mahalo", "Danke", "Arigato", "Merci", "Gracias"],
+  "answer": ""Thank you" in different languages",
+  "category": ""Thank you" in different languages",
+  "wordHints": { /* 每个 clue 的揭晓提示 */ },
+  "spoilerHints": { /* 不剧透的提示 */ },
+  "articleBlocks": [ /* 正文段落数组 */ ],
+  "fullAnalysis": [ /* 与 articleBlocks 内容相同，历史兼容字段 */ ],
+  "solutionNarrative": [ /* 解题过程叙述 */ ],
+  "lessons": [ { "title": "...", "body": "..." } ],
+  "display": {
+    "connectorSummary": "...",
+    "fastStrategy": "...",
+    "clueTableRows": [ { "clue": "...", "examplePhrase": "...", "connectionExplained": "..." } ]
+  },
+  "faqs": [ { "question": "...", "answer": "..." } ]
+}
+```
+
+> **注意**：当前 JSON 结构缺少 `pageMode`、`questionType`、`difficulty` 字段，这是本次重构需要新增的核心字段。`fullAnalysis` 和 `articleBlocks` 存在冗余，需统一收口为 `articleBlocks`。
+
+### 当前 AI 生成链路
+
+1. **Prompt 构建**：`puzzle-generation.ts → buildPuzzlePrompt()` 生成约 470 行的结构化 prompt
+2. **模型调用**：支持 OpenAI / Anthropic / Zhipu / Azure 四种 provider，默认 `gpt-4.1-mini`
+3. **响应解析**：`parseAIResponse()` → JSON 解析 → `ParsedAIResponseSchema` Zod 校验
+4. **槽位校验**：`validateSlotContract()` 检查 8 个槽位字段的格式和内容
+5. **正文组装**：`composeFromSlots()` 将槽位拼装成 `overview + solutionEmergence + articleBlocks`
+6. **内容质检**：`validateContentContract()` + `collectSemanticLintIssues()` 执行 18 条拦截规则
+7. **写入发布**：写入 `data/puzzles/pinpoint-answer-{N}.json` → git push → Vercel 部署
+
+### 当前质检规则清单（18 条 PUBLISH_BLOCKING）
+
+| 规则代码 | 含义 | 来源文件 |
+| --- | --- | --- |
+| `text.localeMarker` | 检测到语言标记残留 `[fr]` `[de]` 等 | `semantic-lint.ts` |
+| `text.brokenEntity` | HTML 实体编码残留 | `semantic-lint.ts` |
+| `text.leadingEllipsis` | 模板片段前导省略号 | `semantic-lint.ts` |
+| `text.englishResidual.unrelated` | 非英文 locale 中残留英文关键词 | `semantic-lint.ts` |
+| `mainAnswer.suspiciousCategoryLabel` | 答案标签过度修饰或机器味重 | `semantic-lint.ts` |
+| `faqs.firstAnswerMissingExactAnswer` | 第一条 FAQ 未包含准确答案文本 | `semantic-lint.ts` |
+| `summary.promotionalTone` | Hero 摘要像营销文案而非内容简介 | `semantic-lint.ts` |
+| `copy.temporaryPageLanguage` | 正文出现临时页面话术 | `semantic-lint.ts` |
+| `summary.answerSpoiler` | Hero 摘要泄露答案 | `semantic-lint.ts` |
+| `overview.leadingAnswerSpoiler` | Overview 首句暴露答案 | `semantic-lint.ts` |
+| `sections.overlap` | Overview 与解题叙事重复率 ≥ 60% | `semantic-lint.ts` |
+| `sections.sharedPhrasing` | 两段正文连续复用 ≥ 7 个相同词 | `semantic-lint.ts` |
+| `answer.overused` | 答案全文出现次数 > 3 | `semantic-lint.ts` |
+| `wrongGuesses.machineyGuess` | 错误猜测标签太机器味 | `semantic-lint.ts` |
+| `solutionEmergence.genericPivot` | 解题转折是通用模板句而非具体 clue | `semantic-lint.ts` |
+| `faqs.genericConnectionAnswer` | 连接类 FAQ 回答太笼统 | `semantic-lint.ts` |
+| `clueDetails.genericExplanation` | clue 解释使用通用填充语 | `semantic-lint.ts` |
+| `answer.semanticNarrowing` | 正文对答案做了额外限定缩窄 | `semantic-lint.ts` |
+| `answer.alternateRestatement` | 正文引入答案的变体说法而非原文 | `semantic-lint.ts` |
+
+### 当前 Content Contract 常量（`content-contract.ts`）
+
+| 常量 | 值 | 说明 |
+| --- | --- | --- |
+| `overviewMinWords` | 65 | full mode overview 最低字数 |
+| `shortOverviewMinWords` | 40 | short mode overview 最低字数 |
+| `solutionEmergenceMinWords` | 90 | full mode 解题叙事最低字数 |
+| `shortSolutionEmergenceMinWords` | 70 | short mode 解题叙事最低字数 |
+| `summaryMinWords` | 20 | 摘要最低字数 |
+| `metaDescriptionMinChars` | 115 | SEO 描述最少字符 |
+| `metaDescriptionMaxChars` | 165 | SEO 描述最多字符 |
+| `clueDetailsRequired` | 5 | clue 详解必须 5 条 |
+| `lessonsMin` | 3 | Lessons 最少 3 条 |
+| `faqsMin` | 3 | FAQ 最少 3 条 |
+
+### 当前 Slot Contract 常量（`slot-contract.ts`）
+
+| 常量 | 值 | 说明 |
+| --- | --- | --- |
+| `heroIntroMinWords` | 20 | Hero 开头最少字数 |
+| `heroIntroMaxWords` | 45 | Hero 开头最多字数 |
+| `connectorSummaryMinWords` | 6 | 连接摘要最少字数 |
+| `connectorSummaryMaxWords` | 16 | 连接摘要最多字数 |
+| `falseStartsMin` | 1 | 错误方向最少 1 个 |
+| `falseStartsMax` | 2 | 错误方向最多 2 个 |
+| `difficultyReasonMinWords` | 10 | 难度原因最少字数 |
+| `portableTakeawayMinWords` | 6 | 可迁移教训最少字数 |
+| `portableTakeawayMaxWords` | 28 | 可迁移教训最多字数 |
+
+### 当前 Fallback 生成器（`fallback-copy.ts`）
+
+支持 5 种模式：`before` / `after` / `typed-category` / `category` / `association`
+
+- `buildSharedFallbackArticleBlocks()` → 生成 6 段 fallback 正文
+- `buildSharedFallbackLessons()` → 生成 3 条 fallback lessons
+- `buildSharedFallbackFaqs()` → 生成 3 条 fallback FAQ
+- `buildSharedFallbackSolutionNarrative()` → 生成 2 段 fallback 解题叙事
+
+> **问题**：fallback 正文虽分 phrase / category 两路，但未按 `obvious / medium / hard` 分级，且 category 分支内 `association` 模式与 `typed-category` 共用同一套文案模板。
+
+---
+
+## 目标
+
+### 业务目标
+
+- 每天都能稳定发布可用详情页
+- 明显题不再被硬写成长文复盘
+- 中等题和复杂题能读起来像真人在讲解，而不是系统在解释
+- 不再出现“正文是 short，SEO 还是 full”或“线上还是旧内容”的状态打架
+
+### 内容目标
+
+- 详情页正文读感不输对手
+- 表格不再一行一个模板
+- FAQ 不再只是把正文换个说法重复一遍
+- fallback（保底内容）也不能像旧模板说明书
+
+### 工程目标
+
+- 正式详情内容、live fallback、worker fallback、admin 修复链统一口径
+- 发布后自动验收必须覆盖页面正文和 metadata（页头信息）
+- 新旧模板句在提交前就能被校验脚本拦下
+
+---
+
+## 非目标
+
+- 这次 PRD 不追求“每篇都像顶级专栏”
+- 不要求模型一次自由发挥直接出完美长文
+- 不把重点放在页面视觉改版
+- 不优先解决多语言
+
+---
+
+## 用户问题
+
+当前详情页对用户主要有 4 类问题：
+
+### 1. 页面看起来像正式分析，内容却像临时占位
+
+例如：
+
+- `formal long-form JSON is still unavailable`
+- `Short mode: compact explanation while the formal long-form JSON is unavailable`
+
+这类话对用户的意思只有一个：页面还没准备好。
+
+### 2. obvious（很明显）题被硬写成“复杂推理题”
+
+例如：
+
+- `Mahalo / Danke / Arigato / Merci / Gracias`
+
+这类题本来一眼就是“谢谢的不同语言”，但系统还会硬写：
+
+- 有误判
+- 有 turning point（关键转折）
+- 某一个 clue 才让答案变具体
+
+这会让正文显得假。
+
+### 3. 表格和 FAQ 太模板
+
+常见问题：
+
+- 五行表格解释几乎同一句型
+- FAQ 只是把答案和连接关系再说一遍
+- 没有回答用户真正会问的问题
+
+### 4. 发布状态和页面状态不同步
+
+之前真实发生过：
+
+- 代码部署成功
+- 线上页面却还是旧内容
+- 正文已经 short mode，metadata（搜索摘要/分享文案）却还是 full mode
+
+---
+
+## 对手详情页的关键做法
+
+基于之前对对手页面和截图的反推，真正值得学的不是样式，而是这 5 件事：
+
+### 1. 对手在写“文章”，不是在拼“说明字段”
+
+它的正文更像：
+
+- 第一反应
+- 错误方向
+- 后面哪个 clue 打断了错误方向
+- 最后如何落到答案
+
+而不是：
+
+- connector
+- overview
+- explanation
+
+### 2. 它会按题目难度切写法
+
+- 明显题：短、快、直接，不强写误判
+- 中等题：有一段误判和一段转折
+- 难题：才适合完整复盘
+
+### 3. 它不会把内部生成状态暴露给用户
+
+用户看到的是页面类型，而不是“后台还没生成完”。
+
+### 4. 它的表格和 FAQ 是补价值，不是补字数
+
+- 表格解释最值得解释的 clue
+- FAQ 回答真实搜索意图
+
+### 5. 它的详情页是“先有内容，再放进页面壳子”
+
+这点是最关键的：
+
+- 不是页面组件临时把几个字段拼成人话
+- 而是先有一篇内容，再渲染到页面
+
+---
+
+## 当前系统根因
+
+### 根因 1：正文来源不够单一
+
+当前正文可能来自：
+
+- 正式 JSON
+- live fallback
+- worker fallback
+- admin 修复链
+
+虽然我们已经做了不少统一，但实际产出时还是会出现：
+
+- 页面模式对了
+- 但内容口吻不对
+
+### 根因 2：所有题都在被同一种“解题剧情模板”处理
+
+尤其是：
+
+- before/after（前后词组）题
+- category（类别）题
+- obvious（明显题）
+- hard misdirection（误导强的难题）
+
+现在没有被真正分开处理。
+
+### 根因 3：short mode 现在还是“兜底产品”，不是“正式产品”
+
+它目前更像：
+
+- 页面撑住别空白
+
+而不是：
+
+- 一种有意设计的轻量详情页
+
+### 根因 4：表格和 FAQ 生成逻辑没有题型分流
+
+所以会出现：
+
+- phrase 题写得像 category 题
+- obvious 题 FAQ 还在讲 turning point
+- 表格每行只是在重复同一个解释器
+
+---
+
+## 产品方案
+
+## 方案总览
+
+将详情页系统拆成两层：
+
+1. `页面模式`
+2. `内容模式`
+
+同时增加一个统一决策器，先决定当前页面该走哪种模式，再决定正文该走哪种写法。
+
+### 统一决策器（新增）
+
+判定顺序固定为：
+
+1. 是否存在正式详情 JSON
+2. 当前题型（`questionType`）
+3. 当前难度（`difficulty`）
+4. AI 草稿是否通过质检
+5. 决定 `pageMode`、`bodyMode`、回退路径和 metadata（页头信息）
+
+#### 决策表
+
+| 是否有正式详情 JSON | questionType | difficulty | AI 质检结果 | pageMode | bodyMode | 页面结果 |
+| --- | --- | --- | --- | --- | --- | --- |
+| 否 | 任意 | 任意 | 不适用 | `live_card` | 无 | 只显示答案卡和极短说明 |
+| 否 | `before/after phrase` / `obvious category` | `obvious` | 不适用 | `quick_guide` | `short` | 显示短版复盘、精简表格、Compact FAQ |
+| 是 | 任意 | `obvious` | 通过 | `quick_guide` | `short` | 显示正式短版详情页 |
+| 是 | 任意 | `medium` | 通过 | `full_analysis` | `standard` | 显示标准版正文 |
+| 是 | 任意 | `hard` | 通过 | `full_analysis` | `deep` | 显示深度版正文 |
+| 是 | 任意 | 任意 | 不通过，但可短版通过 | `quick_guide` | `short` | 降级成正式短版页，不假装长文 |
+| 是 | 任意 | 任意 | 不通过，短版也不过 | `live_card` | 无 | 只保留答案卡，不显示完整分析 |
+
+#### 优先级规则
+
+- `正式详情 JSON` 优先于 live fallback（线上实时兜底）。
+- `obvious` 题优先走 `short`，即使有正式 JSON，也不强行拉成长文。
+- `AI 质检不过` 时，先尝试降级到 `quick_guide`，而不是直接塞一篇假长文。
+- metadata（页头信息）必须跟 `pageMode` 同步，不能出现正文 short、页头 full 的状态打架。
+
+---
+
+## 一、页面模式
+
+### Mode A：Live Answer Card
+
+适用场景：
+
+- 当天题刚出
+- 只有答案和 clue
+- 没有正式详情 JSON
+
+页面只显示：
+
+- clue 卡片
+- reveal（揭晓答案）
+- 极短说明
+- 不显示“完整分析”卡片
+
+目标：
+
+- 先保正确可用
+- 不伪装成完整详情页
+
+### Mode B：Quick Guide
+
+适用场景：
+
+- obvious 题
+- 或正式长文暂时没过线，但已有可用短版内容
+
+产品定义：
+
+- 这是正式页面模式，不是失败保底
+- short mode 的详情页要像一篇短内容，不像占位卡片
+
+页面显示：
+
+- 3 到 4 段短版复盘
+- 精简表格
+- Compact FAQ
+
+禁止出现：
+
+- `formal long-form JSON is still unavailable`
+- `JSON unavailable`
+- 任何内部生成状态文案
+
+### Mode C：Full Analysis
+
+适用场景：
+
+- 正式详情 JSON 已生成
+- 内容质量通过
+
+页面显示：
+
+- article blocks 正文
+- Category
+- Words & How They Fit
+- Lessons
+- FAQ
+
+---
+
+## 二、内容模式
+
+### bodyMode: short
+
+适用：
+
+- obvious 题
+- 明显短语题
+- 识别后几乎一眼能看出的题
+
+要求：
+
+- 3 到 4 段短版正文
+- 不强写误判
+- 不强写 turning point
+- 表格和 FAQ 走短版模板
+- 允许没有单一 turning clue（关键转折线索）
+
+### bodyMode: standard
+
+适用：
+
+- 普通题
+- 有轻微误导，但不需要长篇
+
+要求：
+
+- 5 到 8 段正文
+- 可有 1 次误判
+- 可有 1 个 turning clue
+
+### bodyMode: deep
+
+适用：
+
+- 误导强、转折明显、值得写长文的题
+
+要求：
+
+- 8 到 14 段正文
+- 完整 solve story（解题过程）
+- 更完整 Lessons 和 FAQ
+
+### 统一 schema / contract（新增）
+
+正文、metadata、fallback 和发布验收都必须消费同一份 contract（数据契约），不允许各走各的字段口径。
+
+#### 顶层字段
+
+| 字段 | 必填 | 说明 | short | standard/deep |
+| --- | --- | --- | --- | --- |
+| `slug` | 是 | 页面唯一标识 | 是 | 是 |
+| `pageMode` | 是 | `live_card / quick_guide / full_analysis` | 是 | 是 |
+| `bodyMode` | 条件必填 | `short / standard / deep` | 是 | 是 |
+| `questionType` | 是 | 题型分流结果 | 是 | 是 |
+| `difficulty` | 是 | `obvious / medium / hard` | 是 | 是 |
+| `answer` | 是 | 最终答案 | 是 | 是 |
+| `meta.title` | 是 | 页面标题 | 是 | 是 |
+| `meta.description` | 是 | SEO/分享描述 | 是 | 是 |
+| `articleBlocks` | short/full 条件必填 | 页面正文唯一主来源 | 3-4 段 | 5-14 段 |
+| `table.rows` | 是 | 表格行 | 是 | 是 |
+| `faq.items` | 是 | FAQ 列表 | 1-2 条 | 2-3 条 |
+| `lessons` | full 条件必填 | Lessons 模块 | 否 | 是 |
+
+#### contract 规则
+
+- 页面正文只认 `articleBlocks`
+- metadata 不允许自行拼接旧模板摘要
+- fallback 也必须返回同一份 contract，只是 `pageMode/bodyMode` 不同
+- 详情页组件不再负责“补开头”“补总结”“补 turning point”
+- `articleBlocks` 不存在时，页面只能渲染 `live_card`，不能伪装成完整分析页
+
+#### `articleBlocks` block schema（新增）
+
+`articleBlocks` 是正文唯一主来源，因此 block 结构必须写死，不允许前端、生成器、fallback 各自理解。
+
+| 字段 | 类型 | 必填 | 说明 |
+| --- | --- | --- | --- |
+| `id` | `string` | 是 | block 唯一 ID，用于渲染和回归定位 |
+| `type` | `'paragraph' \| 'heading' \| 'list' \| 'callout'` | 是 | block 类型 |
+| `text` | `string` | 条件必填 | `paragraph / heading / callout` 主文本 |
+| `items` | `string[]` | 条件必填 | `list` 类型条目数组 |
+| `tone` | `'neutral' \| 'transition' \| 'answer' \| 'reflection'` | 否 | 仅供质检和模式判定使用 |
+| `order` | `number` | 是 | block 顺序，必须从 `0` 连续递增 |
+
+额外约束：
+
+- `short` 模式只允许：`paragraph`、`list`
+- `standard / deep` 模式允许：`paragraph`、`heading`、`list`、`callout`
+- 第一条 block 必须是 `paragraph`
+- 至少有 1 条 `tone = answer` 的 block，并明确说出答案
+- 不允许出现空 block，也不允许 `text` 和 `items` 同时为空
+
+#### 表格 row schema（新增）
+
+| 字段 | 类型 | 必填 | 说明 |
+| --- | --- | --- | --- |
+| `clue` | `string` | 是 | 原 clue 文本，必须与 clue 列表一一对应 |
+| `examplePhrase` | `string` | 是 | 具体短语或示例 |
+| `connectionExplained` | `string` | 是 | 解释为何该 clue 成立 |
+| `rowType` | `'phrase' \| 'category' \| 'association'` | 是 | 行级题型标记 |
+
+额外约束：
+
+- before/after 题的 `examplePhrase` 必须是完整短语
+- obvious category 题的 `connectionExplained` 应优先写事实解释，不写模板确认句
+- 5 个 clue 必须对应 5 行，不允许缺行或重排
+
+#### 目标 Puzzle JSON 数据结构（重构后）
+
+```jsonc
+{
+  "puzzleNumber": 695,
+  "slug": "pinpoint-answer-695",
+  // ===== 新增核心字段 =====
+  "pageMode": "quick_guide",               // live_card | quick_guide | full_analysis
+  "bodyMode": "short",                     // short | standard | deep
+  "questionType": "before/after phrase",   // 题型分流结果
+  "difficulty": "obvious",                 // obvious | medium | hard
+  // ===== 现有字段保留 =====
+  "publishDate": "2026-03-26",
+  "clues": ["Tiger", "Plane", "Towel", "Weight", "Clip"],
+  "answer": "Words that come after \"paper\"",
+  "wordHints": { },
+  "spoilerHints": { },
+  "articleBlocks": [ /* 正文唯一主来源 */ ],
+  // ===== 废弃字段（迁移期保留，渲染不再读取）=====
+  // "fullAnalysis": [...],  // 统一为 articleBlocks
+  "solutionNarrative": [ ],
+  "lessons": [ { "title": "...", "body": "..." } ],
+  "display": { },
+  "faqs": [ { "question": "...", "answer": "..." } ],
+  // ===== 新增 metadata 一致性字段 =====
+  "meta": {
+    "title": "LinkedIn Pinpoint #695 Answer -- Words after paper",
+    "description": "Quick guide for Pinpoint #695..."
+  }
+}
+```
+
+#### 代码变更清单
+
+| 文件 | 变更类型 | 说明 |
+| --- | --- | --- |
+| `lib/puzzles/schema.ts` | 修改 | 新增 `pageMode` `questionType` `difficulty` `meta` 字段 |
+| `lib/puzzles/schema.shared.mjs` | 修改 | 同步新增 schema，确保 worker 和 site 共用 |
+| `lib/puzzles/content-contract.ts` | 修改 | 质检规则按 bodyMode 分级调整阈值 |
+| `lib/puzzle-generation.ts` | 修改 | 根据 questionType 选择不同 prompt 模板 |
+| `lib/puzzles/fallback-copy.ts` | 修改 | fallback 按 difficulty 分级生成 |
+| `components/detail/PuzzleFullAnalysis.tsx` | 修改 | 正文只读 articleBlocks |
+| `components/detail/PuzzleDetail.tsx` | 修改 | 根据 pageMode 切换渲染组件 |
+| `scripts/check-pinpoint-guardrails.ts` | 修改 | 增加 pageMode/bodyMode 一致性检查 |
+| `lib/puzzles/question-classifier.ts` | 新增 | 题型自动分类器 |
+
+---
+
+## 三、题型分流
+
+至少分为 4 类：
+
+### 1. before/after phrase
+
+例如：
+
+- `Words that come before "roses"`
+- `Words that come after "paper"`
+
+要求：
+
+- 核心是 shared word（共享词）
+- 表格解释要写出具体短语，不要重复模板句
+
+### 2. obvious category
+
+例如：
+
+- `Mahalo / Danke / Arigato / Merci / Gracias`
+- `Marble / Obsidian / Slate / Granite / Sandstone`
+
+要求：
+
+- 不强行制造戏剧性
+- 承认这题很快能看出来
+- 重点是把答案说清楚
+
+### 3. medium category / association
+
+要求：
+
+- 可以有误判
+- 允许一个明确 turning clue
+
+### 4. hard misdirection
+
+要求：
+
+- 适合完整长文
+- 才允许比较完整的复盘结构
+
+### 题型 + 难度映射规则（新增）
+
+| questionType | 默认 difficulty | 默认 bodyMode | 允许升级条件 |
+| --- | --- | --- | --- |
+| `before/after phrase` | `medium` | `short` 或 `standard` | 只有在误导明显时才升到 `standard` |
+| `obvious category` | `obvious` | `short` | 不升到 `deep` |
+| `medium category / association` | `medium` | `standard` | turning clue 很强时可保持 `standard` |
+| `hard misdirection` | `hard` | `deep` | 默认长文 |
+
+映射原则：
+
+- 明显题默认短，不硬写戏剧性
+- 复杂题才给完整复盘权限
+- `difficulty` 先决定正文长度，再决定 QA 门槛
+
+### `difficulty` 来源与低置信度规则（新增）
+
+`difficulty` 不能只靠大模型自评，也不能完全靠人工拍脑袋，必须由“规则信号 + 模型判断”共同产生。
+
+#### 输入来源
+
+1. `规则信号`
+   - answer pattern（before / after / category / typed-category）
+   - clue 是否明显属于同一语义集合
+   - 是否存在可识别的错误方向
+   - 是否有 clue 会显著收窄答案
+2. `模型判断`
+   - 输出候选 `difficulty`
+   - 输出 `difficultyReason`
+
+#### 判定流程
+
+1. 规则侧先计算：
+   - `obviousScore`
+   - `misdirectionScore`
+2. 模型侧再输出：
+   - `difficultyCandidate`
+   - `difficultyReason`
+3. 统一决策器合并：
+   - `obviousScore >= 0.8` 优先判 `obvious`
+   - `misdirectionScore >= 0.7` 优先判 `hard`
+   - 其余默认 `medium`
+
+#### 低置信度处理
+
+- 如果规则判断和模型判断一致：直接采用
+- 如果不一致但一侧分数明显更高（>= 0.8）：采用高分侧
+- 如果不一致且两侧都不高：默认降到更保守的 `medium`
+
+#### 代价优先级
+
+- 误把 `hard` 判成 `obvious`：风险最高，必须尽量避免
+- 误把 `obvious` 判成 `medium`：成本可接受，只会牺牲一点正文效率
+- 因此低置信度时，宁可保守走 `medium / standard`，也不要贸然走 `obvious / short`
+
+### 题型自动分类逻辑（新增 `classifyQuestionType()`）
+
+```
+function classifyQuestionType(answer, clues):
+  // 第一步：检测答案模式（复用现有 detectAnswerPattern）
+  pattern = detectAnswerPattern(answer)
+  if pattern.kind == "before" or pattern.kind == "after":
+    return { questionType: "before/after phrase", difficulty: "medium" }
+
+  // 第二步：obvious 检测
+  if pattern.kind == "typed-category" or pattern.kind == "category":
+    obviousScore = computeObviousScore(clues, answer)
+    //   - 5 个 clue 中有 >= 3 个能被直接识别为同类 → obvious
+    //   - 所有 clue 都是专有名词且属于已知集合 → obvious
+    //   - 答案本身是日常常识 → obvious
+    if obviousScore >= 0.8:
+      return { questionType: "obvious category", difficulty: "obvious" }
+
+  // 第三步：误导强度检测
+  misdirectionScore = computeMisdirectionScore(clues, answer)
+  //   - 是否有 >= 2 个 clue 容易被归入另一个合理类别
+  //   - 是否有明显的错误方向（false starts）
+  if misdirectionScore >= 0.7:
+    return { questionType: "hard misdirection", difficulty: "hard" }
+
+  // 第四步：默认走 medium
+  return { questionType: "medium category / association", difficulty: "medium" }
+```
+
+> **实现位置**：新增为 `lib/puzzles/question-classifier.ts`，供 `puzzle-generation.ts` 和 `worker/src/index.ts` 共同调用。
+
+> **真实案例对照**：
+> - `#693`（Mahalo/Danke/Arigato/Merci/Gracias）→ `obvious category` + `short`
+> - `#695`（Tiger/Plane/Towel/Weight/Clip，answer: "Words that come after paper"）→ `before/after phrase` + `short` 或 `standard`
+> - `#689`（medium category）→ `medium category / association` + `standard`
+
+---
+
+## 四、正文生成规则
+
+### 原则
+
+- 正文只认 `articleBlocks`
+- 不再把 `overview + solutionEmergence` 当正文主来源
+- 不让页面组件负责“临时补文风”
+
+### 正文最低要求
+
+#### short
+
+- 3 到 4 段（对应 `articleBlocks.length` 3~6）
+- 每段 1 到 2 句
+- 明确答案
+- 不写系统话术
+- `resolveContentBodyMode()` 自动判定：`articleBlockCount > 0 && articleBlockCount <= 6` → short
+- `overview` >= 40 词（`shortOverviewMinWords`）
+- `solutionEmergence` >= 70 词（`shortSolutionEmergenceMinWords`）
+
+#### standard
+
+- 5 到 8 段
+- 有清晰推进（开头 → 误判 → 转折 → 答案 → 收尾）
+- `overview` >= 65 词，`solutionEmergence` >= 90 词
+- 不允许明显模板句
+
+#### deep
+
+- 8 到 14 段
+- 完整 solve story
+- `overview` >= 65 词，`solutionEmergence` >= 90 词
+- 更完整 Lessons（>= 3 条）和 FAQ（>= 3 条）
+
+### 禁止句型
+
+以下句型视为高风险模板句（已在 `semantic-lint.ts` 中实现正则拦截）：
+
+- `same category reading`
+- `same shared frame`
+- `specific enough to trust`
+- `one clean set`
+- `same shelf`
+- `the board started to shift`
+- `made the answer feel concrete`
+- `fits the same shared connection`（已在 `GENERIC_CLUE_EXPLANATION_PATTERNS` 中）
+- `same shared connection that leads to`（已在 `GENERIC_CLUE_EXPLANATION_PATTERNS` 中）
+- `points back to that same connection`（已在 `GENERIC_CLUE_EXPLANATION_PATTERNS` 中）
+
+### 本次新增禁止句型（需加入 `semantic-lint.ts`）
+
+| 禁止句型 | 新增规则代码 | 说明 |
+| --- | --- | --- |
+| `the board felt broad` | `copy.abstractBoard` | 太抽象，不具体 |
+| `the frame shifted` | `copy.abstractFrame` | 太抽象，不具体 |
+| `the category became specific enough` | `copy.abstractSpecific` | 太抽象，不具体 |
+| `this is the hallmark of a well-crafted puzzle` | `copy.flatteryCopy` | 吹捧式文案 |
+| `difficulty varies` | `copy.genericDifficulty` | 无信息量 |
+| `X connects to...` | `copy.genericConnect` | 通用填充语 |
+| `X fits the theme` | `copy.genericFit` | 通用填充语 |
+| `the clues all share this connection` | `copy.genericShare` | 通用填充语 |
+
+---
+
+## 五、表格生成规则
+
+### 原则
+
+- 表格不是重复正文
+- 表格不是每行一个模子
+- 表格优先解释最不 obvious 的 clue
+
+### before/after phrase 题
+
+应写成：
+
+- `paper tiger`: a familiar phrase for a weak threat
+- `paper plane`: a folded toy aircraft
+
+不应写成：
+
+- `makes more sense once the board is read through "paper"`
+
+### obvious category 题
+
+应写成事实解释：
+
+- `Mahalo is the Hawaiian word for "thank you".`
+
+不应写成：
+
+- `helps confirm the same answer`
+
+---
+
+## 六、FAQ 规则
+
+### short mode
+
+- 最多 2 个 FAQ
+- 必须回答真实问题
+
+例如：
+
+- 为什么答案是 `after paper`
+- 哪个 clue 最能确认这个答案
+
+### full mode
+
+- 2 到 3 个 FAQ
+- 不能只是正文改写
+
+#### FAQ contract（新增）
+
+- `short mode` FAQ 只回答最短路径问题
+- `full mode` FAQ 至少有 1 条补充正文没有明确说过的信息
+- 不允许出现“把答案再说一遍”式 FAQ
+- FAQ 也纳入旧模板句校验和答案逻辑质检
+
+---
+
+## 七、回退策略
+
+### 当前问题
+
+过去最大的问题不是没有回退，而是：
+
+- 回退太多套
+- 回退口吻不一致
+- 旧模板会复活
+
+### 新规则
+
+- 只保留一套统一 fallback copy
+- fallback 也分 short / standard / deep
+- fallback 绝不暴露内部状态
+- fallback 不伪装成长文分析
+
+### 降级状态机（新增）
+
+状态流转固定为：
+
+`live_card -> quick_guide -> full_analysis`
+
+#### 升级条件
+
+- `live_card -> quick_guide`
+  - 已有答案
+  - 题型已识别
+  - 至少有可用短版 contract
+
+- `quick_guide -> full_analysis`
+  - 正式详情 JSON 已生成
+  - 内容质量通过结构、文风、答案逻辑和页面状态质检
+
+#### 降级条件
+
+- `full_analysis -> quick_guide`
+  - AI 长文不过线
+  - 但 short mode 可用
+
+- `quick_guide -> live_card`
+  - short mode 也不过线
+  - 或 contract 不完整
+
+#### 状态机原则
+
+- 降级是正式产品行为，不是失败文案
+- 用户只看到页面模式，不看到内部失败原因
+- 任一状态切换都必须同步 metadata、页头标题、FAQ 口径和按钮文案
+
+---
+
+## 八、质检规则
+
+### 第一层：结构质检
+
+- 必须有答案
+- clue 数量匹配
+- table 行数匹配
+- FAQ 数量匹配
+
+### 第二层：文风质检（对应 `semantic-lint.ts`）
+
+| 检查项 | 对应规则代码 | 状态 |
+| --- | --- | --- |
+| 老模板句 | `GENERIC_CLUE_EXPLANATION_PATTERNS` | 已实现 |
+| 营销语气 | `summary.promotionalTone` | 已实现 |
+| 临时页面话术 | `copy.temporaryPageLanguage` | 已实现 |
+| 空转折（通用 pivot） | `solutionEmergence.genericPivot` | 已实现 |
+| Overview 与 SolutionEmergence 重复 | `sections.overlap` (>= 60%) | 已实现 |
+| 连续复用相同措辞 | `sections.sharedPhrasing` (>= 7 词) | 已实现 |
+| 通用 FAQ 回答 | `faqs.genericConnectionAnswer` | 已实现 |
+| 俏皮话/夸张修辞 | 待新增 `copy.flippantTone` | 待实现 |
+| 机械重复（同义句型复读） | 待新增 `copy.mechanicalRepetition` | 待实现 |
+| obvious 题强写 turning point | 待新增 `obvious.forcedTurningPoint` | 待实现 |
+
+### 第三层：答案逻辑质检（对应 `semantic-lint.ts`）
+
+| 检查项 | 对应规则代码 | 状态 |
+| --- | --- | --- |
+| 答案被额外限定缩窄 | `answer.semanticNarrowing` | 已实现 |
+| 引入答案变体说法 | `answer.alternateRestatement` | 已实现 |
+| 答案过度重复 | `answer.overused` (> 3 次) | 已实现 |
+| Hero 泄露答案 | `summary.answerSpoiler` | 已实现 |
+| Overview 首句暴露答案 | `overview.leadingAnswerSpoiler` | 已实现 |
+| 答案标签机器味 | `mainAnswer.suspiciousCategoryLabel` | 已实现 |
+| obvious 题硬写复杂推理 | 待新增 `obvious.forcedComplexReasoning` | 待实现 |
+| questionType 与 bodyMode 不匹配 | 待新增 `mode.mismatch` | 待实现 |
+
+### 第四层：页面状态质检（新增规则）
+
+| 检查项 | 代码位置 | 说明 |
+| --- | --- | --- |
+| metadata 与 pageMode 一致 | `content-contract.ts` 新增 | 校验 `meta.title` / `meta.description` 匹配 `pageMode` |
+| full mode title 包含 "Full Analysis" | `content-contract.ts` 新增 | `pageMode === 'full_analysis'` 时强制 |
+| pageMode / bodyMode / questionType 完整性 | `check-pinpoint-guardrails.ts` 新增 | 预提交卡口 |
+| 发布后线上 HTML 验收 | `release-production.mjs` 新增 | post-deploy 抓取校验 |
+| 线上正文首段与 JSON 一致 | `release-production.mjs` 新增 | 防止缓存导致旧内容残留 |
+| OG/Twitter description 与 meta 一致 | `release-production.mjs` 新增 | 防止 SEO 状态打架 |
+
+### 回归样本集（新增，扩展自 `docs/pinpoint-content-regression-sample-set.md`）
+
+固定回归样本及预期映射：
+
+| 样本 | 题目类型 | questionType | difficulty | bodyMode | 关键检查点 |
+| --- | --- | --- | --- | --- | --- |
+| `#689` | medium category / association | `medium category` | `medium` | `standard` | 正文模式正确；表格不模板重复 |
+| `#690` | before/after phrase | `before/after phrase` | `medium` | `short` 或 `standard` | 正文不像旧模板说明文；表格有具体短语 |
+| `#691` | 答案逻辑易写窄 | `medium category` | `medium` | `standard` | 答案不被缩窄；无 `answer.semanticNarrowing` |
+| `#693` | obvious category（谢谢的不同语言） | `obvious category` | `obvious` | `short` | 不强写 turning point；不硬造误判 |
+| `#695` | before/after phrase（paper） | `before/after phrase` | `medium` | `short` | 表格有 paper Tiger / paper Plane 等具体短语 |
+| `#682` | typed category（Types of dolls） | `medium category` | `medium` | `standard` | category 语言不像 phrase 语言 |
+| `#683` | phrase after（Words after "false"） | `before/after phrase` | `medium` | `standard` | Hero 不剧透；turning point 有具体 clue |
+| `#684` | phrase before（Words before "roses"） | `before/after phrase` | `medium` | `standard` | clue 解释具体；不退回 `X connects to...` |
+
+每次改动后必须检查：
+
+- `questionType` 和 `difficulty` 是否被正确分类
+- `pageMode` 和 `bodyMode` 是否与 `questionType` 映射一致
+- turning clue 是否被强行硬写（obvious 题应允许没有）
+- 表格是否模板重复（每行 `connectionExplained` 不应只替换 clue 名）
+- FAQ 是否只是在复读正文
+- `meta.title` 和 `meta.description` 是否与 `pageMode` 一致
+
+运行命令：
+
+```bash
+# 快速冒烟
+npm run test:pinpoint-regression
+# 核心集
+npm run test:pinpoint-regression:core
+# 全量
+npm run test:pinpoint-regression:all
+```
+
+---
+
+## 九、发布规则
+
+### 发布前
+
+1. 生成内容
+2. 机器质检
+3. 不通过则重生
+4. 再不通过则切 short fallback 或更稳的 fallback
+
+### 重试、超时与成本上限（新增）
+
+- 同一篇内容最多完整重生 `2` 次
+- 第 1 次失败：
+  - 保持同模式 prompt
+  - 带失败原因重生
+- 第 2 次失败：
+  - 使用降级 prompt
+  - 优先保住正确性和自然度下限
+- 单次请求超时：
+  - 正文生成：`30s`
+  - 质检复判：`20s`
+- 单篇内容整条链总耗时上限：`120s`
+
+超过上限后的默认动作：
+
+- 有 `short` 可用：切 `quick_guide`
+- `short` 也不可用：退到 `live_card`
+
+成本控制规则：
+
+- 每题最多允许：
+  - 1 次主生成
+  - 1 次重生
+  - 1 次答案逻辑复判
+- 禁止为了追求长文质量无限重试
+- 每日成本超出预算阈值时，自动提高 `short mode` 优先级
+
+### 发布后
+
+自动验收必须检查：
+
+- 正确答案出现
+- 已知错误答案不出现
+- 正文模式与 metadata 一致
+- 不含旧模板句
+
+---
+
+## 十、验收标准
+
+详情页达到“合格”的最低标准：
+
+- 用户看不出内部生成状态
+- 正文不是系统帮助卡
+- 表格不再五行一个模子
+- FAQ 不是正文复读
+- obvious 题不强写复杂推理
+- short mode 和 full mode 不打架
+
+达到“接近对手”的标准：
+
+- 正文像一篇短文章
+- 每段都在推进
+- 句子自然
+- 不靠模板句撑字数
+
+---
+
+## 十一、实施优先级
+
+### P0
+
+- short mode 去掉内部状态文案
+- short mode / full mode 页头、正文、metadata 完全同步
+- phrase 题 short mode 表格单独模板
+- 统一决策器落地到代码
+- 统一 schema 落地到页面、fallback、发布验收
+
+### P1
+
+- 正文只认 `articleBlocks`
+- 按题型 + 难度分流
+- fallback 统一成 short / standard / deep 三套
+- obvious 题允许没有 turning clue
+- FAQ / table contract 接到同一份 schema
+
+### P2
+
+- FAQ 按题型重写
+- 表格解释器按题型分流
+- 回归样本集固定化（`689/690/691/693/695`）
+- 发布后验收扩展到更多线上字段
+
+### Owner 与四周计划（新增）
+
+以下 owner 先按职责写，评审后再替换成具体人名：
+
+| 任务 | Owner 角色 | 输出物 |
+| --- | --- | --- |
+| 决策器与 schema | 内容生成负责人 | 统一 contract、模式决策实现 |
+| 页面模式与组件渲染 | 前端负责人 | short/full 统一渲染与 metadata 同步 |
+| fallback 重构 | 内容系统负责人 | 三套 fallback copy 和分流逻辑 |
+| 质检与发布验收 | 发布链路负责人 | 结构/文风/答案逻辑/页面状态验收 |
+
+#### 第 1 周
+
+- 决策器表落代码
+- contract 字段统一
+- 去掉 short mode 内部状态文案
+
+#### 第 2 周
+
+- before/after phrase short 模板
+- obvious category short 模板
+- FAQ / 表格按题型分流第一版
+
+#### 第 3 周
+
+- 回退状态机统一
+- 发布前后验收接入 schema 和页面模式检查
+- 固定回归样本跑通
+
+#### 第 4 周
+
+- 调整 deep/standard 文风
+- 清理残留旧模板句
+- 形成评审后的正式上线标准
+
+### 旧页面迁移与兼容（新增）
+
+迁移原则：
+
+- 旧页面不要求一次性全部重生成
+- 但新旧 contract 必须允许一段过渡期内并存
+- 迁移期间页面渲染优先级必须固定，不能因为字段缺失回退到旧模板拼装
+
+迁移分 3 步：
+
+1. `兼容期`
+   - 旧 JSON 允许保留 `fullAnalysis / solutionNarrative`
+   - 页面渲染优先读取 `articleBlocks`
+2. `回填期`
+   - 优先回填：
+     - 固定回归样本集
+     - 最近 30 天高流量页面
+     - 被质检脚本标红的旧页面
+3. `收口期`
+   - 停止在新页面里写入 `fullAnalysis` 作为正文主来源
+   - 旧字段只作为历史兼容，不再参与新渲染和新验收
+
+迁移验收要求：
+
+- 发布脚本必须能区分：
+  - 旧 contract 页面
+  - 新 contract 页面
+- 不允许因为旧页面尚未回填，就让新页面降级回旧逻辑
+- 回归集中的页面在切新 contract 后，必须全部通过 `validate:data` 和线上 HTML 验收
+
+---
+
+## 十二、我建议先做哪三刀
+
+如果只做最值钱的三件事，按顺序应该是：
+
+1. `short mode 产品化`
+   - 去掉内部状态
+   - 统一页头和正文口径
+   - 不再像占位页
+
+2. `before/after phrase 题单独短版模板`
+   - 重点解决 `695` 这种题
+   - 表格和 FAQ 不再重复
+
+3. `题型 + 难度分流`
+   - obvious 题不再强写 turning point
+   - 正文模式跟题目真实复杂度匹配
+
+---
+
+## 十三、衡量指标与数据埋点（新增）
+
+### 为什么必须补这一节
+
+当前 PRD 已经说明了：
+
+- 为什么要改
+- 改成什么样
+- 先做哪几刀
+
+但还缺一个评审时一定会被问的问题：
+
+- 上线之后，怎么证明这次重构真的比旧链路更好？
+
+### North Star（核心指标）
+
+详情页系统重构后，以以下两个指标作为核心衡量：
+
+1. `详情页平均停留时长`
+2. `生成内容一次通过率`
+
+解释：
+
+- 停留时长代表用户是否真的在读
+- 一次通过率代表系统是否真的变稳，而不是每天靠人工救火
+
+### 质量指标
+
+| 指标 | 定义 | 目标 |
+| --- | --- | --- |
+| AI 一次通过率 | 不触发 fallback 的正式详情页比例 | `> 90%` |
+| obvious 题 short 通过率 | obvious 题直接用 short mode 成功上线的比例 | `> 95%` |
+| 错答案拦截率 | 被答案逻辑质检拦下的错误方向稿件占比 | `100% 拦截` |
+| 旧模板句残留数 | 上线页面中命中旧模板句的数量 | `0` |
+| 正文/metadata 一致率 | 正文模式与 metadata 模式完全一致的页面比例 | `100%` |
+
+### 体验指标
+
+| 指标 | 含义 | 观察窗口 |
+| --- | --- | --- |
+| 页面平均停留时长 | 用户是否愿意继续往下读 | 上线后 7 天 |
+| 跳出率 | 用户是否点进来立刻离开 | 上线后 7 天 |
+| Share Rate（分享率） | 用户是否愿意分享详情页 | 上线后 14 天 |
+
+### 运维指标
+
+| 指标 | 含义 |
+| --- | --- |
+| 生成耗时 | full / short 生成链平均耗时 |
+| 超时率 | 大模型请求超时比例 |
+| fallback 触发率 | 被迫降级到 quick/live 的比例 |
+| 发布后验收失败率 | 部署成功但线上页面未通过验收的比例 |
+
+### 告警阈值与响应机制（新增）
+
+| 指标 | 告警阈值 | 默认动作 | Owner |
+| --- | --- | --- | --- |
+| AI 一次通过率 | 连续 2 天 `< 80%` | 提高 short mode 优先级，检查 prompt 最近变更 | 内容生成负责人 |
+| fallback 触发率 | 单日 `> 40%` | 检查模型稳定性与质检门槛 | 发布链路负责人 |
+| 发布后验收失败率 | 单日 `>= 1` 次 | 阻断后续发布，优先修复 | 发布链路负责人 |
+| 错答案拦截失败 | 任意一次漏拦 | 视为 P0 事故 | 内容系统负责人 |
+| metadata / 正文不一致 | 任意一次命中 | 视为 P1 事故 | 前端负责人 |
+
+SLA（响应时限）：
+
+- `P0`：30 分钟内确认并进入修复
+- `P1`：2 小时内确认并给出临时止血方案
+- `P2`：1 个工作日内纳入排期
+
+### 数据埋点要求
+
+- 每篇详情页必须记录：
+  - `pageMode`
+  - `bodyMode`
+  - `questionType`
+  - `difficulty`
+  - 是否触发 fallback
+  - 是否命中答案逻辑质检
+  - 发布后线上验收是否通过
+- 这些字段必须能在后台汇总成日报或周报
+
+---
+
+## 十四、SEO 与缓存风险控制（新增）
+
+### 为什么这是风险点
+
+我们这几天已经真实遇到过：
+
+- 正文已经是 short mode
+- metadata 还是 full mode
+- 线上页面更新了，但浏览器或缓存层还展示旧内容
+
+这说明 SEO 和缓存不是补充问题，而是页面模式重构的主风险之一。
+
+### 原则
+
+- short mode 和 full mode 都是正式页面模式
+- 搜索引擎看到的 title/description 必须和页面真实模式一致
+- 不允许出现“正文是 short，SEO 还是 full walkthrough”的状态打架
+
+### TDK（标题/描述/关键词）规则
+
+- `live_card`
+  - 使用极简标题和说明
+  - 不宣称“完整分析”
+- `quick_guide`
+  - 明确使用 `Quick Guide / Compact Guide` 口径
+  - description 必须是短版说明，不写 `full walkthrough included`
+- `full_analysis`
+  - 才允许使用 `Answer & Full Analysis / Full Walkthrough` 口径
+
+### 缓存策略要求
+
+- 页面升级为 `full_analysis` 后，发布后自动验收必须重新抓线上 HTML
+- 验收对象必须包含：
+  - 正文首段
+  - metadata description
+  - OG/Twitter description
+- 如果线上仍返回旧模式文案，发布脚本应继续等待，直到超时或验收通过
+
+### 搜索引擎抓取策略
+
+- short mode 页面允许被抓取，但必须是“真实短版页”，不能是失败占位页
+- full mode 上线后，应触发重新验收，确保搜索引擎抓到的是最终模式文案
+- 不建议默认使用 `503 Service Unavailable` 作为 short mode 的常规策略
+  - short mode 是正式产品模式，不是错误页
+  - 重点是保证模式一致，而不是把 short mode 伪装成临时错误状态
+
+### 缓存与浏览器验收口径
+
+- 发布后脚本验收通过，才算发布成功
+- 人工查看页面时，默认用以下方式避开本地缓存误判：
+  - 强制刷新
+  - 无痕窗口
+  - 带随机参数 URL
+
+---
+
+## 十五、AI 工作流要求（新增附录）
+
+### 原则
+
+- 不是让模型“自由发挥一篇详情页”
+- 而是先决定题型和难度，再让模型走对应内容链
+- 负向规则（禁止词）只能做补充，不能代替正向示例
+
+### 推荐工作流
+
+1. `题型分类`
+   - 输出 `questionType`
+   - 输出 `difficulty`
+2. `模式决策`
+   - 产出 `pageMode`
+   - 产出 `bodyMode`
+3. `正文生成`
+   - short / standard / deep 走不同 prompt
+4. `结构化区块生成`
+   - table
+   - FAQ
+   - lessons
+5. `多层质检`
+   - 结构
+   - 文风
+   - 答案逻辑
+   - 页面状态
+
+### Prompt 设计要求
+
+- 每种 `questionType + bodyMode` 至少有一套专用 prompt
+- prompt 不能只靠“不要这样写”
+- 必须给模型正向示例（good examples）和反例（bad examples）
+
+### Few-shot（少量示例教学）要求
+
+至少建立以下示例库：
+
+- `before/after phrase + short`
+- `obvious category + short`
+- `medium category + standard`
+- `hard misdirection + deep`
+
+每个示例库至少包含：
+
+- 1 个好例子
+- 1 个坏例子
+- 为什么坏
+- 这一类题最容易翻车的点
+
+### Few-shot 示例库治理（新增）
+
+- 初版 owner：内容系统负责人
+- 审核 owner：内容生成负责人 + 产品负责人
+- 每次 prompt 主版本升级时，必须同步检查 few-shot 是否仍匹配当前文风标准
+- 示例库必须有版本号，并与 prompt 版本绑定记录
+- 任意一次线上事故页面，如果被判定为“本可由示例库避免”，必须在下一轮回顾中补进示例库
+
+### 生成策略
+
+- `short` 不强写 turning clue
+- `obvious` 题允许没有误判
+- `deep` 才允许完整 solve story（解题复盘）
+- 表格和 FAQ 也必须走题型模板，不允许复用通用老模板
+
+### 边界情况处理
+
+- 如果 LLM API（大模型接口）完全不可用：
+  - `live_card` 必须可纯本地兜底
+- 如果 full 失败但 short 可用：
+  - 正式降级为 `quick_guide`
+- 如果答案逻辑质检失败：
+  - 不发布 AI 稿
+  - 回退到更稳的 fallback
+  - 并记录失败原因，供后续回归样本使用
+
+### 评审时需要拍板的技术口径
+
+- 页面模式是在后台生成/落库阶段确定，还是在请求时临时计算
+- 示例库由谁维护
+- fallback 是否和正式内容共用同一套 contract
+- obvious 题是否允许完全没有 turning point
+
+---
+
+## 附：本次 PRD 依据
+
+本 PRD 依据以下真实问题和已确认事实整理：
+
+- `#690` 正文像旧模板说明文
+- `#691` 曾出现答案方向写窄
+- `#693` obvious 题被硬写成长文复盘
+- `#694` 出现 short mode 合理但通知/校验误导
+- `#695` 当前 short mode 页面像系统帮助卡，不像内容页
+- 对手详情页的共性：文章优先、按题型/难度切模式、不暴露内部状态、表格和 FAQ 真正补价值

--- a/docs/pinpoint-detail-rebuild-prd-2026-03-27.md
+++ b/docs/pinpoint-detail-rebuild-prd-2026-03-27.md
@@ -1,0 +1,759 @@
+# Pinpoint 详情页重构详细 PRD（2026-03-27）
+
+## 受众与假设
+
+本文默认面向产品、工程、内容和 SEO 一起评审。目标不是讨论某一段文案怎么改，而是统一详情页的产品口径、生成链路和发布规则。
+
+## 一句话结论
+
+要避免详情页继续出现“短版抢跑、正文像模板、页面像答案工具页”的问题，我们需要同时做三件事：
+
+- 把公开站点收敛成单一正式内容源，只让正式全文或保底全文上线
+- 把生成 schema 从“页面填空字段”改成“解题证据链字段”
+- 把详情页改成正文优先、解释优先、相关串联优先
+
+如果只允许做一件事，先做第一件：公开站点只认 `registry.json + detail JSON`，不再让 live fallback 抢跑。
+
+---
+
+## 与 03-26 PRD 的关系
+
+本文不是对 `docs/pinpoint-detail-generation-prd-2026-03-26.md` 的平行补充，而是它的后续收敛版。两份文档的关系分为三类：
+
+- `继续沿用`：03-26 中关于“正式发布不要依赖运行时临场拼稿”“题型分流是必要的”“`articleBlocks` 不能再和历史字段长期双轨”的方向继续保留
+- `明确替代`：03-27 用更强的发布状态机、证据链 schema 和单轨公开口径，替代 03-26 里偏页面模式导向的部分设计
+- `历史兼容`：03-26 中已进入代码或数据层的字段，不会在首轮上线中强制消失，但不再作为 v2 的长期主字段
+
+为避免评审时把两份文档混读，出现“到底哪个字段还算真相源”的争议，以下概念以 03-27 为最终口径：
+
+| 03-26 概念 | 03-27 口径 | 处理方式 |
+| --- | --- | --- |
+| `pageMode` (`live_card / quick_guide / full_analysis`) | `detailState` + feature flag + 页面结构 | `pageMode` 不再作为 v2 主字段；发布状态由 `detailState` 表达，页面差异由渲染层和 flag 控制 |
+| `bodyMode` (`short / standard / deep`) | `difficultyBand` 驱动内容深度，`detailMode` 仅做兼容 | `bodyMode` 不作为 03-27 主字段继续扩展；历史值可在迁移期参与兼容渲染 |
+| `difficulty` | `difficultyBand` | 视为字段改名并收敛语义；历史 `difficultyLevel / difficulty` 在迁移期映射到 `difficultyBand` |
+| `questionType` 的旧枚举 | `phrase / category / association / hybrid` | 旧枚举作为迁移来源，新枚举作为 v2 正式枚举；映射规则需在 Phase 2 前拍板 |
+| `articleBlocks` 作为正文唯一主来源 | `articleBlocks` 降级为派生渲染字段 | v2 中真实源字段是 `solvePath / turningPoint / clueRows / faqItems`，`articleBlocks` 由这些字段组装得到 |
+| `live_card -> quick_guide -> full_analysis` 模式升级链 | `draft / generating / validated / publishing_placeholder / fallback_full / published / failed` | 03-27 以后只讨论发布状态链，不再用页面模式描述公开状态 |
+
+迁移原则：
+
+- 若 03-26 与 03-27 出现术语冲突，以 03-27 为准
+- 若历史代码已使用 03-26 字段名，则在 Phase 2 前允许兼容读取，但不继续扩大写入面
+- 所有替代关系都以“发布口径先统一，字段再迁移”为顺序执行
+
+---
+
+## 一、背景
+
+过去几天的详情页优化已经修掉了一批硬伤，比如 FAQ 可见内容和结构化数据不一致、phrase fallback 方向写反、正文数据源错位等问题；但更底层的问题还在：
+
+- 同一题上线早期，公开站点仍可能先暴露 `detailMode: "short"` 的临时详情页
+- 正式全文虽然能发布，但生成方式仍然偏向“统一壳子换词”
+- 页面结构更像“答案工具页”，不是“高价值解析页”
+
+这三件事叠加后，结果不是“站坏了”，而是：
+
+- 用户能看到内容，但第一眼不够像完整解析
+- 搜索引擎能抓到页面，但不容易持续把它当高价值页放大
+- 团队会反复遇到“今天这页可用，但为什么还是不强”的问题
+
+当前相关实现和文档主要分散在这些文件里：
+
+- `lib/puzzle-generation.ts`
+- `lib/puzzles/slot-contract.ts`
+- `lib/puzzles/content-contract.ts`
+- `lib/puzzles/fallback-copy.ts`
+- `lib/puzzles/data.ts`
+- `worker/src/index.ts`
+- `components/detail/PuzzleDetail.tsx`
+- `components/detail/PuzzleFullAnalysis.tsx`
+- `app/(detail)/linkedin-pinpoint-answers/[slug]/page.tsx`
+- `docs/pinpoint-detail-generation-prd-2026-03-26.md`
+- `docs/pinpoint-content-generation-best-practice-2026-03-17.md`
+
+---
+
+## 二、问题定义
+
+### 1. 公开站点存在两条内容源，短版会抢跑
+
+当前正式内容源是 `data/puzzles/registry.json` 和 `data/puzzles/{slug}.json`，但公开查询仍允许回退到 Worker live 数据，进而拼出 `detailMode: "short"`、`detailSource: "fallback"` 的临时详情页，见 `lib/puzzles/data.ts`。  
+这意味着首页、当天页、详情页、summary、sitemap 不一定同时看到同一份内容。
+
+### 2. 生成系统缺少“证据链”，只能靠模板补齐
+
+当前 schema 更像组件字段集合，而不是解题过程记录。`lib/puzzles/slot-contract.ts` 要求 hero、connector、turning point、false starts、clue details 等字段，但没有强制记录：
+
+- 最初误判是什么
+- 误判为什么看起来合理
+- 哪条 clue 打破了误判
+- 每条 clue 的非显然解释是什么
+- FAQ 分别回答了哪类搜索意图
+
+结果是 `lib/puzzle-generation.ts` 只能继续统一拼接 `overview`、`solutionEmergence`、`articleBlocks`、`lessons`、`faqs`。页面看起来完整，但不同题之间很容易只剩“换词差异”。
+
+### 3. 质量闸门更擅长拦脏词，不擅长拦空信息
+
+当前 `scripts/validate-data.mjs`、`lib/puzzles/content-contract.ts`、`lib/puzzles/semantic-lint.ts` 主要拦的是旧模板短语、字数不足、答案过度重复、HTML 残留、通用 pivot 等问题。  
+这能防止明显坏稿上线，但还防不住“格式全对、信息很空”的稿子。
+
+### 4. 页面信息架构更像答案展示页，不像解析页
+
+`components/detail/PuzzleDetail.tsx` 和 `components/detail/PuzzleFullAnalysis.tsx` 目前仍然把不少交互和辅助模块放在正文前。用户和搜索引擎最需要的“答案为什么成立、关键转折 clue 是什么、为什么不是别的答案”没有在首屏正文立住。
+
+### 5. 内链过于通用，详情页缺少主题集群关系
+
+当前详情页主要依赖 recent list 和前后页导航，缺少“同题型”“同套路”“同样靠转折 clue 才解开”的上下文内链。  
+这会让页面更像单条记录，而不是一个主题网络里的节点。
+
+---
+
+## 三、目标
+
+### 业务目标
+
+- 每天都能稳定上线完整详情页
+- 当天页首次可见时就是正式全文或保底全文
+- 详情页从“可用”提升到“有持续权重潜力”
+
+### 用户目标
+
+- 用户进入页面后，30 秒内就能看到答案、关键转折和逐 clue 解释
+- obvious 题不再被硬写成复杂复盘
+- 中等题和复杂题读起来像真人在讲解，而不是系统在解释
+
+### SEO 目标
+
+- 新详情页的索引口径统一，不再出现短版和正式页并行
+- 页面可见内容与 `Article`、`FAQPage` 等结构化数据真实对齐
+- 每篇至少提供 2 到 3 个 clue-specific 的长尾搜索价值点
+
+### 工程目标
+
+- 公开站点只读单一正式内容源
+- 生成链路以结构化证据链为中心，而不是以共享模板补全为中心
+- 发布前质检既能拦坏稿，也能拦“看起来合格、其实没新信息”的空稿
+
+---
+
+## 四、非目标
+
+- 本次 PRD 不要求大改整体视觉设计
+- 不以“每篇都写成顶级专栏”为目标
+- 不优先解决多语言扩展
+- 不把更多 schema 类型堆上页面当成主要方案
+
+### 上线切分与边界
+
+本 PRD 的 Phase 0/1 目标不是提升内容质量，而是先消除公开口径分裂；Phase 2/3 才负责提升正文独特性和 SEO 价值。
+
+为避免评审时把所有改造打包成一次性大改，本方案按上线边界拆成四层：
+
+- `P0，必须一起上线`：关闭公开 live fallback、明确发布状态机、把 `short mode` 首发判为失败、统一 summary/sitemap/detail 的正式口径
+- `P1，可在 P0 稳定后上线`：引入 schema v2 字段、建立新旧字段兼容渲染、把 fallback 收敛为 `fallback_full`
+- `P2，可独立上线`：正文前移、交互后移、`HowTo` 口径收紧、相关题模块替换 recent list
+- `P3，持续收紧`：重复度 guardrail、clue-specific FAQ 规则、相关题供数优化、质量阈值调参
+
+评审和排期时默认遵循以下规则：
+
+- `P0` 是当前 PRD 的阻塞项，没有 `P0` 就不进入内容质量讨论
+- `P1` 可以与 `P2` 并行开发，但不得先于 `P0` 上线
+- `P2/P3` 的失败不应回滚 `P0` 的单轨发布原则
+- 历史页迁移不阻塞 `P0/P1`，默认先兼容渲染，再择机回填
+
+---
+
+## 五、核心产品原则
+
+### 1. 正式全文优先于任何“先可见”
+
+公开站点第一次展示给用户和搜索引擎的内容，必须是正式全文或保底全文，不允许短版临时页先上线、再被正式稿覆盖。
+
+### 2. 固定结构，差异内容
+
+可以保留稳定页面壳子，但正文证据必须按题目变化。统一的是阅读节奏，不是句子库。
+
+### 3. 页面字段必须对应真实解题证据
+
+以后 schema 中每个高价值字段都应该能回答一个真实问题，例如：
+
+- 我为什么一开始会猜错
+- 哪条 clue 让方向收窄
+- 每条 clue 为什么不是泛泛“属于同一类”
+- 用户真正还会继续搜什么
+
+### 4. 质量门槛从“格式对”升级到“信息新”
+
+未来不过线的标准不仅是错、脏、重复，还包括“没有独特解释价值”。
+
+### 5. 公开内容源只能有一个
+
+`registry.json + detail JSON` 是唯一公开真相源。Worker live 数据只保留给后台预览、监控和排障。
+
+---
+
+## 六、方案概览
+
+### 方案 A：发布链路收敛为单轨
+
+目标是让公开链路只剩这一个顺序：
+
+1. 抓到当天题目
+2. 生成正式全文草稿
+3. 执行质量闸门
+4. 不过线时自动重生一次
+5. 再不过线时生成模板保底全文
+6. 一次性写入 `data/puzzles/{slug}.json` 和 `data/puzzles/registry.json`
+7. Git 提交成功后再调用 revalidate
+8. 页面、summary、sitemap 同步可见
+
+对应改造重点：
+
+- `lib/puzzles/data.ts` 的公开查询默认关闭 `allowLiveWorkerFallback`
+- `worker/src/index.ts` 不再让 `quickPublishToSite()` 成为公开页面的前置轨道
+- `app/api/revalidate/route.ts` 只负责刷新正式内容，不再放大 live fallback
+
+### 方案 B：生成 schema 升级为“证据链 schema”
+
+建议新增或重构为以下核心字段组：
+
+- `solvePath`
+  - `firstRead`
+  - `falseStarts`
+  - `whyFalseStartPlausible`
+  - `breakingClue`
+  - `pivot`
+  - `fullBoardConfirmation`
+- `turningPoint`
+  - `clue`
+  - `whyDecisive`
+  - `whatChangedAfterIt`
+- `clueRows`
+  - `clue`
+  - `surfaceMisread`
+  - `resolvedPhraseOrMember`
+  - `nonObviousWhy`
+  - `searchableContext`
+- `faqItems`
+  - `intentType`
+  - `question`
+  - `answer`
+  - `tiedClue`
+- `uniquenessSignals`
+  - `angle`
+  - `relatedEntities`
+  - `doNotRepeatPatterns`
+
+这会把当前“页面字段”转成“解题证据字段”，让程序更像渲染器，而不是代写器。
+
+### 方案 C：页面改成正文优先
+
+目标页面结构建议固定为：
+
+1. `H1 + 发布信息 + 80-120 词直接回答导语`
+2. `How the pattern emerges`
+3. `Turning clue`
+4. `Why each clue fits`
+5. `Why this answer and not others`
+6. `FAQ`
+7. `相关题 / 前后题`
+8. `share / check-in / 次要 CTA`
+
+原则是把“解释”放到“交互”前面，把“正文”放到“壳子”前面。
+
+### 方案 D：上下文内链替代泛 recent list
+
+详情页底部的内链建议改成三组：
+
+- 同题型：before/after、phrase、broad category
+- 同解法：靠某条转折 clue 才锁定答案
+- 相邻日期：上一题 / 下一题
+
+同时补齐旧单数路径 `/linkedin-pinpoint-answer/:slug` 到当前 canonical 路径的 301。
+
+---
+
+## 七、详细需求
+
+### 7.1 内容源与发布规则
+
+- 公开站点默认不允许 live fallback 参与内容决策
+- 公开详情页只在正式全文或保底全文准备好后上线
+- 如果当天题尚未生成正式内容，允许短暂 publishing 占位态，但该状态不得进入 sitemap，不得作为正式页返回
+- `scripts/release-production.mjs` 需把“当天页仍为 short mode”判为失败，而不是可接受状态
+
+补充规则：
+
+- 在 `published` 或 `fallback_full` 之前，正式详情页 slug 必须保持不可发现、不可索引：返回 `404`，且不得在首页、related、前后题、summary 或其他公开模块暴露 href
+- `/pinpoint/today` 如进入 `publishing_placeholder`，默认返回 `503 Service Unavailable`，并携带 `Retry-After`
+- 如因框架或基础设施限制暂时无法返回 `503`，只允许采用临时 `200 + noindex` 兜底，但必须同时满足 `no-store`、不暴露新 slug 链接、且不得作为默认长期方案
+
+### 7.2 生成器规则
+
+- 程序不再默认自动写整段 lessons 和 FAQ
+- 程序保留排版职责：字段顺序、段落位置、显示层统一
+- 模型或上游生成器负责交付证据链字段
+- `fallback-copy.ts` 仅作为最后兜底，且兜底目标是“保底全文”，不是“公开短版”
+- `Phase 2` 默认采用“两段式生成 + repair pass”，不要求单次大 JSON 调用一次性产出完全合格结果
+
+补充决策：
+
+- `difficultyBand` 首版采用“规则预判 + 模型建议 + 校验层收敛”的双阶段判定，不由单一来源直接拍板
+- 模型可以回传 `suggestedDifficultyBand` 作为建议值；Worker 规则层先给出 `preliminaryDifficultyBand`，再由校验层完成最终收敛
+- 当规则层与模型建议冲突且均无高置信时，默认落到 `medium`，并记录 `warning` 供人工抽检
+- `questionType` 必须在正文生成前确定；`difficultyBand` 必须在正文生成前存在预判值，并在质检前收敛为正式值
+
+推荐的生成顺序：
+
+1. 先生成 `solvePath / turningPoint / clueRows`
+2. 运行一次 schema 与语义初检
+3. 再基于通过初检的中间结果生成 `faqItems / summary / derived articleBlocks`
+4. 若发生局部结构错误，优先触发 repair pass，而不是整篇重写
+
+### 7.2.1 `fallback_full` 最低公开标准
+
+`fallback_full` 是可公开、可索引状态，因此它必须满足独立于 `published` 的最低内容标准，不能退化为换名字的 `short mode`。
+
+最低标准如下：
+
+- 必须包含完整 `clueRows`，且行数与 clue 数一致
+- 必须包含至少 `2` 段可见正文，其中一段解释答案为什么成立，一段解释全盘如何收束
+- 必须包含 `3` 条可见 FAQ，且至少 `1` 条绑定具体 clue 或题目实体
+- 不允许出现“formal long-form JSON is unavailable”或同类临时占位话术
+- 必须生成可公开的 title、description、canonical 和可见首屏导语
+- 若不满足以上任一项，则不得进入 `fallback_full`，应继续停留在 `generating` 或转入 `failed`
+
+补充说明：
+
+- `fallback_full` 允许使用轻量 LLM、规则模板或修复链路生成，但它仍然属于“可公开完整页”，不是纯系统灾备页
+- 当外部依赖严重故障，导致 `fallback_full` 也无法稳定生成时，系统不得硬凑 `fallback_full`
+
+### 7.2.2 `emergency_minimal` 灾备模式
+
+为防止极端情况下连续停更，系统保留最高级别的人工灾备开关 `emergency_minimal`，但该模式不属于默认发布路径。
+
+触发条件：
+
+- 正式全文、repair pass、`fallback_full` 均连续失败，且超过重试预算
+- GitHub、部署平台或主 LLM 供应商出现跨小时级别故障
+- 由人工明确开启 break-glass 开关，并记录原因、开启时间和计划关闭时间
+
+最低要求：
+
+- 页面不得白屏，必须有题号、日期、clues、答案和最小解释
+- 页面明确标记为临时灾备模式，不输出正常的深度解析承诺
+- 不得替代 `fallback_full` 成为常规日更通道
+- 故障解除后必须优先恢复到 `fallback_full` 或 `published`
+
+### 7.3 内容质量规则
+
+新增至少以下硬性规则：
+
+- turning point 必须点名具体 clue，不接受空泛转折句
+- 每条 clue 解释都必须包含该 clue 的专属语义或实体信息
+- FAQ 至少 2 条绑定具体 clue 名词或题目实体
+- 与最近 30 篇相比，lesson 标题和 FAQ 问法不得高度重复
+- false start 不能是通用桶词，例如“some category of things”
+
+质检后果必须分级，而不是统一叫“不过线”：
+
+| 等级 | 典型问题 | 处理方式 |
+| --- | --- | --- |
+| `hard fail` | `turningPoint` 缺失但题型为 `medium / hard`；`clueRows` 行数不等于 clue 数；`fallback_full` 低于最低公开标准；答案被缩窄或写错 | 阻塞发布；自动重生 1 次；再次失败则转 `fallback_full` 或 `failed` |
+| `soft fail` | 某条 clue 解释过泛；FAQ clue 绑定数量不足；重复度超过预警阈值但未达到禁止阈值 | 不立即阻塞；优先触发自动重生；若连续两次 soft fail 叠加则升级为 `hard fail` |
+| `warning` | 风格偏平、实体上下文偏弱、`difficultyBand` 规则判定置信度低 | 允许发布，但写入审计日志，进入每日抽检列表 |
+
+### 7.4 页面结构规则
+
+- 首屏必须先回答“答案是什么、为什么成立、关键转折是什么”
+- reveal 卡、share、check-in 不能压过正文首屏
+- clue table 是正文证据区，不是正文替代品
+- `HowTo` 只在页面存在清晰步骤区时输出
+- `FAQPage` 只输出可见 FAQ
+
+### 7.5 SEO 与 URL 规则
+
+- canonical 只保留 `/linkedin-pinpoint-answers/[slug]/`
+- 补齐旧路径到 canonical 的永久跳转
+- `app/sitemap.ts` 继续只吃正式内容源
+- 结构化数据遵循“页面可见内容支撑 schema”，不以类型数量为目标
+
+### 7.6 发布状态机与公开口径
+
+为避免不同系统对“当天页是否已发布”理解不一致，公开链路统一使用下表作为状态机定义：
+
+| 状态 | 数据源 | 公开行为 | 索引 / sitemap | summary | revalidate | 允许转移 |
+| --- | --- | --- | --- | --- | --- | --- |
+| `draft` | 抓题结果，仅内部可见 | 公开站点不暴露新 slug；`/pinpoint/today` 继续显示上一题 | 不索引，不进 sitemap | 保持上一题 | 否 | `generating` / `failed` |
+| `generating` | 生成中的草稿与质检中间态 | 与 `draft` 相同；不返回新题正式页 | 不索引，不进 sitemap | 保持上一题 | 否 | `validated` / `fallback_full` / `failed` |
+| `validated` | 已通过质检但尚未提交的正式全文 | 仅内部预览可见；公开站点仍不切题 | 不索引，不进 sitemap | 保持上一题 | 否 | `published` / `failed` |
+| `publishing_placeholder` | 仅用于 `/pinpoint/today` 的短暂占位态 | `/pinpoint/today` 默认返回 `503 + Retry-After` 的占位响应；未来 slug 仍返回 `404` | 不索引，不进 sitemap | 保持上一题 | 否 | `published` / `fallback_full` / `failed` |
+| `fallback_full` | 已提交仓库的保底全文 | 新题详情页返回 `200`，允许 canonical；正文为保底全文，不是短版 | 可索引，可进 sitemap | 展示新题 | 是 | `published` / `failed` |
+| `published` | 已提交仓库的正式全文 | 新题详情页返回 `200`，公开站点全面切题 | 可索引，可进 sitemap | 展示新题 | 是 | `failed` |
+| `failed` | 生成、提交或部署失败 | 保持上一题公开状态；不暴露失败中的新题页 | 不索引，不进 sitemap | 保持上一题 | 仅对上一题 | 人工恢复到 `draft` 或 `generating` |
+
+补充规则：
+
+- 公开详情页不允许以 `detailMode: "short"` 作为首发状态
+- `publishing_placeholder` 只允许出现在 `/pinpoint/today`，不允许出现在正式详情页 slug
+- `fallback_full` 属于可公开状态，`short mode` 不属于可公开状态
+- 一旦进入 `published` 或 `fallback_full`，`registry`、detail JSON、summary、sitemap 必须在同一发布轮次内对齐
+
+`publishing_placeholder` 的页面表现也需要固定，避免前端自行发挥：
+
+- 页面默认返回 `503 + Retry-After`
+- 可显示“今天的正式解析正在发布，几分钟后刷新查看”这一类中性提示
+- 不展示上一题正文，不复用上一题答案卡，不展示 clue table、FAQ、share 模块
+- 如果当天题号已知，可显示日期和题号；如果未知，只显示中性发布提示
+- 响应必须使用 `no-store` 或等价的禁缓存策略，避免占位态被 CDN 或 Next.js 缓存固化
+
+### 7.7 状态转移触发器
+
+状态机不仅定义“能转去哪”，还需要定义“由谁触发、以什么为准”：
+
+| 转移 | 触发系统 | 进入条件 | 退出条件 |
+| --- | --- | --- | --- |
+| `draft -> generating` | Worker | 当天 clues 与答案抓取成功，生成任务已创建 | 进入质检或生成失败 |
+| `generating -> validated` | 生成器 + 质检脚本 | schema v2 校验通过，`hard fail = 0` | 等待提交仓库 |
+| `generating -> fallback_full` | 生成器 | 正式全文生成失败或超时达到重试上限，且 `fallback_full` 自身通过最低公开标准 | 等待提交仓库 |
+| `generating -> failed` | Worker | 正式全文与 `fallback_full` 均未通过最低要求，或外部依赖故障超出重试预算 | 人工恢复或下一轮任务 |
+| `validated -> publishing_placeholder` | 发布链路 | 达到对外发布时间窗口，但 Git 提交或部署尚未完成 | Git 提交成功后进入 `published`，或 fallback 提交成功后进入 `fallback_full` |
+| `validated -> published` | GitHub 提交 + revalidate | detail JSON、registry 提交成功，且发布后检查通过 | 正常运行或故障转 `failed` |
+| `fallback_full -> published` | 内容修复链路 | 后续正式全文补齐并通过质检，再次提交仓库成功 | 正常运行或故障转 `failed` |
+| `published -> failed` | 监控 / 发布脚本 | 发布后检查发现正式页缺失、summary/sitemap 口径错位、关键页面返回异常 | 人工恢复或回滚 |
+
+补充说明：
+
+- `generating -> validated` 与 `validated -> published` 均为自动转移，不要求人工确认
+- 是否触发 `publishing_placeholder` 由发布时间窗口和提交进度共同决定，不作为默认路径
+- `fallback_full -> published` 是允许的升级路径，但不是必须路径
+
+### 7.8 可观测性与告警
+
+状态机、降级路径和发布脚本只有在“异常能被及时看见”时才有意义，因此本方案把可观测性视为 `P0/P1` 的配套要求，而不是上线后的附加优化。
+
+最低监控面应覆盖以下四类信号：
+
+| 场景 | 监控项 | 触发条件 | 默认动作 | Owner |
+| --- | --- | --- | --- | --- |
+| 状态停滞 | `draft / generating / validated / publishing_placeholder` 停留时长 | 任一状态停留超过阈值 | 发送告警并标记当前 puzzle 为需人工关注 | 工程 |
+| 连续降级 | `fallback_full` / `emergency_minimal` 触发频率 | 连续多题或多天触发降级 | 通知工程 + 内容，暂停默认信任自动链路 | 工程 / 内容 |
+| 非法转移 | 状态机外转移、跳级转移 | 出现未在 7.7 定义表中的转移 | 立即告警，并拒绝写入正式 registry | 工程 |
+| 发布后异常 | 缓存未清、summary/sitemap 错位、关键页异常 | 发布后检查失败 | 保持旧公开状态或进入人工回滚流程 | 工程 |
+
+建议的初始阈值如下：
+
+- `draft` 停留超过 `5 分钟`
+- `generating` 停留超过 `15 分钟`
+- `validated` 停留超过 `10 分钟`
+- `publishing_placeholder` 停留超过 `5 分钟`
+- `fallback_full` 连续触发 `2` 题或 `2` 天
+- `emergency_minimal` 任意一次触发都必须立即通知人工
+
+日志与事件要求：
+
+- 每次状态转移都必须留下结构化事件，至少包含 `puzzleNumber / slug / fromState / toState / ts / trigger / reason`
+- `hard fail / soft fail / warning` 结果必须进入同一条审计链路，便于按题号追溯
+- 发布后检查必须记录是否成功清理 `registry`、页面 path、`worker-live` 和相关 summary/sitemap 缓存
+
+告警处理原则：
+
+- 告警默认先通知工程 DRI
+- 连续 `fallback_full`、重复度异常、低置信 `difficultyBand` 激增时，同时通知内容 DRI
+- `emergency_minimal` 只能在人工确认后开启；开启和关闭都必须留痕
+- 任何“非法状态转移”都视为 P1 级问题，优先级高于单篇内容质量问题
+
+与验收和回滚的关系：
+
+- 7.8 不是单独系统，它直接支撑第八节的发布验收和第十节的回滚流程
+- 若没有结构化状态事件和停滞告警，`P0` 只能算“功能能跑”，不能算“可稳定上线”
+
+---
+
+## 八、验收标准
+
+### 发布验收（上线当天，阻塞项）
+
+以下项目属于发布阻塞项，未满足则本轮不应视为完成上线：
+
+- 新题首发时，公开详情页 `short mode` 命中率必须为 `0%`
+- `registry.json / detail JSON / summary / sitemap` 这四个口径的同轮一致率必须 `>= 99%`
+- `publishing_placeholder` 不得进入 sitemap，未来 slug 在未发布前必须返回 `404`
+- `FAQPage` 仅在页面存在可见 FAQ 时输出，命中率必须 `100%`
+- `revalidate` 只能刷新正式内容，不得触发公开短版抢跑
+- `publishing_placeholder` 默认返回 `503 + Retry-After`，且发布后缓存清理必须成功
+
+### 内容与页面验收（上线当天，阻塞项）
+
+- obvious 题不得被渲染为“复杂误判 -> 神秘转折 -> 长复盘”的正文结构
+- 每篇新题必须包含完整 `clueRows`，且行数与 clue 数一致
+- 中等和复杂题至少包含 `1` 个明确 turning clue 和 `2` 个 clue-specific FAQ
+- 首屏正文必须在不点击 reveal 的前提下回答“答案是什么、为什么成立、关键转折是什么”
+- clue table 在移动端不得出现致命布局溢出
+
+### 效果验收（4-8 周复盘，不阻塞首发）
+
+- 7 天收录率相较 Phase 0 冻结基线提升 `>= 15%`
+- clue-specific 查询覆盖相较基线提升 `>= 20%`
+- detail-to-detail CTR 相较基线提升 `>= 10%`
+- FAQ rich result 仅在可见 FAQ 存在时出现，异常命中率为 `0`
+- 最近 30 篇中 lesson 标题和 FAQ 问法的高重复样本占比降至 `<= 5%`
+
+### 验收执行方式
+
+为避免验收标准停留在口头层，执行方式固定如下：
+
+- `CI / 本地脚本`：负责 schema 校验、guardrail 分级、`clueRows` 行数、FAQ 可见性与结构化数据对齐检查
+- `release-production` 发布后检查：负责验证 `/pinpoint/today`、正式详情页、summary、sitemap 四口径是否一致，并断言首发 `short mode` 命中率为 `0`
+- `人工 smoke check`：每天抽查当天页首屏、`publishing_placeholder`、移动端 clue table 和 related 模块
+- `周复盘`：SEO 与产品联合检查 7 天收录率、clue-specific 查询覆盖、detail-to-detail CTR
+
+阻塞项默认由脚本和发布检查自动判定；人工检查用于补足“脚本可通过但体验仍差”的情况，不替代阻塞规则。
+
+---
+
+## 九、成功指标
+
+没有现成可信历史数据的指标，不在本 PRD 中虚构数字。`Phase 0` 启动前必须冻结一份基线快照；未冻结的指标不阻塞 `P0` 上线，但必须在 `Phase 1` 结束前补齐。
+
+| 指标 | 当前基线 | 4 周目标 | 8 周目标 | 数据来源 | Owner |
+| --- | --- | --- | --- | --- | --- |
+| 24h 公开口径一致率 | 待冻结 | `>= 95%` | `>= 98%` | 发布日志 + 抽样页面检查 | 工程 |
+| 首发 `short mode` 命中率 | 当前存在，待冻结 | `0%` | `0%` | 发布日志 | 工程 |
+| Publishing Latency P50 | 待冻结 | `<= 5 分钟` | `<= 4 分钟` | 发布日志 | 工程 |
+| Publishing Latency P90 | 待冻结 | `<= 10 分钟` | `<= 8 分钟` | 发布日志 | 工程 |
+| 7 天收录率 | 待冻结 | 基线 `+15%` | 基线 `+25%` | GSC | SEO |
+| clue-specific 查询覆盖 | 待冻结 | 基线 `+20%` | 基线 `+35%` | GSC | SEO |
+| detail-to-detail CTR | 待冻结 | 基线 `+10%` | 基线 `+20%` | 站内埋点 | 产品 / SEO |
+| 高重复 FAQ / lesson 占比 | 待冻结 | `<= 15%` | `<= 5%` | guardrail 审计脚本 | 内容 |
+| 正文滚动深度中位数 | 待冻结 | 基线 `+10%` | 基线 `+15%` | 站内埋点 | 产品 |
+
+---
+
+## 十、实施计划
+
+### DRI 与协作边界
+
+| 模块 | DRI | 协作 | 完成定义 |
+| --- | --- | --- | --- |
+| 发布链路与状态机 | 工程 | 产品 | 公开站点只认正式内容源，`short mode` 首发归零 |
+| 证据链 schema v2 | 产品 / 内容 | 工程 | 新字段 contract、兼容规则、渲染优先级评审通过 |
+| guardrail 与重复度规则 | 内容 | 工程 | hard fail / soft fail / warning 规则落地并可跑 |
+| 页面结构与 related 模块 | 前端工程 | 产品 / SEO | 正文前移上线，相关题模块接入供数 |
+| canonical / redirect / sitemap | SEO | 工程 | 旧路径承接规则上线并通过抽检 |
+| 指标冻结与复盘 | SEO / 产品 | 工程 | 基线快照冻结，4 周和 8 周复盘有人负责 |
+
+### Feature Flag 与回滚原则
+
+为避免一次性大改导致全链路回退，本 PRD 推荐按能力拆 flag，而不是只留一个总开关：
+
+- `detail_public_formal_only`：控制公开路由是否只认正式内容源
+- `detail_schema_v2`：控制渲染层是否优先读取 schema v2 字段
+- `detail_article_first_layout`：控制正文前移的新结构
+- `detail_related_clusters`：控制相关题模块与新供数
+- `detail_emergency_minimal_mode`：控制最高级别灾备降级，仅允许人工开启
+
+统一回滚原则：
+
+- `P0` 回滚时允许恢复上一版正式全文读取逻辑，但不允许恢复公开 `short mode` 首发
+- `schema v2` 若渲染异常，优先回滚渲染优先级，不回滚新字段写入
+- 页面结构或 related 模块出问题时，只回滚对应前端 flag，不影响单轨发布
+- 回滚后必须重新刷 `summary`、sitemap 和受影响页面缓存，避免口径再次分裂
+- `detail_emergency_minimal_mode` 只能在连续失败达到阈值后人工开启，且必须在正式链路恢复后关闭
+
+### Phase 0：冻结错误路径（1 天）
+
+- 关闭公开路由上的 live fallback
+- 把 short mode 首发视为发布失败
+- 保留内部预览和监控，不影响后台排障
+
+### Phase 1：收敛发布链路（1-2 天）
+
+- 调整 Worker 发布顺序
+- 保证正式全文或保底全文先写入仓库，再触发 revalidate
+- 对齐 summary、sitemap、详情页读取逻辑
+
+### Phase 2：重构 schema 与生成器（2-4 天）
+
+- 新增证据链 schema
+- 降低程序自动代写比例
+- 补充 uniqueness guardrails
+
+### Phase 3：改造页面信息架构（2-3 天）
+
+- 调整正文首屏结构
+- 重排 reveal / share / CTA
+- 改造相关题内链模块
+
+### Phase 4：观测与调优（持续 2-4 周）
+
+- 按题型抽查新页
+- 结合 GSC 和页面行为数据复盘
+- 根据重复风险和长尾覆盖继续收紧 guardrails
+
+---
+
+## 十一、风险与缓解
+
+### 风险 1：短期内发布速度变慢
+
+因为短版抢跑被拿掉，早期可能出现更短暂的 publishing 占位态。  
+缓解方式：优先保证保底全文生成链路稳定，而不是恢复短版公开。
+
+### 风险 2：schema 改造过大，牵动多处逻辑
+
+`worker`、`site`、`scripts` 都会受到影响。  
+缓解方式：先加新字段，保留旧字段兼容一段时间，再分阶段下线旧字段。
+
+### 风险 3：质量规则过严导致当天无法发稿
+
+缓解方式：保留“自动重生 1 次 + 保底全文”的双保险，不让“全挂掉”成为风险。
+
+### 风险 4：页面改造后短期指标波动
+
+缓解方式：优先做正文前移和相关题内链，不做大视觉改版，降低同时变化的变量数量。
+
+### 风险 5：状态机与公开返回规则理解不一致
+
+如果 `/pinpoint/today`、未来 slug、summary、sitemap 对 `publishing` 状态理解不同，会再次出现口径分裂。  
+缓解方式：以本 PRD 的状态机表为唯一解释源，并在 `release-production` 检查中加入状态断言。
+
+---
+
+## 十二、依赖与开放问题
+
+### 依赖
+
+- Worker 发布链路调整
+- detail JSON schema 扩展
+- guardrail 脚本补强
+- 详情页组件改造
+- 301 redirect 补齐
+
+### Phase 2 前必须拍板的前置决策
+
+| 决策项 | 拍板人 | 最晚时间 |
+| --- | --- | --- |
+| `questionType` 与 `difficultyBand` 是否拆成两个字段，而不是复用同一个维度 | 产品 DRI + 内容 DRI | `Phase 1` 结束前 |
+| obvious 题是否允许省略 `turningPoint`，以及省略后页面渲染什么替代模块 | 产品 DRI + 前端工程 DRI | `Phase 1` 结束前 |
+| `fallback_full` 是否至少拆为 `phrase / category / obvious / hard` 四类模板 | 内容 DRI + 工程 DRI | `Phase 1` 结束前 |
+| 相关题一版是否先只使用规则供数，而不等待 embedding 或人工标签系统 | 产品 DRI + SEO DRI | `Phase 2` 开始前 |
+
+### 开放问题
+
+- `HowTo` 是否直接下线，改为只保留 `Article + FAQPage + BreadcrumbList`
+- Phase 3 之后是否有必要为历史高流量页面批量回填 schema v2 字段
+- related clusters 的第二版是否引入 embedding 相似度或人工标签
+
+---
+
+## 十三、参考实现与证据
+
+- 发布链路与 live fallback：`lib/puzzles/data.ts`、`worker/src/index.ts`、`app/api/revalidate/route.ts`
+- 生成与质检：`lib/puzzle-generation.ts`、`lib/puzzles/slot-contract.ts`、`lib/puzzles/content-contract.ts`、`lib/puzzles/semantic-lint.ts`
+- 页面结构与 schema：`components/detail/PuzzleDetail.tsx`、`components/detail/PuzzleFullAnalysis.tsx`、`app/(detail)/linkedin-pinpoint-answers/[slug]/page.tsx`
+- 现有文档：`docs/pinpoint-detail-generation-prd-2026-03-26.md`、`docs/pinpoint-content-generation-best-practice-2026-03-17.md`
+
+---
+
+## 附录 A：Schema Contract（v2 草案）
+
+### A.1 设计原则
+
+- `questionType` 负责描述题的结构，不负责描述难度
+- `difficultyBand` 负责描述题的阅读和解释深度，不负责描述题型
+- `detailState` 负责公开发布状态，不再让 `detailMode` 同时承担“页面模式”和“发布状态”两种含义
+- 新字段用于新题写入；旧字段保留历史兼容读取，不要求首轮全量回填
+
+### A.2 推荐字段草案
+
+```json
+{
+  "questionType": "phrase | category | association | hybrid",
+  "difficultyBand": "obvious | medium | hard",
+  "detailState": "draft | generating | validated | publishing_placeholder | fallback_full | published | failed",
+  "detailMode": "full | short",
+  "solvePath": {
+    "firstRead": "string",
+    "falseStarts": ["string"],
+    "whyFalseStartPlausible": ["string"],
+    "breakingClue": "string",
+    "pivot": "string",
+    "fullBoardConfirmation": "string"
+  },
+  "turningPoint": {
+    "clue": "string",
+    "whyDecisive": "string",
+    "whatChangedAfterIt": "string"
+  },
+  "clueRows": [
+    {
+      "clue": "string",
+      "surfaceMisread": "string",
+      "resolvedPhraseOrMember": "string",
+      "nonObviousWhy": "string",
+      "searchableContext": "string"
+    }
+  ],
+  "faqItems": [
+    {
+      "intentType": "definition | clue_background | comparison | solve_strategy | category_context",
+      "question": "string",
+      "answer": "string",
+      "tiedClue": "string | null"
+    }
+  ],
+  "uniquenessSignals": {
+    "angle": "string",
+    "relatedEntities": ["string"],
+    "doNotRepeatPatterns": ["string"]
+  }
+}
+```
+
+### A.3 Required / Optional / Deprecated
+
+| 字段 | 要求 | 说明 |
+| --- | --- | --- |
+| `questionType` | 新题必填 | `Phase 2` 前必须拍板枚举 |
+| `difficultyBand` | 新题必填 | 历史页可由现有 `difficultyLevel` 映射 |
+| `detailState` | 新题必填 | 作为公开状态机唯一状态字段 |
+| `detailMode` | 兼容保留 | 历史页可继续读取；新题不再用它表达发布状态 |
+| `solvePath.firstRead` | 新题必填 | obvious 题也要说明第一眼读法 |
+| `solvePath.falseStarts` | 条件必填 | `medium / hard` 至少提供 `0-2` 条；obvious 题可为空数组 |
+| `solvePath.whyFalseStartPlausible` | 条件必填 | 仅在 `falseStarts` 非空时必填，长度需与之对应 |
+| `solvePath.breakingClue` | `medium / hard` 必填 | obvious 题可为空 |
+| `turningPoint` | `medium / hard` 必填 | obvious 题允许省略，但页面必须渲染“quick pattern confirmation”替代块 |
+| `clueRows` | 新题必填 | 行数必须等于 clue 数 |
+| `faqItems` | 新题必填 | `3-5` 条，至少 `2` 条 `tiedClue` 非空 |
+| `uniquenessSignals` | 内部必填 | 不要求前端渲染，但用于 guardrail 审计 |
+
+### A.4 渲染优先级与兼容策略
+
+- 新渲染器优先读取 `detailState`、`questionType`、`difficultyBand`、`solvePath`、`turningPoint`、`clueRows`、`faqItems`
+- `articleBlocks` 在 v2 中降级为派生渲染字段：新题由 `solvePath`、`turningPoint`、`clueRows`、`faqItems` 组装得到，用于页面展示和历史兼容，不再作为源字段要求模型直接填写
+- 历史页若缺少新字段，继续回退到现有 `articleBlocks`、`fullAnalysis`、`solutionNarrative`、`display.clueTableRows` 等旧字段
+- `Phase 2` 上线后，新题必须写新字段；历史页默认兼容渲染，不阻塞上线
+- 旧字段是否退场，不在首轮上线中解决；需满足“最近 30 篇已回填 + 14 天零 legacy-only 发布”后再单独评审
+
+### A.4.1 `difficultyBand` 赋值规则
+
+`difficultyBand` 由 Worker 规则层在正文生成前给出预判值，并在生成后由校验层收敛为正式值，作为质检和渲染分流的共同输入。
+
+首版采用“规则预判，模型建议，校验收敛，人工兜底”的顺序：
+
+- 规则层根据 `questionType`、clue 显著性、答案直观性和历史 obvious 样本规则先给出 `preliminaryDifficultyBand`
+- 模型可回传 `suggestedDifficultyBand`，用于补足 false starts 复杂度和叙事深度判断
+- 校验层对 `preliminaryDifficultyBand` 与 `suggestedDifficultyBand` 做收敛；若两者冲突且均无高置信，则正式写入 `medium`
+- 低置信结果必须打 `warning`，进入每日抽检列表
+- 人工只在抽检或回补时覆盖，不进入默认日常链路
+
+### A.5 Related 供数第一版规则
+
+为避免 related 模块阻塞主线，一版供数只用确定性规则：
+
+- 同题型：基于 `questionType`
+- 同难度：基于 `difficultyBand`
+- 相邻日期：基于 `publishDate`
+
+embedding、人工标签和更细的“同解法”关系，放在第二版评审。

--- a/docs/staging-graphql-cookie-recovery-runbook-2026-03-28.md
+++ b/docs/staging-graphql-cookie-recovery-runbook-2026-03-28.md
@@ -1,0 +1,143 @@
+# Staging GraphQL Cookie Recovery Runbook
+
+适用场景：`pinpoint-worker-staging` 或 `pinpoint-worker-shadow` 的 `/admin/preflight-linkedin` 返回 `graphql 401`，但生产 `pinpoint-worker` 的同一预检仍然正常。
+
+一句话判断：这通常不是发布链路坏了，而是演练环境的 `GRAPHQL_COOKIE` 过期了。
+
+## 这份 runbook 解决什么
+
+- 修复 `staging` / `shadow` 的 LinkedIn 直连抓取鉴权
+- 尽量不碰生产配置
+- 尽量不去追 Cloudflare 里读不出来的旧 secret 原值
+
+## 先决条件
+
+- 本机浏览器里当前已登录 LinkedIn
+- 本机可以运行 `npx wrangler`
+- 已拿到 `ADMIN_SECRET`
+
+## 不要先做的事
+
+- 不要先改生产 `pinpoint-worker`
+- 不要先去追 Cloudflare 里旧的 `GRAPHQL_TOKEN` / `GRAPHQL_CSRF_TOKEN` 原值
+- 不要把浏览器 cookie 明文贴到日志、文档或聊天工具里
+
+## 标准修复步骤
+
+### 1. 先确认是演练环境问题，不是上游整体故障
+
+```bash
+export ADMIN_SECRET='<your-admin-secret>'
+
+curl "https://pinpoint-worker.2296744453m.workers.dev/admin/preflight-linkedin?secret=$ADMIN_SECRET&date=2026-03-28"
+curl "https://pinpoint-worker-staging.2296744453m.workers.dev/admin/preflight-linkedin?secret=$ADMIN_SECRET&date=2026-03-28"
+curl "https://pinpoint-worker-shadow.2296744453m.workers.dev/admin/preflight-linkedin?secret=$ADMIN_SECRET&date=2026-03-28"
+```
+
+预期口径：
+
+- 如果生产返回 `ok: true` 且 `source: "graphql"`，而 `staging` / `shadow` 返回 `graphql 401`，优先怀疑演练环境 `GRAPHQL_COOKIE` 过期
+
+### 2. 从本机浏览器提取一份新的 LinkedIn cookie
+
+优先使用当前仍保持登录的浏览器配置。`2026-03-28` 实测里，Edge 配置可直接取到 `li_at` 和 `JSESSIONID`。
+
+```bash
+python3 - <<'PY' >/tmp/linkedin_edge_cookie.txt
+import browser_cookie3
+
+jar = browser_cookie3.edge(domain_name='linkedin.com')
+seen = set()
+parts = []
+for c in jar:
+    if c.name in seen:
+        continue
+    seen.add(c.name)
+    parts.append(f"{c.name}={c.value}")
+print('; '.join(parts), end='')
+PY
+```
+
+快速确认这份 cookie 是否够用：
+
+```bash
+python3 - <<'PY'
+from pathlib import Path
+text = Path('/tmp/linkedin_edge_cookie.txt').read_text()
+print('li_at=' in text)
+print('JSESSIONID=' in text)
+PY
+```
+
+预期输出：两行都应为 `True`
+
+### 3. 只更新演练环境，不改生产
+
+```bash
+cd /Users/elng/web/pinpointanswertoday/new-pinpoint-site/worker
+npx wrangler secret put GRAPHQL_COOKIE --env staging < /tmp/linkedin_edge_cookie.txt
+npx wrangler secret put GRAPHQL_COOKIE --env shadow < /tmp/linkedin_edge_cookie.txt
+```
+
+### 4. 重新跑预检
+
+```bash
+export ADMIN_SECRET='<your-admin-secret>'
+
+curl "https://pinpoint-worker-staging.2296744453m.workers.dev/admin/preflight-linkedin?secret=$ADMIN_SECRET&date=2026-03-28"
+curl "https://pinpoint-worker-shadow.2296744453m.workers.dev/admin/preflight-linkedin?secret=$ADMIN_SECRET&date=2026-03-28"
+```
+
+成功标志：
+
+- 返回 `ok: true`
+- `source` 变成 `"graphql"`
+- 返回 5 个 clue / answers
+
+### 5. 如需继续做完整发布演练
+
+如果当天已经跑过一次，需要先清掉当天的 enrich 完成标记，再重新手动触发：
+
+```bash
+cd /Users/elng/web/pinpointanswertoday/new-pinpoint-site/worker
+npx wrangler kv key delete 'publish:2026-03-28:enrich_done' --env staging --binding PP_DATA --remote
+```
+
+然后再跑：
+
+```bash
+export ADMIN_SECRET='<your-admin-secret>'
+
+curl "https://pinpoint-worker-staging.2296744453m.workers.dev/admin/run?secret=$ADMIN_SECRET&publish=1&force=1&i18n=0&date=2026-03-28"
+curl "https://pinpoint-worker-staging.2296744453m.workers.dev/monitor/cron-status?secret=$ADMIN_SECRET"
+```
+
+成功标志：
+
+- `/admin/run` 返回 `source: "graphql"`
+- `/monitor/cron-status` 最终 `outcome: "succeeded"`
+- `enrich.detailState` 允许是 `published` 或 `fallback_full`
+
+## 收尾
+
+临时 cookie 文件用完就删：
+
+```bash
+rm -f /tmp/linkedin_edge_cookie.txt
+```
+
+## 如果还是失败
+
+按这个顺序继续查：
+
+1. 先确认浏览器里是否真的还有 LinkedIn 登录态
+2. 换另一个浏览器配置重新提取 cookie
+3. 再看 `staging` / `shadow` 是否还缺 `GRAPHQL_TOKEN`
+4. 最后才考虑去重建或补录额外 token
+
+## `2026-03-28` 实测结论
+
+- 生产预检正常，`staging` / `shadow` 初始返回 `graphql 401`
+- 仅刷新 `GRAPHQL_COOKIE` 后，`staging` / `shadow` 的 `/admin/preflight-linkedin` 都恢复为 `source: "graphql"`
+- 当前 worker 会从 `GRAPHQL_COOKIE` 里的 `JSESSIONID` 自动拼 `csrf-token`
+- 因此这类故障的首要排查项是 `GRAPHQL_COOKIE`，不是 `GRAPHQL_CSRF_TOKEN`

--- a/worker/README.md
+++ b/worker/README.md
@@ -44,7 +44,7 @@ wrangler deploy --env staging --name pinpoint-worker-staging  # 受控演练（�
 | `GRAPHQL_CSRF_TOKEN` | Voyager GraphQL 可选 CSRF token | 可选 | 可选 |
 | `SITE_API_TOKEN` | 调 `/api/admin/generate-draft` 的 Bearer token（enrichment/i18n 用） | ❌ | ✅ |
 | `GITHUB_TOKEN_NEW_SITE` | GitHub fine-grained PAT，`contents:write` on `elng12/pinpoint-answer-today-new` | ❌ | ✅ |
-| `NEW_SITE_REVALIDATE_SECRET` | 必须与 Vercel `REVALIDATE_SECRET` 值完全一致 | ❌ | ✅ |
+| `NEW_SITE_REVALIDATE_SECRET` | 必须与 Vercel `REVALIDATE_SECRET` 值完全一致；仅正式 `main` 分支需要 | ❌ | staging 可选 / 生产必需 |
 | `FEISHU_WEBHOOK_URL` | 飞书告警 webhook URL | ❌ | ✅ |
 | `FALLBACK_WEBHOOK_SECRET` | Worker 调站点 `/api/fallback/worker-pinpoint` 的 HMAC 签名密钥 | ❌ | ✅ |
 | `ADMIN_SECRET` | 受保护管理接口的密钥 | 可选 | ✅ |
@@ -58,10 +58,64 @@ wrangler deploy --env staging --name pinpoint-worker-staging  # 受控演练（�
 - `FEISHU_WEBHOOK_URL` 不是阶段 B 演练必需；如果 staging 只是短期手动验证，可先不配，避免测试告警进入正式群
 - `GITHUB_TOKEN_NEW_SITE` 长期应使用 fine-grained PAT，并限制到 `elng12/pinpoint-answer-today-new` 的 `contents:write`；临时复用本机 `gh auth token` 只适合一次性演练，不适合长期保留
 - 站点 enrichment 走的是站点自己的 `/api/admin/generate-draft`，所以除了 Cloudflare Worker secret 以外，Vercel 站点侧也要有可用的 `API_SECRET_TOKEN` / `ADMIN_PASSPHRASE` / `OPENAI_API_KEY` / `OPENAI_BASE_URL` / `AI_MODEL`
+- `shadow` 默认写演练分支 `worker-shadow`，`staging` 默认写演练分支 `worker-staging`；非 `main` 分支不会触发正式站 `revalidate`、页面探活或发布通知
 - 如果用 OpenRouter，推荐统一口径为：
   - `OPENAI_API_KEY=<OpenRouter key>`
   - `OPENAI_BASE_URL=https://openrouter.ai/api/v1`
   - `AI_MODEL=google/gemini-2.0-flash-001` 或你实际在用的模型
+
+### `graphql 401` 优先修复顺序
+
+如果 `staging` / `shadow` 的 `/admin/preflight-linkedin` 返回 `graphql 401`，先不要默认去找 `GRAPHQL_TOKEN` 或 `GRAPHQL_CSRF_TOKEN` 原值。当前 worker 会优先从 `GRAPHQL_COOKIE` 里的 `JSESSIONID` 自动拼出 `csrf-token`，所以最常见的原因其实是 `GRAPHQL_COOKIE` 过期。
+
+完整演练步骤见：
+
+- `docs/staging-graphql-cookie-recovery-runbook-2026-03-28.md`
+
+推荐排查顺序：
+
+1. 先对比生产和演练环境的预检结果
+   - 如果生产 `pinpoint-worker` 预检正常，而 `staging` / `shadow` 返回 `graphql 401`，优先怀疑演练环境 cookie 过期
+2. 先刷新 `GRAPHQL_COOKIE`
+   - 从本机当前已登录 LinkedIn 的浏览器会话提取一份新 cookie
+   - 至少要包含 `li_at` 和 `JSESSIONID`
+3. 只有在刷新 cookie 后仍然失败，再继续核对 `GRAPHQL_TOKEN`
+
+`2026-03-28` 实测结论：
+
+- 仅刷新 `GRAPHQL_COOKIE` 就让 `shadow` 和 `staging` 的 `/admin/preflight-linkedin` 从 `graphql 401` 恢复为 `source: "graphql"`
+- `GRAPHQL_CSRF_TOKEN` 在当前 worker 实现里不是首要排查项
+
+推荐命令：
+
+```bash
+python3 - <<'PY' >/tmp/linkedin_edge_cookie.txt
+import browser_cookie3
+jar = browser_cookie3.edge(domain_name='linkedin.com')
+seen = set()
+parts = []
+for c in jar:
+    if c.name in seen:
+        continue
+    seen.add(c.name)
+    parts.append(f"{c.name}={c.value}")
+print('; '.join(parts), end='')
+PY
+
+cd /Users/elng/web/pinpointanswertoday/new-pinpoint-site/worker
+npx wrangler secret put GRAPHQL_COOKIE --env staging < /tmp/linkedin_edge_cookie.txt
+npx wrangler secret put GRAPHQL_COOKIE --env shadow < /tmp/linkedin_edge_cookie.txt
+rm -f /tmp/linkedin_edge_cookie.txt
+```
+
+补完后立刻用下面的预检接口确认：
+
+```bash
+export ADMIN_SECRET='<your-admin-secret>'
+
+curl "https://pinpoint-worker-staging.2296744453m.workers.dev/admin/preflight-linkedin?secret=$ADMIN_SECRET&date=2026-03-28"
+curl "https://pinpoint-worker-shadow.2296744453m.workers.dev/admin/preflight-linkedin?secret=$ADMIN_SECRET&date=2026-03-28"
+```
 
 本机 env 副本策略：
 
@@ -109,9 +163,10 @@ wrangler deploy --env staging --name pinpoint-worker-staging  # 受控演练（�
 常用参数：
 
 - `publish=1`：抓取后继续发布
-- `force=1`：即使命中“疑似昨天旧数据”规则也继续跑发布链路
+- `force=1`：即使命中“疑似昨天旧数据”规则也继续跑发布链路；不会清除“今天已完成 enrich”这把完成锁
 - `date=YYYY-MM-DD`：手动指定日期
 - `i18n=0` 或 `i18n=1`：关闭或开启多语言
+- `source=stored`：仅演练分支可用；直接使用该环境 KV 里已存的题目数据，不再现场抓取
 
 推荐命令：
 
@@ -121,6 +176,16 @@ export ADMIN_SECRET='<your-admin-secret>'
 curl "https://pinpoint-worker.2296744453m.workers.dev/admin/run?secret=$ADMIN_SECRET&publish=1&force=1&i18n=0"
 curl "https://pinpoint-worker-staging.2296744453m.workers.dev/admin/run?secret=$ADMIN_SECRET&publish=1&force=1&i18n=0"
 curl "https://pinpoint-worker-shadow.2296744453m.workers.dev/admin/run?secret=$ADMIN_SECRET"
+```
+
+如果 staging / shadow 的上游抓取临时失效，可以先把一份题目写进演练环境，再用 `source=stored` 跑发布链路：
+
+```bash
+curl -X POST "https://pinpoint-worker-staging.2296744453m.workers.dev/admin/put-doc?secret=$ADMIN_SECRET" \
+  -H "content-type: application/json" \
+  --data '{"theme":"Example theme","mainAnswer":"Example theme","answers":["One","Two","Three","Four","Five"]}'
+
+curl "https://pinpoint-worker-staging.2296744453m.workers.dev/admin/run?secret=$ADMIN_SECRET&publish=1&force=1&i18n=0&source=stored"
 ```
 
 返回含义：

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -84,7 +84,7 @@ binding = "PP_DATA"
 preview_id = "pp_data_dev"
 
 # ---------------------------------------------------------------------------
-# Shadow (stage A) — 影子运行，只抓取 + 写 KV，不写 GitHub，不触发 revalidate，不发告警
+# Shadow (stage A) — 影子运行，只抓取 + 写独立 KV，不写正式分支，不触发正式站刷新
 # 部署命令：wrangler deploy --env shadow --name pinpoint-worker-shadow
 # 不绑定 Cron，只能手动触发
 # 需要配置的 Secrets（仅抓取相关）：GRAPHQL_COOKIE、GRAPHQL_TOKEN、GRAPHQL_CSRF_TOKEN
@@ -96,11 +96,12 @@ VOYAGER_GRAPHQL_ENDPOINT    = "https://www.linkedin.com/voyager/api/graphql"
 FALLBACK_WEBHOOK            = "https://pinpointanswertoday.app/api/fallback/worker-pinpoint"
 ALLOW_SELF_GRAPHQL          = "false"
 GITHUB_REPO_NEW_SITE        = "elng12/pinpoint-answer-today-new"
-GITHUB_BRANCH_NEW_SITE      = "main"
+GITHUB_BRANCH_NEW_SITE      = "worker-shadow"
 NEW_SITE_URL                = "https://pinpointanswertoday.app"
 AUTO_PUBLISH_ENABLED        = "false"
 AUTO_ENRICH_ENABLED         = "false"
 AUTO_I18N_ENABLED           = "false"
+ADMIN_PUT_DOC_ENABLED       = "true"
 AUTO_I18N_LOCALES           = "fr,de,pt-BR"
 AUTO_I18N_PARALLEL          = "2"
 AUTO_PUBLISH_TIMEOUT_MS     = "15000"
@@ -112,7 +113,8 @@ SITE_BASE_URL               = ""
 
 [[env.shadow.kv_namespaces]]
 binding = "PP_DATA"
-id = "2689a48e886548a3acbe8fa9ede4e3f6"
+id = "eec495bd5bc344dca194cbe970d3d50a"
+remote = true
 
 [env.shadow.triggers]
 crons = []
@@ -121,7 +123,7 @@ crons = []
 binding = "AI"
 
 # ---------------------------------------------------------------------------
-# Staging (stage B) — 受控演练，允许完整链路，但只能手动触发，不绑定 Cron
+# Staging (stage B) — 受控演练，允许完整链路，但只写演练分支，不绑定 Cron
 # 部署命令：wrangler deploy --env staging --name pinpoint-worker-staging
 # 需要配置全套 Secrets（GITHUB_TOKEN_NEW_SITE、NEW_SITE_REVALIDATE_SECRET 等）
 # ---------------------------------------------------------------------------
@@ -131,11 +133,12 @@ VOYAGER_GRAPHQL_ENDPOINT    = "https://www.linkedin.com/voyager/api/graphql"
 FALLBACK_WEBHOOK            = "https://pinpointanswertoday.app/api/fallback/worker-pinpoint"
 ALLOW_SELF_GRAPHQL          = "false"
 GITHUB_REPO_NEW_SITE        = "elng12/pinpoint-answer-today-new"
-GITHUB_BRANCH_NEW_SITE      = "main"
+GITHUB_BRANCH_NEW_SITE      = "worker-staging"
 NEW_SITE_URL                = "https://pinpointanswertoday.app"
 AUTO_PUBLISH_ENABLED        = "true"
 AUTO_ENRICH_ENABLED         = "true"
 AUTO_I18N_ENABLED           = "false"
+ADMIN_PUT_DOC_ENABLED       = "true"
 AUTO_I18N_LOCALES           = "fr,de,pt-BR"
 AUTO_I18N_PARALLEL          = "2"
 AUTO_PUBLISH_TIMEOUT_MS     = "15000"
@@ -147,7 +150,8 @@ SITE_BASE_URL               = ""
 
 [[env.staging.kv_namespaces]]
 binding = "PP_DATA"
-id = "2689a48e886548a3acbe8fa9ede4e3f6"
+id = "027ced3a21454b649569b50f142aef0e"
+remote = true
 
 [env.staging.triggers]
 crons = []


### PR DESCRIPTION
把 Cloudflare Worker 的 shadow/staging 环境改成写各自的演练分支与独立 KV（避免误写 main/误触发正式刷新）。并补充演练与排障文档。\n\n变更点：\n- shadow: GITHUB_BRANCH_NEW_SITE=worker-shadow，KV 绑定指向独立 namespace（remote=true）\n- staging: GITHUB_BRANCH_NEW_SITE=worker-staging，KV 绑定指向独立 namespace（remote=true）\n- 启用 ADMIN_PUT_DOC_ENABLED，方便演练时写入样例数据\n- 新增 docs/ 下的 runbook/检查清单/PRD，README 中引用排障手册\n\n说明：这些改动不会自动影响线上行为，只有重新 deploy 对应 env 才会生效。