### PR TITLE
fix: restore /api/health and /api/pinpoint/today

### DIFF
--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from "next/server";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const DEFAULT_WORKER_HEALTH_URL = "https://pinpoint-worker.2296744453m.workers.dev/health";
+
+function resolveWorkerHealthUrl(): URL {
+  const raw = String(process.env.PINPOINT_WORKER_HEALTH_URL || DEFAULT_WORKER_HEALTH_URL).trim();
+  try {
+    return new URL(raw);
+  } catch {
+    return new URL(DEFAULT_WORKER_HEALTH_URL);
+  }
+}
+
+function buildNoStoreHeaders(contentType?: string | null): Headers {
+  const headers = new Headers({ "Cache-Control": "no-store" });
+  if (contentType) headers.set("content-type", contentType);
+  return headers;
+}
+
+/**
+ * GET /api/health
+ *
+ * Proxies the Cloudflare Worker health endpoint so monitors can use a stable URL
+ * on the Vercel-hosted main domain.
+ */
+export async function GET() {
+  const workerHealthUrl = resolveWorkerHealthUrl();
+
+  try {
+    const upstream = await fetch(workerHealthUrl, { cache: "no-store" });
+    const body = await upstream.text();
+
+    return new NextResponse(body, {
+      status: upstream.status,
+      headers: buildNoStoreHeaders(upstream.headers.get("content-type") || "application/json"),
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "upstream unavailable";
+    return NextResponse.json(
+      { error: message, workerHealthUrl: workerHealthUrl.toString() },
+      { status: 503, headers: buildNoStoreHeaders("application/json") },
+    );
+  }
+}
+

--- a/app/api/pinpoint/today/route.ts
+++ b/app/api/pinpoint/today/route.ts
@@ -1,0 +1,55 @@
+import { NextResponse } from "next/server";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const DEFAULT_WORKER_HEALTH_URL = "https://pinpoint-worker.2296744453m.workers.dev/health";
+
+function resolveWorkerBaseUrl(): URL {
+  const raw = String(process.env.PINPOINT_WORKER_HEALTH_URL || DEFAULT_WORKER_HEALTH_URL).trim();
+  try {
+    const url = new URL(raw);
+    url.pathname = "";
+    url.search = "";
+    url.hash = "";
+    return url;
+  } catch {
+    return new URL("https://pinpoint-worker.2296744453m.workers.dev");
+  }
+}
+
+function buildNoStoreHeaders(contentType?: string | null): Headers {
+  const headers = new Headers({ "Cache-Control": "no-store" });
+  if (contentType) headers.set("content-type", contentType);
+  return headers;
+}
+
+/**
+ * GET /api/pinpoint/today
+ *
+ * Proxies the Cloudflare Worker endpoint so the main domain can serve the legacy
+ * JSON response without relying on Cloudflare routing in front of Vercel.
+ */
+export async function GET(req: Request) {
+  const requestUrl = new URL(req.url);
+  const workerBaseUrl = resolveWorkerBaseUrl();
+  const upstreamUrl = new URL("/api/pinpoint/today", workerBaseUrl);
+  upstreamUrl.search = requestUrl.search;
+
+  try {
+    const upstream = await fetch(upstreamUrl, { cache: "no-store" });
+    const body = await upstream.text();
+
+    return new NextResponse(body, {
+      status: upstream.status,
+      headers: buildNoStoreHeaders(upstream.headers.get("content-type") || "application/json"),
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "upstream unavailable";
+    return NextResponse.json(
+      { error: message, upstreamUrl: upstreamUrl.toString() },
+      { status: 503, headers: buildNoStoreHeaders("application/json") },
+    );
+  }
+}
+


### PR DESCRIPTION
Fixes 404 on https://pinpointanswertoday.app/api/health and /api/pinpoint/today by proxying to the Cloudflare Worker.\n\n- Adds Next.js route handlers for /api/health and /api/pinpoint/today\n- Uses PINPOINT_WORKER_HEALTH_URL (defaults to the production worker)\n\nTest: npm run typecheck