### PR TITLE
Redirect legacy /linkedin-pinpoint shortcuts

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -132,6 +132,12 @@ const nextConfig: NextConfig = {
         destination: "/puzzles",
         permanent: true,
       },
+      // Legacy archive shortcut: /en/linkedin-pinpoint → /puzzles
+      {
+        source: `/${locale}/linkedin-pinpoint`,
+        destination: "/puzzles",
+        permanent: true,
+      },
       // Legacy connectors archive root has no dedicated page in the new site
       {
         source: `/${locale}/puzzles/connectors`,
@@ -276,6 +282,12 @@ const nextConfig: NextConfig = {
       // Legacy connectors archive root → canonical archive
       {
         source: "/puzzles/connectors",
+        destination: "/puzzles",
+        permanent: true as const,
+      },
+      // Old LinkedIn archive shortcut → canonical archive
+      {
+        source: "/linkedin-pinpoint",
         destination: "/puzzles",
         permanent: true as const,
       },

--- a/scripts/check-routing-regressions.ts
+++ b/scripts/check-routing-regressions.ts
@@ -61,8 +61,10 @@ async function checkRedirectConfig() {
   );
   assertRedirectRule(rules, "/fr/puzzles/:number(\\d+)", "/linkedin-pinpoint-answers/pinpoint-answer-:number/");
   assertRedirectRule(rules, "/de/pinpoint/:date(\\d{4}-\\d{2}-\\d{2})", "/pinpoint/:date");
+  assertRedirectRule(rules, "/en/linkedin-pinpoint", "/puzzles");
   assertRedirectRule(rules, "/puzzles/connectors", "/puzzles");
   assertRedirectRule(rules, "/feedback", "/contact-us");
+  assertRedirectRule(rules, "/linkedin-pinpoint", "/puzzles");
   assertRedirectRule(rules, "/pinpoint-answer-:number(\\d+)", "/linkedin-pinpoint-answers/pinpoint-answer-:number/");
 
   console.log("ok: next.config.ts preserves key locale and legacy redirect rules");


### PR DESCRIPTION
## What
- Add legacy shortcut redirects:
  - /linkedin-pinpoint -> /puzzles
  - /{locale}/linkedin-pinpoint -> /puzzles

## Why
- Preserve old inbound links from the previous site and avoid 404s.

## Verification
- npm run test:pinpoint-routing
- npm run typecheck
- npm run lint
