### PR TITLE
Simplify middleware canonicalization

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -7,6 +7,10 @@ const PUBLIC_FILE = /\.[^/]+$/;
 const WWW_HOST = "www.pinpointanswertoday.app";
 const APEX_HOST = "pinpointanswertoday.app";
 
+// Canonical URL policy:
+// - Always normalize www -> apex host.
+// - Detail pages keep a trailing slash (SEO + stable relative asset paths).
+// - Everything else removes the trailing slash.
 function normalizePathForCanonical(pathname: string): string {
   if (pathname === "/") {
     return pathname;
@@ -23,44 +27,43 @@ function normalizePathForCanonical(pathname: string): string {
   return pathname.endsWith("/") ? pathname.slice(0, -1) : pathname;
 }
 
-export function middleware(request: NextRequest) {
-  const currentUrl = new URL(request.url);
-  const { pathname } = currentUrl;
-  const hostname = (request.headers.get("x-forwarded-host")
+function getRequestHostname(request: NextRequest, currentUrl: URL): string {
+  return (request.headers.get("x-forwarded-host")
     ?? request.headers.get("host")
     ?? currentUrl.hostname)
     .replace(/:\d+$/, "");
+}
+
+function shouldBypassCanonicalization(pathname: string): boolean {
+  return (
+    pathname === "/" ||
+    pathname.startsWith("/api") ||
+    pathname.startsWith("/_next") ||
+    PUBLIC_FILE.test(pathname)
+  );
+}
+
+export function middleware(request: NextRequest) {
+  const currentUrl = new URL(request.url);
+  const { pathname } = currentUrl;
+  const hostname = getRequestHostname(request, currentUrl);
 
   if (hostname === WWW_HOST) {
     const url = new URL(request.url);
     url.hostname = APEX_HOST;
     url.pathname = normalizePathForCanonical(pathname);
-    return Response.redirect(url, 308);
+    return NextResponse.redirect(url, 308);
   }
 
-  if (
-    pathname === "/" ||
-    pathname.startsWith("/api") ||
-    pathname.startsWith("/_next") ||
-    PUBLIC_FILE.test(pathname)
-  ) {
+  if (shouldBypassCanonicalization(pathname)) {
     return NextResponse.next();
   }
 
-  if (DETAIL_WITHOUT_SLASH.test(pathname)) {
+  const canonicalPathname = normalizePathForCanonical(pathname);
+  if (canonicalPathname !== pathname) {
     const url = new URL(request.url);
-    url.pathname = `${pathname}/`;
-    return Response.redirect(url, 308);
-  }
-
-  if (DETAIL_WITH_SLASH.test(pathname)) {
-    return NextResponse.next();
-  }
-
-  if (pathname.endsWith("/")) {
-    const url = new URL(request.url);
-    url.pathname = pathname.slice(0, -1);
-    return Response.redirect(url, 308);
+    url.pathname = canonicalPathname;
+    return NextResponse.redirect(url, 308);
   }
 
   return NextResponse.next();


### PR DESCRIPTION
## What
- Refactor middleware canonical URL normalization to compute the canonical pathname once and redirect from a single decision point.
- Keep behavior the same:
  - www -> apex
  - detail pages keep trailing slash
  - all other pages remove trailing slash

## Why
- Lower cognitive load and reduce the chance of future bugs when routes expand.

## Verification
- npm run test:pinpoint-routing
- npm run typecheck
- npm run lint
