### PR TITLE
chore(visual): add detail screenshot script

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,22 @@ npm run test:pinpoint-regression:all
 - `docs/pinpoint-content-regression-sample-set.md`
 - `docs/pinpoint-content-generation-best-practice-2026-03-17.md`
 
+## 详情页视觉自检（图1基线）
+
+为了避免把详情页“从图1改成图2那种大重排”，改完详情相关组件后建议跑一次截图自检：
+
+```bash
+npm run dev
+```
+
+另开一个终端执行：
+
+```bash
+npm run visual:detail
+```
+
+默认会截 `695/697/698` 三篇详情页，图片输出到 `tmp/visual-baseline/<今天日期>/`。
+
 ## 正式发布
 
 如果这次改动会同时影响站点和 `worker/`，不要只做 `git push`。

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "worker:preflight": "node scripts/worker-ops.mjs preflight --env prod",
     "worker:health": "node scripts/worker-ops.mjs health --env prod",
     "worker:refresh-cookie": "node scripts/worker-ops.mjs refresh-cookie --targets all",
+    "visual:detail": "node scripts/capture-detail-screenshots.mjs",
     "test:pinpoint-seo": "tsx scripts/check-pinpoint-seo-builders.ts",
     "test:pinpoint-routing": "tsx scripts/check-routing-regressions.ts",
     "test:pinpoint-guardrails": "npm run test:pinpoint-seo && npm run test:pinpoint-routing && tsx scripts/check-pinpoint-guardrails.ts",

--- a/scripts/capture-detail-screenshots.mjs
+++ b/scripts/capture-detail-screenshots.mjs
@@ -1,0 +1,99 @@
+import { spawn } from "node:child_process";
+import { mkdir } from "node:fs/promises";
+import { resolve } from "node:path";
+
+function todayIsoDate() {
+  const now = new Date();
+  const yyyy = String(now.getFullYear());
+  const mm = String(now.getMonth() + 1).padStart(2, "0");
+  const dd = String(now.getDate()).padStart(2, "0");
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+function parseArgs(argv) {
+  const numbers = [];
+  let baseUrl = "http://localhost:3004";
+  let outDir = `tmp/visual-baseline/${todayIsoDate()}`;
+  let viewport = "1440,900";
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+
+    if (!arg) continue;
+
+    if (arg === "--base-url") {
+      baseUrl = argv[i + 1] ?? baseUrl;
+      i += 1;
+      continue;
+    }
+
+    if (arg === "--out-dir") {
+      outDir = argv[i + 1] ?? outDir;
+      i += 1;
+      continue;
+    }
+
+    if (arg === "--viewport") {
+      viewport = argv[i + 1] ?? viewport;
+      i += 1;
+      continue;
+    }
+
+    if (/^\d+$/.test(arg)) {
+      numbers.push(Number(arg));
+      continue;
+    }
+  }
+
+  return { numbers, baseUrl, outDir, viewport };
+}
+
+function run(command, args) {
+  return new Promise((resolvePromise, rejectPromise) => {
+    const child = spawn(command, args, { stdio: "inherit" });
+    child.once("error", rejectPromise);
+    child.once("exit", (code) => {
+      if (code === 0) {
+        resolvePromise();
+        return;
+      }
+      rejectPromise(new Error(`${command} exited with code ${code}`));
+    });
+  });
+}
+
+async function main() {
+  const { numbers, baseUrl, outDir, viewport } = parseArgs(process.argv.slice(2));
+  const chosenNumbers = numbers.length > 0 ? numbers : [695, 697, 698];
+
+  await mkdir(resolve(outDir), { recursive: true });
+
+  for (const puzzleNumber of chosenNumbers) {
+    const slug = `pinpoint-answer-${puzzleNumber}`;
+    const url = `${baseUrl.replace(/\/$/, "")}/linkedin-pinpoint-answers/${slug}/`;
+    const filename = resolve(outDir, `detail-${puzzleNumber}.png`);
+
+    // Keep this as a CLI call on purpose: the repo does not rely on Playwright APIs directly.
+    await run(process.platform === "win32" ? "npx.cmd" : "npx", [
+      "--yes",
+      "playwright",
+      "screenshot",
+      "--viewport-size",
+      viewport,
+      "--full-page",
+      "--wait-for-selector",
+      "main.detail-page-main",
+      url,
+      filename,
+    ]);
+  }
+
+  console.log(`ok: screenshots saved in ${outDir}`);
+}
+
+main().catch((error) => {
+  console.error("fatal: capture-detail-screenshots failed");
+  console.error(error);
+  process.exitCode = 1;
+});
+


### PR DESCRIPTION
新增一个轻量的可视化回归辅助脚本，便于快速生成 detail 页截图基线。

用法：
- npm run dev (默认 3004)
- npm run visual:detail [695 697 698]
  可选参数：--base-url / --out-dir / --viewport

实现：
- scripts/capture-detail-screenshots.mjs 通过 npx playwright screenshot 生成全页截图
- package.json 增加 visual:detail 脚本入口
