### PR TITLE
ci: add PR guardrails workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  checks:
+    name: Lint, Typecheck, Guardrails
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install
+        run: npm ci
+
+      - name: Validate Data
+        run: npm run validate:data
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Pinpoint Guardrails
+        run: npm run test:pinpoint-guardrails
+


### PR DESCRIPTION
新增 GitHub Actions CI：每个 PR / main push 自动跑\n\n- npm run validate:data\n- npm run lint\n- npm run typecheck\n- npm run test:pinpoint-guardrails\n\n目的：把路由/SEO/安全类回归变成自动卡口，不再依赖人工检查。