### PR TITLE
refactor(puzzles): extract live fallback builders

### DIFF
--- a/components/detail/PuzzleFullAnalysis.tsx
+++ b/components/detail/PuzzleFullAnalysis.tsx
@@ -30,6 +30,73 @@ function splitIntoSentences(paragraph: string): string[] {
   return (matches ?? [paragraph]).map((sentence) => sentence.trim()).filter(Boolean);
 }
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function findPreviousWord(input: string, matchStart: number): string | null {
+  const before = input.slice(0, matchStart);
+  const match = before.match(/([A-Za-z]+)[^A-Za-z]*$/);
+  return match?.[1] ?? null;
+}
+
+function findNextWord(input: string, matchEnd: number): string | null {
+  const after = input.slice(matchEnd);
+  const match = after.match(/^[^A-Za-z]*([A-Za-z]+)/);
+  return match?.[1] ?? null;
+}
+
+type SharedPhraseToken = { kind: "before" | "after"; token: string };
+
+function getSharedPhraseToken(answer: string): SharedPhraseToken | null {
+  const trimmed = answer.trim();
+  const after = trimmed.match(/^Words that come after\s+["“]?(.+?)["”]?$/i);
+  if (after?.[1]) return { kind: "after", token: after[1].trim().toLowerCase() };
+  const before = trimmed.match(/^Words that come before\s+["“]?(.+?)["”]?$/i);
+  if (before?.[1]) return { kind: "before", token: before[1].trim().toLowerCase() };
+  return null;
+}
+
+function applyClueCasing(paragraph: string, clues: string[], phraseToken: SharedPhraseToken | null): string {
+  let out = paragraph;
+  const normalizedClues = clues
+    .map((clue) => clue.trim())
+    .filter(Boolean)
+    // Replace multi-word clues first so single-word passes don't disturb them.
+    .sort((a, b) => b.length - a.length);
+
+  for (const clue of normalizedClues) {
+    // Only apply casing to simple alpha words/phrases; skip emoji/punctuation-heavy clues.
+    if (!/^[A-Za-z][A-Za-z'’\-\s]*$/.test(clue)) continue;
+    const pattern = new RegExp(`\\b${escapeRegExp(clue)}\\b`, "gi");
+    const isSingleWord = !clue.includes(" ");
+
+    out = out.replace(pattern, (match, offset) => {
+      if (!isSingleWord) return clue;
+
+      if (phraseToken?.kind === "after") {
+        const previousWord = findPreviousWord(out, offset);
+        if (previousWord?.toLowerCase() === phraseToken.token) {
+          // e.g. keep "paper plane" lowercase in shared-word puzzles.
+          return match;
+        }
+      }
+
+      if (phraseToken?.kind === "before") {
+        const nextWord = findNextWord(out, offset + match.length);
+        if (nextWord?.toLowerCase() === phraseToken.token) {
+          // e.g. keep "traffic light" lowercase in shared-word puzzles.
+          return match;
+        }
+      }
+
+      return clue;
+    });
+  }
+
+  return out;
+}
+
 function buildReadableParagraphs(paragraphs: string[]): string[] {
   const trimmedParagraphs = paragraphs.map((paragraph) => paragraph.trim()).filter(Boolean);
   if (trimmedParagraphs.length >= 5) {
@@ -102,6 +169,13 @@ function dedupeParagraphs(paragraphs: string[]): string[] {
   return unique;
 }
 
+function dedupeAgainstReference(paragraphs: string[], reference: string[]): string[] {
+  if (reference.length === 0) return paragraphs;
+  const referenceKeys = new Set(reference.map(normalizeParagraphKey));
+  const filtered = paragraphs.filter((paragraph) => !referenceKeys.has(normalizeParagraphKey(paragraph)));
+  return filtered.length > 0 ? filtered : paragraphs;
+}
+
 function buildSolvePathParagraphs(puzzle: PuzzleDetailRecord): string[] {
   const paragraphs: string[] = [];
 
@@ -119,7 +193,19 @@ function buildSolvePathParagraphs(puzzle: PuzzleDetailRecord): string[] {
   });
 
   if (puzzle.turningPoint?.clue) {
-    paragraphs.push(`${puzzle.turningPoint.clue} was the turning clue. ${puzzle.turningPoint.whyDecisive}`);
+    const clue = puzzle.turningPoint.clue;
+    const why = puzzle.turningPoint.whyDecisive?.trim();
+    const normalizedWhy = why?.toLowerCase() ?? "";
+    const normalizedClue = clue.trim().toLowerCase();
+
+    // Avoid "X was the turning clue. X is the turning point..." style repetition.
+    if (why && normalizedWhy.startsWith(normalizedClue)) {
+      paragraphs.push(why);
+    } else if (why) {
+      paragraphs.push(`${clue} was the turning clue. ${why}`);
+    } else {
+      paragraphs.push(`${clue} was the turning clue.`);
+    }
   } else if (puzzle.solvePath?.breakingClue) {
     paragraphs.push(`${puzzle.solvePath.breakingClue} was the clue that tightened the board.`);
   }
@@ -133,6 +219,34 @@ function buildSolvePathParagraphs(puzzle: PuzzleDetailRecord): string[] {
   }
 
   return dedupeParagraphs(paragraphs);
+}
+
+function tightenWalkthroughParagraphs(paragraphs: string[], puzzle: PuzzleDetailRecord): string[] {
+  if (paragraphs.length <= 4) return paragraphs;
+
+  const answer = puzzle.answer.trim().toLowerCase();
+  const clueNeedle = puzzle.clues.map((clue) => clue.trim().toLowerCase()).filter(Boolean);
+
+  const kept = paragraphs.filter((paragraph, index) => {
+    if (index === paragraphs.length - 1) return true; // keep the closing line
+
+    const trimmed = paragraph.trim();
+    const lower = trimmed.toLowerCase();
+    if (answer && lower.includes(answer)) return true;
+    if (/(the answer (?:is|was)|once\b)/i.test(trimmed)) return true;
+    if (trimmed.length >= 140) return true;
+
+    const mentionsClue = clueNeedle.some((clue) => clue && lower.includes(clue));
+    if (mentionsClue && /(made sense|fit|worked|clicked|lands?|confirm|narrow)/i.test(trimmed)) {
+      return true;
+    }
+
+    return false;
+  });
+
+  const unique = dedupeParagraphs(kept);
+  // If we filtered too aggressively, keep the original text.
+  return unique.length >= 3 ? unique : paragraphs;
 }
 
 function renderClueTable(puzzle: PuzzleDetailRecord) {
@@ -239,8 +353,19 @@ export function PuzzleFullAnalysis({
 }) {
   const isShortMode = puzzle.detailMode === "short";
   const isFallbackShortMode = isShortMode && puzzle.detailSource === "fallback";
-  const walkthroughParagraphs = buildWalkthroughParagraphs(puzzle);
-  const solvePathParagraphs = buildSolvePathParagraphs(puzzle);
+  const phraseToken = getSharedPhraseToken(puzzle.answer);
+  const solvePathParagraphs = dedupeParagraphs(
+    buildSolvePathParagraphs(puzzle).map((paragraph) => applyClueCasing(paragraph, puzzle.clues, phraseToken)),
+  );
+  const walkthroughParagraphs = dedupeAgainstReference(
+    dedupeParagraphs(
+      tightenWalkthroughParagraphs(
+        buildWalkthroughParagraphs(puzzle).map((paragraph) => applyClueCasing(paragraph, puzzle.clues, phraseToken)),
+        puzzle,
+      ),
+    ),
+    solvePathParagraphs,
+  );
   const visibleFaqEntries = getVisibleDetailFaqEntries(puzzle.faqItems, puzzle.faqs, puzzle.detailMode);
   const analysisTitle = isShortMode
     ? `Pinpoint ${puzzle.number} Quick Guide`

--- a/lib/puzzles/data.ts
+++ b/lib/puzzles/data.ts
@@ -15,13 +15,21 @@ import {
   type PuzzleUniquenessSignalsRecord,
 } from "@/lib/puzzles/schema";
 import { fetchPuzzleContent, fetchRegistry, warnRemoteFallback } from "@/lib/puzzles/data-sources";
-import {
-  buildSharedFallbackArticleBlocks,
-  buildSharedFallbackFaqs,
-  buildSharedFallbackLessons,
-  buildSharedFallbackSolutionNarrative,
-} from "@/lib/puzzles/fallback-copy";
+import { buildSharedFallbackSolutionNarrative } from "@/lib/puzzles/fallback-copy";
 import { getBundledRegistryEntries } from "@/lib/puzzles/registry-bundled";
+import {
+  buildLiveArticleBreakdown,
+  buildLiveClueExplanation,
+  buildLiveConnectorSummary,
+  buildLiveFallbackPhrase,
+  buildLiveFaqs,
+  buildLiveLessons,
+  buildLiveWordHints,
+  detectLiveAnswerPattern,
+  normalizeLooseLiveText,
+  pickLiveTurningPoint,
+  singularizeTrailingWord,
+} from "@/lib/puzzles/live-fallback";
 
 export type PuzzleDetailDisplay = {
   connectorSummary: string;
@@ -106,13 +114,6 @@ type LiveWorkerPuzzleRecord = {
   answer: string;
 };
 
-type LiveAnswerPattern =
-  | { kind: "before"; token: string }
-  | { kind: "after"; token: string }
-  | { kind: "typed-category"; noun: string; singularNoun: string }
-  | { kind: "association"; subject: string }
-  | { kind: "category"; label: string };
-
 // ── Constants ──────────────────────────────────────────────────────────────
 
 const DETAIL_PUBLIC_FORMAL_ONLY =
@@ -171,52 +172,6 @@ function inferPuzzleNumberFromDate(isoDate: string): number | null {
   if (diffDays < 0) return null;
 
   return BASELINE_NUMBER + diffDays;
-}
-
-function normalizeLooseLiveText(value: string): string {
-  return value
-    .toLowerCase()
-    .replace(/["“”'`]/g, "")
-    .replace(/[^\p{L}\p{N}]+/gu, " ")
-    .replace(/\s+/g, " ")
-    .trim();
-}
-
-function stripStraightAndCurlyQuotes(value: string): string {
-  return value.replace(/["“”]/g, "");
-}
-
-function singularizeTrailingWord(text: string): string {
-  const trimmed = text.trim();
-  if (!trimmed) return trimmed;
-
-  const words = trimmed.split(/\s+/);
-  const lastWord = words[words.length - 1] || trimmed;
-  const lowerLastWord = lastWord.toLowerCase();
-
-  const irregularSingulars: Record<string, string> = {
-    mice: "mouse",
-    geese: "goose",
-    teeth: "tooth",
-    feet: "foot",
-    men: "man",
-    women: "woman",
-    people: "person",
-    children: "child",
-  };
-
-  let singularLastWord = lastWord;
-  if (irregularSingulars[lowerLastWord]) {
-    singularLastWord = irregularSingulars[lowerLastWord];
-  } else if (/ies$/i.test(lastWord)) {
-    singularLastWord = `${lastWord.slice(0, -3)}y`;
-  } else if (/(ches|shes|xes|zes)$/i.test(lastWord)) {
-    singularLastWord = lastWord.slice(0, -2);
-  } else if (/s$/i.test(lastWord) && !/ss$/i.test(lastWord)) {
-    singularLastWord = lastWord.slice(0, -1);
-  }
-
-  return [...words.slice(0, -1), singularLastWord].join(" ").trim() || trimmed;
 }
 
 function parseLesson(lesson: LessonItem): { title: string | null; body: string } {
@@ -541,211 +496,6 @@ function resolveEvidenceUniquenessSignals(
       ),
     ).slice(0, 5),
   };
-}
-
-function detectLiveAnswerPattern(answer: string): LiveAnswerPattern {
-  const text = answer.trim();
-
-  const before = text.match(/^Words that come before\s+["“]?(.+?)["”]?$/i);
-  if (before?.[1]) return { kind: "before", token: before[1].trim() };
-
-  const after = text.match(/^Words that come after\s+["“]?(.+?)["”]?$/i);
-  if (after?.[1]) return { kind: "after", token: after[1].trim() };
-
-  const typedCategory = text.match(/^(Types|Kinds)\s+of\s+(.+)$/i);
-  if (typedCategory?.[2]) {
-    const noun = typedCategory[2].trim();
-    return {
-      kind: "typed-category",
-      noun,
-      singularNoun: singularizeTrailingWord(noun),
-    };
-  }
-
-  const association = text.match(/^Things associated with\s+(.+)$/i);
-  if (association?.[1]) {
-    return { kind: "association", subject: association[1].trim() };
-  }
-
-  return {
-    kind: "category",
-    label: text || "shared category",
-  };
-}
-
-function buildLiveConnectorSummary(answer: string): string {
-  const pattern = detectLiveAnswerPattern(answer);
-  if (pattern.kind === "before") {
-    return `familiar phrases that end with "${pattern.token}"`;
-  }
-  if (pattern.kind === "after") {
-    return `familiar phrases and common terms that begin with "${pattern.token}"`;
-  }
-  if (pattern.kind === "typed-category") {
-    return `a category board focused on ${pattern.noun.toLowerCase()}`;
-  }
-  if (pattern.kind === "association") {
-    return `a board centered on the theme of ${pattern.subject}`;
-  }
-  const cleanedLabel = pattern.label.replace(/\s+/g, " ").trim();
-  if (cleanedLabel) {
-    return `a category board focused on ${cleanedLabel}`;
-  }
-  return "a shared category board with one connector";
-}
-
-function buildLiveSpecialPhrase(clue: string, answer: string): string {
-  const pattern = detectLiveAnswerPattern(answer);
-  if (pattern.kind !== "before" && pattern.kind !== "after") return "";
-
-  const symbolGroupPattern = /\(\s*[^\p{L}\p{N}]+\s*\)|[^\p{L}\p{N}\s()'"&,-]+/gu;
-  const replaced = clue.replace(symbolGroupPattern, ` ${pattern.token} `).replace(/\s+/g, " ").trim();
-  if (replaced === clue) return "";
-
-  return stripStraightAndCurlyQuotes(replaced.replace(/\(\s*\)/g, "").replace(/\s+/g, " ").trim());
-}
-
-function buildLiveFallbackPhrase(clue: string, answer: string): string {
-  const pattern = detectLiveAnswerPattern(answer);
-  if (pattern.kind === "before") {
-    return buildLiveSpecialPhrase(clue, answer) || `${clue} ${pattern.token}`.trim();
-  }
-  if (pattern.kind === "after") {
-    return buildLiveSpecialPhrase(clue, answer) || `${pattern.token} ${clue}`.trim();
-  }
-  if (pattern.kind === "typed-category") {
-    const baseClue = clue.replace(/\s*\([^)]*\)\s*/g, " ").replace(/\s+/g, " ").trim();
-    const normalizedBase = baseClue || clue;
-    if (normalizeLooseLiveText(normalizedBase).includes(normalizeLooseLiveText(pattern.singularNoun))) {
-      return normalizedBase;
-    }
-    return `${normalizedBase} ${pattern.singularNoun}`.trim();
-  }
-  return clue.trim();
-}
-
-function scoreLiveClueSpecificity(clue: string): number {
-  const text = clue.trim();
-  if (!text) return 0;
-  const words = text.split(/\s+/).filter(Boolean);
-  let score = text.length;
-  score += words.length * 5;
-  score += (text.match(/-/g)?.length || 0) * 6;
-  score += (text.match(/\(/g)?.length || 0) * 4;
-  score += /\b(the|island|bridge|square|park|museum|tower|center|bay)\b/i.test(text) ? 8 : 0;
-  return score;
-}
-
-function pickLiveTurningPoint(clues: string[], answer: string): string {
-  let bestClue = clues[0] || "the key clue";
-  let bestScore = -1;
-  const pattern = detectLiveAnswerPattern(answer);
-
-  for (let index = 0; index < clues.length; index += 1) {
-    const clue = clues[index] || "";
-    let score = scoreLiveClueSpecificity(clue) + index;
-    if (
-      pattern.kind === "association" &&
-      /\b(square|island|bridge|park|museum|tower|center|bay)\b/i.test(clue)
-    ) {
-      score += 10;
-    }
-    if (score > bestScore) {
-      bestScore = score;
-      bestClue = clue;
-    }
-  }
-
-  return bestClue;
-}
-
-function buildLiveClueExplanation(clue: string, answer: string, index: number, turningPoint: string): string {
-  const pattern = detectLiveAnswerPattern(answer);
-  const phrase = buildLiveFallbackPhrase(clue, answer);
-
-  if (pattern.kind === "before" || pattern.kind === "after") {
-    return `"${phrase}" is a familiar phrase or term, which is why this clue fits once "${pattern.token}" is in place.`;
-  }
-
-  if (pattern.kind === "typed-category") {
-    const variants = [
-      `"${phrase}" is a recognizable ${pattern.singularNoun.toLowerCase()}, so it gives the board a clean category fit.`,
-      `Once the board is read as ${pattern.noun.toLowerCase()}, "${phrase}" stops feeling broad and becomes an exact fit.`,
-      `"${phrase}" belongs in the same ${pattern.singularNoun.toLowerCase()} frame, which keeps the category specific instead of loose.`,
-    ];
-    return variants[index % variants.length] || variants[0];
-  }
-
-  if (pattern.kind === "association") {
-    const subject = pattern.subject;
-    if (clue === turningPoint) {
-      return `"${clue}" is one of the clearest anchors for a ${subject} reading, which is why it helps lock the board into place.`;
-    }
-    const variants = [
-      `"${clue}" fits naturally once the board is read through ${subject} rather than as a loose general-interest category.`,
-      `"${clue}" supports the same ${subject}-based frame as the other clues, so it reads as part of one picture instead of an isolated reference.`,
-      `"${clue}" works because it points back to the same ${subject} context that ties the whole board together.`,
-    ];
-    return variants[index % variants.length] || variants[0];
-  }
-
-  if (clue === turningPoint) {
-    return `"${clue}" is the clue that makes the shared answer concrete enough to test across the full board.`;
-  }
-  const variants = [
-    `"${clue}" fits more cleanly once the board is tested under the same answer as the other clues.`,
-    `"${clue}" helps confirm the same answer instead of pulling the board back toward a looser guess.`,
-    `"${clue}" belongs in the same set as the rest of the board, which is why the answer sharpens once this pattern becomes visible.`,
-  ];
-  return variants[index % variants.length] || variants[0];
-}
-
-function buildLiveWordHints(clues: string[], answer: string): Record<string, string> {
-  const turningPoint = pickLiveTurningPoint(clues, answer);
-  return Object.fromEntries(
-    clues.map((clue, index) => [clue, buildLiveClueExplanation(clue, answer, index, turningPoint)]),
-  );
-}
-
-function buildLiveLessons(answer: string, turningPoint: string): LessonItem[] {
-  const pattern = detectLiveAnswerPattern(answer);
-  return buildSharedFallbackLessons({ kind: pattern.kind, turningPoint });
-}
-
-function buildLiveFaqs(puzzleNumber: number, answer: string, turningPoint: string): FaqItem[] {
-  const pattern = detectLiveAnswerPattern(answer);
-  const connectorSummary = buildLiveConnectorSummary(answer);
-  return buildSharedFallbackFaqs({
-    puzzleNumber,
-    kind: pattern.kind,
-    answer,
-    turningPoint,
-    connectorSummary,
-  });
-}
-
-function buildLiveArticleBreakdown(
-  puzzleNumber: number,
-  clues: string[],
-  answer: string,
-  turningPoint: string,
-): string[] {
-  const pattern = detectLiveAnswerPattern(answer);
-  const connectorSummary = buildLiveConnectorSummary(answer);
-  const sampleReads = clues
-    .slice(0, 2)
-    .map((clue) => buildLiveFallbackPhrase(clue, answer));
-  const finalChecks = clues.slice(-2);
-
-  return buildSharedFallbackArticleBlocks({
-    kind: pattern.kind,
-    clues,
-    answer,
-    turningPoint,
-    connectorSummary,
-    sampleReads,
-    finalChecks,
-  });
 }
 
 function toLivePuzzleDetail(record: LiveWorkerPuzzleRecord): PuzzleDetail | null {

--- a/lib/puzzles/live-fallback.ts
+++ b/lib/puzzles/live-fallback.ts
@@ -1,0 +1,264 @@
+import type { FaqItem, LessonItem } from "@/lib/puzzles/schema";
+import {
+  buildSharedFallbackArticleBlocks,
+  buildSharedFallbackFaqs,
+  buildSharedFallbackLessons,
+} from "@/lib/puzzles/fallback-copy";
+
+export type LiveAnswerPattern =
+  | { kind: "before"; token: string }
+  | { kind: "after"; token: string }
+  | { kind: "typed-category"; noun: string; singularNoun: string }
+  | { kind: "association"; subject: string }
+  | { kind: "category"; label: string };
+
+export function normalizeLooseLiveText(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/["“”'`]/g, "")
+    .replace(/[^\p{L}\p{N}]+/gu, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function stripStraightAndCurlyQuotes(value: string): string {
+  return value.replace(/["“”]/g, "");
+}
+
+export function singularizeTrailingWord(text: string): string {
+  const trimmed = text.trim();
+  if (!trimmed) return trimmed;
+
+  const words = trimmed.split(/\s+/);
+  const lastWord = words[words.length - 1] || trimmed;
+  const lowerLastWord = lastWord.toLowerCase();
+
+  const irregularSingulars: Record<string, string> = {
+    mice: "mouse",
+    geese: "goose",
+    teeth: "tooth",
+    feet: "foot",
+    men: "man",
+    women: "woman",
+    people: "person",
+    children: "child",
+  };
+
+  let singularLastWord = lastWord;
+  if (irregularSingulars[lowerLastWord]) {
+    singularLastWord = irregularSingulars[lowerLastWord];
+  } else if (/ies$/i.test(lastWord)) {
+    singularLastWord = `${lastWord.slice(0, -3)}y`;
+  } else if (/(ches|shes|xes|zes)$/i.test(lastWord)) {
+    singularLastWord = lastWord.slice(0, -2);
+  } else if (/s$/i.test(lastWord) && !/ss$/i.test(lastWord)) {
+    singularLastWord = lastWord.slice(0, -1);
+  }
+
+  return [...words.slice(0, -1), singularLastWord].join(" ").trim() || trimmed;
+}
+
+export function detectLiveAnswerPattern(answer: string): LiveAnswerPattern {
+  const text = answer.trim();
+
+  const before = text.match(/^Words that come before\s+["“]?(.+?)["”]?$/i);
+  if (before?.[1]) return { kind: "before", token: before[1].trim() };
+
+  const after = text.match(/^Words that come after\s+["“]?(.+?)["”]?$/i);
+  if (after?.[1]) return { kind: "after", token: after[1].trim() };
+
+  const typedCategory = text.match(/^(Types|Kinds)\s+of\s+(.+)$/i);
+  if (typedCategory?.[2]) {
+    const noun = typedCategory[2].trim();
+    return {
+      kind: "typed-category",
+      noun,
+      singularNoun: singularizeTrailingWord(noun),
+    };
+  }
+
+  const association = text.match(/^Things associated with\s+(.+)$/i);
+  if (association?.[1]) {
+    return { kind: "association", subject: association[1].trim() };
+  }
+
+  return {
+    kind: "category",
+    label: text || "shared category",
+  };
+}
+
+export function buildLiveConnectorSummary(answer: string): string {
+  const pattern = detectLiveAnswerPattern(answer);
+  if (pattern.kind === "before") {
+    return `familiar phrases that end with "${pattern.token}"`;
+  }
+  if (pattern.kind === "after") {
+    return `familiar phrases and common terms that begin with "${pattern.token}"`;
+  }
+  if (pattern.kind === "typed-category") {
+    return `a category board focused on ${pattern.noun.toLowerCase()}`;
+  }
+  if (pattern.kind === "association") {
+    return `a board centered on the theme of ${pattern.subject}`;
+  }
+  const cleanedLabel = pattern.label.replace(/\s+/g, " ").trim();
+  if (cleanedLabel) {
+    return `a category board focused on ${cleanedLabel}`;
+  }
+  return "a shared category board with one connector";
+}
+
+function buildLiveSpecialPhrase(clue: string, answer: string): string {
+  const pattern = detectLiveAnswerPattern(answer);
+  if (pattern.kind !== "before" && pattern.kind !== "after") return "";
+
+  const symbolGroupPattern = /\(\s*[^\p{L}\p{N}]+\s*\)|[^\p{L}\p{N}\s()'"&,-]+/gu;
+  const replaced = clue.replace(symbolGroupPattern, ` ${pattern.token} `).replace(/\s+/g, " ").trim();
+  if (replaced === clue) return "";
+
+  return stripStraightAndCurlyQuotes(replaced.replace(/\(\s*\)/g, "").replace(/\s+/g, " ").trim());
+}
+
+export function buildLiveFallbackPhrase(clue: string, answer: string): string {
+  const pattern = detectLiveAnswerPattern(answer);
+  if (pattern.kind === "before") {
+    return buildLiveSpecialPhrase(clue, answer) || `${clue} ${pattern.token}`.trim();
+  }
+  if (pattern.kind === "after") {
+    return buildLiveSpecialPhrase(clue, answer) || `${pattern.token} ${clue}`.trim();
+  }
+  if (pattern.kind === "typed-category") {
+    const baseClue = clue.replace(/\s*\([^)]*\)\s*/g, " ").replace(/\s+/g, " ").trim();
+    const normalizedBase = baseClue || clue;
+    if (normalizeLooseLiveText(normalizedBase).includes(normalizeLooseLiveText(pattern.singularNoun))) {
+      return normalizedBase;
+    }
+    return `${normalizedBase} ${pattern.singularNoun}`.trim();
+  }
+  return clue.trim();
+}
+
+function scoreLiveClueSpecificity(clue: string): number {
+  const text = clue.trim();
+  if (!text) return 0;
+  const words = text.split(/\s+/).filter(Boolean);
+  let score = text.length;
+  score += words.length * 5;
+  score += (text.match(/-/g)?.length || 0) * 6;
+  score += (text.match(/\(/g)?.length || 0) * 4;
+  score += /\b(the|island|bridge|square|park|museum|tower|center|bay)\b/i.test(text) ? 8 : 0;
+  return score;
+}
+
+export function pickLiveTurningPoint(clues: string[], answer: string): string {
+  let bestClue = clues[0] || "the key clue";
+  let bestScore = -1;
+  const pattern = detectLiveAnswerPattern(answer);
+
+  for (let index = 0; index < clues.length; index += 1) {
+    const clue = clues[index] || "";
+    let score = scoreLiveClueSpecificity(clue) + index;
+    if (
+      pattern.kind === "association" &&
+      /\b(square|island|bridge|park|museum|tower|center|bay)\b/i.test(clue)
+    ) {
+      score += 10;
+    }
+    if (score > bestScore) {
+      bestScore = score;
+      bestClue = clue;
+    }
+  }
+
+  return bestClue;
+}
+
+export function buildLiveClueExplanation(clue: string, answer: string, index: number, turningPoint: string): string {
+  const pattern = detectLiveAnswerPattern(answer);
+  const phrase = buildLiveFallbackPhrase(clue, answer);
+
+  if (pattern.kind === "before" || pattern.kind === "after") {
+    return `"${phrase}" is a familiar phrase or term, which is why this clue fits once "${pattern.token}" is in place.`;
+  }
+
+  if (pattern.kind === "typed-category") {
+    const variants = [
+      `"${phrase}" is a recognizable ${pattern.singularNoun.toLowerCase()}, so it gives the board a clean category fit.`,
+      `Once the board is read as ${pattern.noun.toLowerCase()}, "${phrase}" stops feeling broad and becomes an exact fit.`,
+      `"${phrase}" belongs in the same ${pattern.singularNoun.toLowerCase()} frame, which keeps the category specific instead of loose.`,
+    ];
+    return variants[index % variants.length] || variants[0];
+  }
+
+  if (pattern.kind === "association") {
+    const subject = pattern.subject;
+    if (clue === turningPoint) {
+      return `"${clue}" is one of the clearest anchors for a ${subject} reading, which is why it helps lock the board into place.`;
+    }
+    const variants = [
+      `"${clue}" fits naturally once the board is read through ${subject} rather than as a loose general-interest category.`,
+      `"${clue}" supports the same ${subject}-based frame as the other clues, so it reads as part of one picture instead of an isolated reference.`,
+      `"${clue}" works because it points back to the same ${subject} context that ties the whole board together.`,
+    ];
+    return variants[index % variants.length] || variants[0];
+  }
+
+  if (clue === turningPoint) {
+    return `"${clue}" is the clue that makes the shared answer concrete enough to test across the full board.`;
+  }
+  const variants = [
+    `"${clue}" fits more cleanly once the board is tested under the same answer as the other clues.`,
+    `"${clue}" helps confirm the same answer instead of pulling the board back toward a looser guess.`,
+    `"${clue}" belongs in the same set as the rest of the board, which is why the answer sharpens once this pattern becomes visible.`,
+  ];
+  return variants[index % variants.length] || variants[0];
+}
+
+export function buildLiveWordHints(clues: string[], answer: string): Record<string, string> {
+  const turningPoint = pickLiveTurningPoint(clues, answer);
+  return Object.fromEntries(
+    clues.map((clue, index) => [clue, buildLiveClueExplanation(clue, answer, index, turningPoint)]),
+  );
+}
+
+export function buildLiveLessons(answer: string, turningPoint: string): LessonItem[] {
+  const pattern = detectLiveAnswerPattern(answer);
+  return buildSharedFallbackLessons({ kind: pattern.kind, turningPoint });
+}
+
+export function buildLiveFaqs(puzzleNumber: number, answer: string, turningPoint: string): FaqItem[] {
+  const pattern = detectLiveAnswerPattern(answer);
+  const connectorSummary = buildLiveConnectorSummary(answer);
+  return buildSharedFallbackFaqs({
+    puzzleNumber,
+    kind: pattern.kind,
+    answer,
+    turningPoint,
+    connectorSummary,
+  });
+}
+
+export function buildLiveArticleBreakdown(
+  puzzleNumber: number,
+  clues: string[],
+  answer: string,
+  turningPoint: string,
+): string[] {
+  const pattern = detectLiveAnswerPattern(answer);
+  const connectorSummary = buildLiveConnectorSummary(answer);
+  const sampleReads = clues
+    .slice(0, 2)
+    .map((clue) => buildLiveFallbackPhrase(clue, answer));
+  const finalChecks = clues.slice(-2);
+
+  return buildSharedFallbackArticleBlocks({
+    kind: pattern.kind,
+    clues,
+    answer,
+    turningPoint,
+    connectorSummary,
+    sampleReads,
+    finalChecks,
+  });
+}


### PR DESCRIPTION
目标：继续拆分 lib/puzzles/data.ts，降低单文件复杂度，同时保持 live worker fallback 行为不变。

变更：
- 新增 lib/puzzles/live-fallback.ts，集中 live fallback 的 answer pattern 识别、turning point 选择、FAQ/lessons/analysis 组装等逻辑。
- lib/puzzles/data.ts 移除对应实现，改为从 live-fallback 模块导入并复用。

验证：
- npm run typecheck
- npm run lint
- npm run test:pinpoint-guardrails
