### PR TITLE
feat(nav): add mobile menu

### DIFF
--- a/app/styles/responsive.css
+++ b/app/styles/responsive.css
@@ -1,4 +1,12 @@
 @media (max-width: 900px) {
+  .nav-links-desktop {
+    display: none;
+  }
+
+  .nav-menu {
+    display: block;
+  }
+
   .footer-grid,
   .footer-link-grid,
   .detail-hero-grid,

--- a/app/styles/sections.css
+++ b/app/styles/sections.css
@@ -287,6 +287,95 @@
   color: var(--muted);
 }
 
+.nav-menu {
+  display: none;
+  position: relative;
+}
+
+.nav-menu-trigger {
+  list-style: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  background: var(--surface-frost);
+  color: var(--muted);
+  cursor: pointer;
+  user-select: none;
+  font-size: 16px;
+  font-weight: 700;
+  transition: border-color 160ms ease, background 160ms ease;
+}
+
+.nav-menu-trigger::marker {
+  display: none;
+}
+
+.nav-menu-trigger::-webkit-details-marker {
+  display: none;
+}
+
+.nav-menu-trigger:hover {
+  border-color: var(--brand-line-strong);
+  background: var(--surface-raised);
+}
+
+.nav-menu-trigger:focus-visible {
+  outline: 2px solid color-mix(in oklch, var(--brand) 55%, transparent);
+  outline-offset: 3px;
+}
+
+.nav-menu-icon {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.nav-menu-icon span {
+  display: block;
+  width: 18px;
+  height: 2px;
+  background: color-mix(in oklch, var(--text) 72%, var(--muted) 28%);
+  border-radius: 999px;
+}
+
+.nav-menu-panel {
+  display: none;
+  position: absolute;
+  top: calc(100% + 12px);
+  right: 0;
+  z-index: 40;
+  width: min(320px, calc(100vw - 48px));
+  padding: 10px;
+  border-radius: 18px;
+  border: 1px solid var(--line);
+  background: var(--surface-raised);
+  box-shadow: var(--shadow);
+}
+
+.nav-menu[open] .nav-menu-panel {
+  display: grid;
+  gap: 6px;
+}
+
+.nav-menu-panel a {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 12px;
+  border-radius: 14px;
+  font-weight: 700;
+  color: var(--brand-dark);
+  transition: background 160ms ease, color 160ms ease;
+}
+
+.nav-menu-panel a:hover {
+  background: color-mix(in oklch, var(--brand) 10%, var(--surface) 90%);
+  color: var(--brand-dark);
+}
+
 .brand {
   display: inline-flex;
   align-items: center;
@@ -778,4 +867,3 @@
 .archive-search-copy {
   margin: 0;
 }
-

--- a/components/layout/NavBar.tsx
+++ b/components/layout/NavBar.tsx
@@ -34,13 +34,32 @@ export function NavBar({ isDetailPage = false }: NavBarProps) {
           />
           Pinpoint Answer Today
         </Link>
-        <nav className="nav-links">
+
+        <nav className="nav-links nav-links-desktop" aria-label="Primary navigation">
           {navLinks.map((link) => (
             <Link key={`${link.href}-${link.label}`} href={link.href} prefetch={false}>
               {link.label}
             </Link>
           ))}
         </nav>
+
+        <details className="nav-menu">
+          <summary className="nav-menu-trigger" aria-label="Open navigation menu">
+            <span className="nav-menu-trigger-label">Menu</span>
+            <span className="nav-menu-icon" aria-hidden="true">
+              <span />
+              <span />
+              <span />
+            </span>
+          </summary>
+          <nav className="nav-menu-panel" aria-label="Mobile navigation">
+            {navLinks.map((link) => (
+              <Link key={`mobile-${link.href}-${link.label}`} href={link.href} prefetch={false}>
+                {link.label}
+              </Link>
+            ))}
+          </nav>
+        </details>
       </div>
     </header>
   );


### PR DESCRIPTION
目标：补齐移动端导航的可用性，避免导航项增多后挤压换行影响体验。

实现：
- components/layout/NavBar.tsx 增加基于 <details>/<summary> 的移动端菜单，不引入客户端 state。
- app/styles/sections.css + app/styles/responsive.css 添加菜单样式与移动端隐藏/显示规则。

验证：
- npm run typecheck
- npm run lint
- npm run build
