### PR TITLE
chore(seo): harden analytics bootstrap and refine hero copy

### DIFF
--- a/components/analytics/AnalyticsScripts.tsx
+++ b/components/analytics/AnalyticsScripts.tsx
@@ -9,6 +9,11 @@ export function AnalyticsScripts() {
     return null;
   }
 
+  const measurementIdLiteral = JSON.stringify(GA_MEASUREMENT_ID);
+  const scriptSrcLiteral = JSON.stringify(
+    `https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`,
+  );
+
   const bootstrapAnalytics = `
     (function() {
       window.dataLayer = window.dataLayer || [];
@@ -29,11 +34,11 @@ export function AnalyticsScripts() {
 
         var script = document.createElement("script");
         script.async = true;
-        script.src = "https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}";
+        script.src = ${scriptSrcLiteral};
         document.head.appendChild(script);
 
         window.gtag("js", new Date());
-        window.gtag("config", "${GA_MEASUREMENT_ID}", {
+        window.gtag("config", ${measurementIdLiteral}, {
           anonymize_ip: true,
           transport_type: "beacon"
         });

--- a/components/home/HomeHero.tsx
+++ b/components/home/HomeHero.tsx
@@ -21,7 +21,7 @@ export function HomeHero({
         <p className="home-hero-kicker">Today&apos;s Pinpoint hints, yesterday&apos;s answer, and the archive</p>
         <h1 className="home-hero-title">{`Today's LinkedIn Pinpoint #${puzzle.number} Answer`}</h1>
         <p className="home-hero-subtitle">
-          {`If you need LinkedIn Pinpoint answer today, this page keeps today's answer, spoiler-safe hints, yesterday's answer, and the full archive in one place for Puzzle #${puzzle.number}.`}
+          {`Need today's LinkedIn Pinpoint answer? Find spoiler-safe hints, yesterday's solution, and the full archive for Puzzle #${puzzle.number} in one place.`}
         </p>
         <div className="button-row home-hero-actions">
           <Link className="button-primary home-hero-primary" href={routes.detail(puzzle.slug)} prefetch={false}>


### PR DESCRIPTION
两个小调整：

- AnalyticsScripts 内联脚本用 JSON.stringify 转义 GA id，避免潜在注入/拼接风险
- 首页 Hero subtitle 改为更自然的表述，降低 answer 关键词堆砌感

验证：npm run lint && npm run typecheck