### PR TITLE
Harden legacy theme redirect lookups

### DIFF
--- a/app/(site)/puzzles/themes/[slug]/page.tsx
+++ b/app/(site)/puzzles/themes/[slug]/page.tsx
@@ -1,6 +1,6 @@
 import { notFound, permanentRedirect } from "next/navigation";
 import { routes } from "@/lib/paths/routes";
-import { getLegacyThemeRedirectSlug } from "@/lib/puzzles/data";
+import { getLegacyThemeOrConnectorRedirectSlug } from "@/lib/puzzles/data";
 
 export const revalidate = 86400;
 
@@ -10,7 +10,7 @@ export default async function LegacyThemePage({
   params: Promise<{ slug: string }>;
 }) {
   const { slug } = await params;
-  const detailSlug = await getLegacyThemeRedirectSlug(slug);
+  const detailSlug = await getLegacyThemeOrConnectorRedirectSlug(slug);
 
   if (!detailSlug) {
     notFound();

--- a/lib/puzzles/data.ts
+++ b/lib/puzzles/data.ts
@@ -14,6 +14,7 @@ export {
   getArchiveEntriesGrouped,
   getCurrentPuzzle,
   getLegacyConnectorRedirectSlug,
+  getLegacyThemeOrConnectorRedirectSlug,
   getLegacyThemeRedirectSlug,
   getNextPreview,
   getPuzzleBySlug,
@@ -22,4 +23,3 @@ export {
   getRecentEntries,
   getSitemapDetailEntries,
 } from "@/lib/puzzles/data/public";
-

--- a/lib/puzzles/data/legacy-redirects.ts
+++ b/lib/puzzles/data/legacy-redirects.ts
@@ -2,16 +2,32 @@ import { cache } from "react";
 import { fetchRegistry } from "@/lib/puzzles/data-sources";
 import { isDetailEntry } from "@/lib/puzzles/data/registry";
 
-function normalizeLegacyLookupValue(value: string): string {
+function slugifyLegacyLookupValue(value: string): string {
   return value
-    .normalize("NFKD")
-    .replace(/[\u2018\u2019\u201C\u201D]/g, "")
     .replace(/[^\x00-\x7F]/g, "")
     .toLowerCase()
     .replace(/&/g, " and ")
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/-+/g, "-")
     .replace(/^-|-$/g, "");
+}
+
+function getLegacyLookupVariants(value: string): string[] {
+  const normalizedValue = value
+    .normalize("NFKD")
+    .replace(/[\u2018\u2019]/g, "'")
+    .replace(/[\u201C\u201D]/g, '"');
+
+  return Array.from(
+    new Set([
+      slugifyLegacyLookupValue(normalizedValue.replace(/['"]/g, "")),
+      slugifyLegacyLookupValue(normalizedValue.replace(/['"]/g, "-")),
+    ]),
+  ).filter(Boolean);
+}
+
+function normalizeLegacyLookupValue(value: string): string {
+  return getLegacyLookupVariants(value)[0] ?? "";
 }
 
 function addLegacyRedirectCandidate(map: Map<string, string | null>, key: string, slug: string) {
@@ -62,7 +78,9 @@ const getLegacyThemeRedirectMap = cache(async (): Promise<Map<string, string | n
 
   for (const entry of entries) {
     for (const candidate of [entry.category, entry.mainAnswer]) {
-      addLegacyRedirectCandidate(map, normalizeLegacyLookupValue(candidate), entry.slug);
+      for (const key of getLegacyLookupVariants(candidate)) {
+        addLegacyRedirectCandidate(map, key, entry.slug);
+      }
     }
   }
 
@@ -89,8 +107,13 @@ export async function getLegacyThemeRedirectSlug(legacySlug: string): Promise<st
   return map.get(normalizeLegacyLookupValue(legacySlug)) ?? null;
 }
 
+export async function getLegacyThemeOrConnectorRedirectSlug(
+  legacySlug: string,
+): Promise<string | null> {
+  return (await getLegacyThemeRedirectSlug(legacySlug)) ?? getLegacyConnectorRedirectSlug(legacySlug);
+}
+
 export async function getLegacyConnectorRedirectSlug(legacySlug: string): Promise<string | null> {
   const map = await getLegacyConnectorRedirectMap();
   return map.get(normalizeLegacyLookupValue(legacySlug)) ?? null;
 }
-

--- a/lib/puzzles/data/public.ts
+++ b/lib/puzzles/data/public.ts
@@ -13,7 +13,11 @@ import { getLiveWorkerPuzzle } from "@/lib/puzzles/data/live-worker";
 import { fetchRegistry } from "@/lib/puzzles/data-sources";
 import { getBundledRegistryEntries } from "@/lib/puzzles/registry-bundled";
 
-export { getLegacyConnectorRedirectSlug, getLegacyThemeRedirectSlug } from "@/lib/puzzles/data/legacy-redirects";
+export {
+  getLegacyConnectorRedirectSlug,
+  getLegacyThemeOrConnectorRedirectSlug,
+  getLegacyThemeRedirectSlug,
+} from "@/lib/puzzles/data/legacy-redirects";
 
 const DETAIL_PUBLIC_FORMAL_ONLY =
   (process.env.DETAIL_PUBLIC_FORMAL_ONLY ?? "true").trim().toLowerCase() !== "false";
@@ -160,4 +164,3 @@ export async function getSitemapDetailEntries() {
   const entries = await getDetailEntries();
   return entries.map((e) => ({ slug: e.slug, updatedAt: e.updatedAt }));
 }
-

--- a/scripts/check-routing-regressions.ts
+++ b/scripts/check-routing-regressions.ts
@@ -2,6 +2,11 @@ import assert from "node:assert/strict";
 import nextConfig from "../next.config";
 import { middleware } from "../middleware";
 import { NextRequest } from "next/server";
+import {
+  getLegacyConnectorRedirectSlug,
+  getLegacyThemeOrConnectorRedirectSlug,
+  getLegacyThemeRedirectSlug,
+} from "../lib/puzzles/data/legacy-redirects";
 
 type RedirectRule = {
   source: string;
@@ -92,9 +97,30 @@ function checkMiddlewareCanonicalization() {
   console.log("ok: middleware preserves canonical slash and host normalization");
 }
 
+async function checkLegacyFamilyRedirectLookup() {
+  assert.equal(
+    await getLegacyThemeRedirectSlug("things-you-d-find-at-a-doctor-s-office"),
+    "pinpoint-answer-495",
+    "legacy theme slugs should still resolve when apostrophes were flattened into dash-separated slugs",
+  );
+  assert.equal(
+    await getLegacyThemeOrConnectorRedirectSlug("coat"),
+    "pinpoint-answer-560",
+    "legacy theme pages should fall back to connector lookups for mislabeled old links",
+  );
+  assert.equal(
+    await getLegacyConnectorRedirectSlug("coat"),
+    "pinpoint-answer-560",
+    "legacy connector slugs should keep resolving to canonical detail pages",
+  );
+
+  console.log("ok: legacy family lookups handle apostrophe slugs and theme-to-connector fallback");
+}
+
 async function main() {
   await checkRedirectConfig();
   checkMiddlewareCanonicalization();
+  await checkLegacyFamilyRedirectLookup();
   console.log("Pinpoint routing regression passed.");
 }
 


### PR DESCRIPTION
## What
- Improve legacy theme lookup normalization to handle apostrophe-heavy slugs.
- Allow /puzzles/themes/[slug] to fall back to connector redirects when old links are mislabeled.
- Add routing regression coverage for the legacy lookup behavior.

## Why
- Reduce 404s from old inbound links that were generated with different slug rules.

## Verification
- npm run test:pinpoint-routing
- npm run typecheck
- npm run lint
