### PR TITLE
Add Worker summary watchdog

### DIFF
--- a/worker/README.md
+++ b/worker/README.md
@@ -45,6 +45,7 @@ wrangler deploy --env staging --name pinpoint-worker-staging  # 受控演练（�
 | `SITE_API_TOKEN` | 调 `/api/admin/generate-draft` 的 Bearer token（enrichment/i18n 用） | ❌ | ✅ |
 | `GITHUB_TOKEN_NEW_SITE` | GitHub fine-grained PAT，`contents:write` on `elng12/pinpoint-answer-today-new` | ❌ | ✅ |
 | `NEW_SITE_REVALIDATE_SECRET` | 必须与 Vercel `REVALIDATE_SECRET` 值完全一致；仅正式 `main` 分支需要 | ❌ | staging 可选 / 生产必需 |
+| `NEW_SITE_SUMMARY_WATCHDOG_ENABLED` | 可选；默认开启。主抓取窗口后校验正式站 summary，未更新时提前飞书告警 | ❌ | 可选 |
 | `FEISHU_WEBHOOK_URL` | 飞书告警 webhook URL | ❌ | ✅ |
 | `FALLBACK_WEBHOOK_SECRET` | Worker 调站点 `/api/fallback/worker-pinpoint` 的 HMAC 签名密钥 | ❌ | ✅ |
 | `ADMIN_SECRET` | 受保护管理接口的密钥 | 可选 | ✅ |
@@ -95,6 +96,13 @@ npm run worker:refresh-cookie
 
 - 上面三个命令都会读取仓库根目录的 `.env.local`（需要包含 `ADMIN_PASSPHRASE`），不会打印 secret 或 cookie 内容
 - 如果你只想更新某一个环境的 cookie：`node scripts/worker-ops.mjs refresh-cookie --targets staging`
+
+生产 Worker 还会在主抓取窗口后增加一次自动校验：
+
+- 当前 production cron 覆盖北京时间夏令时 `15:01 / 15:03 / 15:07 / 15:10 / 15:15 / 15:20 / 15:25`
+- `:25` 这次会检查正式站 `/api/puzzles/summary` 是否已经显示当天题
+- 如果 Worker 已抓到当天答案，但正式站 summary 仍停在旧日期，会先尝试 revalidate；仍失败则立即飞书告警
+- 告警通过 KV 的 `notify:site-summary-watchdog:<date>` 去重，避免同一天重复推送
 
 ### `graphql 401` 优先修复顺序
 
@@ -288,7 +296,7 @@ curl "https://pinpoint-worker.2296744453m.workers.dev/admin/test-fallback?secret
 | 配置项 | 值 |
 |---|---|
 | KV namespace | `PP_DATA`，namespace ID `2689a48e886548a3acbe8fa9ede4e3f6` |
-| Cron | `1,3,7,10,15,20 7,8 * * *`（UTC；覆盖夏令时/冬令时，Worker 会自动跳过无效窗口），即北京时间夏令时 `15:01 / 15:03 / 15:07 / 15:10 / 15:15 / 15:20`，冬令时 `16:01 / 16:03 / 16:07 / 16:10 / 16:15 / 16:20` |
+| Cron | `1,3,7,10,15,20,25 7,8 * * *`（UTC；覆盖夏令时/冬令时，Worker 会自动跳过无效窗口），即北京时间夏令时 `15:01 / 15:03 / 15:07 / 15:10 / 15:15 / 15:20 / 15:25`，冬令时 `16:01 / 16:03 / 16:07 / 16:10 / 16:15 / 16:20 / 16:25` |
 | staging Cron | 已显式关闭：`[env.staging.triggers].crons = []` |
 | 目标仓库 | `elng12/pinpoint-answer-today-new`，分支 `main` |
 | revalidate 地址 | `https://pinpointanswertoday.app/api/revalidate` |
@@ -360,7 +368,7 @@ npm run test:pinpoint-regression:core
    - 如果同一题在几分钟内反复出现 `add answer data` / `mark live` 对应部署，说明仍有重复写入
 
 2. Worker Cron 触发
-   - 当前生产窗口：北京时间夏令时 `15:01 / 15:03 / 15:07 / 15:10 / 15:15 / 15:20`，冬令时 `16:01 / 16:03 / 16:07 / 16:10 / 16:15 / 16:20`
+   - 当前生产窗口：北京时间夏令时 `15:01 / 15:03 / 15:07 / 15:10 / 15:15 / 15:20 / 15:25`，冬令时 `16:01 / 16:03 / 16:07 / 16:10 / 16:15 / 16:20 / 16:25`
    - 正常预期：cron 可以重复触发，但不会因为同样内容反复提交 GitHub
 
 3. Worker 日志关键词

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -53,6 +53,7 @@ export interface Env {
   NEW_SITE_URL?: string;                 // e.g. https://pinpointanswertoday.app (new site)
   NEW_SITE_REVALIDATE_SECRET?: string;   // matches REVALIDATE_SECRET on Vercel
   NEW_SITE_LIVE_REFRESH_ENABLED?: string; // optional: set "true" to allow worker-triggered live refresh fallback
+  NEW_SITE_SUMMARY_WATCHDOG_ENABLED?: string; // optional: set "false" to disable post-window site summary alerts
 }
 
 type Answer = { rank: number; word: string; confidence?: number };
@@ -252,6 +253,7 @@ const cronHeartbeatLatestKey = "monitor:cron:last";
 const cronHeartbeatDayKeyOf = (d: string) => `monitor:cron:${d}`;
 const cronHeartbeatDayRunsKeyOf = (d: string) => `monitor:cron:${d}:runs`;
 const cronHeartbeatRunKeyOf = (runId: string) => `monitor:cron:run:${runId}`;
+const siteSummaryWatchdogNotifiedKeyOf = (d: string) => `notify:site-summary-watchdog:${d}`;
 const cronHeartbeatRunsLimit = 20;
 const nonPublicDetailStateAlertThresholdMs = 15 * 60 * 1000;
 
@@ -635,6 +637,19 @@ function formatDateInTimeZone(date: Date, timeZone: string): string {
 
 function getBeijingTodayDate(now = new Date()): string {
   return formatDateInTimeZone(now, BEIJING_TIME_ZONE);
+}
+
+function formatBeijingTime(date = new Date()): string {
+  return new Intl.DateTimeFormat("zh-CN", {
+    timeZone: BEIJING_TIME_ZONE,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  }).format(date);
 }
 
 function normalizedWordSignature(words: string[]): string {
@@ -3522,6 +3537,114 @@ async function maybeRefreshNewSiteLiveFallback(
   };
 }
 
+type SiteSummaryStatus = {
+  ok: boolean;
+  status?: number;
+  latestNumber?: number;
+  latestIso?: string;
+  error?: string;
+};
+
+async function fetchSiteSummaryStatus(env: Env, date: string): Promise<SiteSummaryStatus> {
+  const publicSiteBaseUrl = getPublicSiteBaseUrl(env);
+  const url = `${publicSiteBaseUrl}/api/puzzles/summary?cb=worker-watchdog-${Date.now()}`;
+  try {
+    const res = await fetchWithTimeout(
+      url,
+      {
+        method: "GET",
+        headers: {
+          "cache-control": "no-cache",
+          pragma: "no-cache",
+        },
+      },
+      12_000,
+    );
+    const text = await res.text();
+    if (!res.ok) {
+      return { ok: false, status: res.status, error: text.slice(0, 240) || `HTTP ${res.status}` };
+    }
+
+    let parsed: JsonRecord | null = null;
+    try {
+      parsed = JSON.parse(text) as JsonRecord;
+    } catch {
+      return { ok: false, status: res.status, error: "summary returned non-json response" };
+    }
+
+    const latest = asRecord(parsed?.latest);
+    const latestIso = typeof latest?.isoPublishedAt === "string" ? latest.isoPublishedAt.trim() : "";
+    const latestNumberRaw = Number(latest?.puzzleNumber);
+    return {
+      ok: latestIso.startsWith(`${date}T`),
+      status: res.status,
+      latestNumber: Number.isFinite(latestNumberRaw) ? latestNumberRaw : undefined,
+      latestIso,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : String(error || "unknown summary check error"),
+    };
+  }
+}
+
+async function checkAndMarkSiteSummaryWatchdogNotified(env: Env, date: string): Promise<boolean> {
+  try {
+    const key = siteSummaryWatchdogNotifiedKeyOf(date);
+    const existing = await env.PP_DATA.get(key);
+    if (existing !== null) return true;
+    await env.PP_DATA.put(key, new Date().toISOString(), { expirationTtl: 172800 });
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+async function maybeNotifySiteSummaryWatchdog(
+  env: Env,
+  date: string,
+  doc: Doc,
+  heartbeat: CronHeartbeat,
+  cron: string | undefined,
+): Promise<void> {
+  if (!envFlag(env.NEW_SITE_SUMMARY_WATCHDOG_ENABLED, true)) return;
+  if (!hasNotifyWebhook(env)) return;
+  if (!String(cron || "").includes(":25 ")) return;
+  if (heartbeat.triggerKind !== "scheduled" || heartbeat.outcome === "failed") return;
+
+  const publicSiteBaseUrl = getPublicSiteBaseUrl(env);
+  const puzzleNumber = inferPuzzleNumber((doc as unknown as { puzzleNumber?: unknown }).puzzleNumber, date);
+  let summary = await fetchSiteSummaryStatus(env, date);
+  if (summary.ok) return;
+
+  if (hasNewSiteRevalidateConfig(env)) {
+    await triggerNewSiteRevalidate(env, puzzleNumber);
+    await sleep(5000);
+    summary = await fetchSiteSummaryStatus(env, date);
+    if (summary.ok) return;
+  }
+
+  const alreadyNotified = await checkAndMarkSiteSummaryWatchdogNotified(env, date);
+  if (alreadyNotified) return;
+
+  const words = doc.answers.map((a) => a.word).slice(0, 5).join(" | ");
+  await notifyCron(env, "❌ Worker 已抓到答案，但正式站仍未更新", [
+    `日期: ${date}`,
+    `检查时间: ${formatBeijingTime()} 北京时间`,
+    `触发: Cloudflare Worker ${cron || "scheduled"} 主窗口后校验`,
+    `抓取来源: ${doc.source}`,
+    `主题: ${doc.mainAnswer || doc.theme || "（空）"}`,
+    `答案: ${words}`,
+    `预期谜题: #${puzzleNumber}`,
+    `正式站 latest: #${summary.latestNumber ?? "未知"} ${summary.latestIso || "（空）"}`,
+    `原因: ${summary.error || "summary 日期不是今天"}`,
+    `健康检查: ${publicSiteBaseUrl}/api/health`,
+    `今日接口: ${publicSiteBaseUrl}/api/pinpoint/today`,
+    `说明: 这是 15:25 左右的早期发布校验，不再等 GitHub Actions 备份任务延迟触发。`,
+  ]);
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 
 async function enrichPublishToSite(
@@ -6067,6 +6190,7 @@ export default {
       heartbeat.durationMs = durationMs;
       heartbeat.endedAt = new Date().toISOString();
       await persistCronHeartbeat(env, heartbeat);
+      await maybeNotifySiteSummaryWatchdog(env, date, doc, heartbeat, controller.cron);
       const alreadyNotified = await checkAndMarkCronSuccessNotified(env, date);
       if (!alreadyNotified) {
         await notifyCron(env, "✅ Worker 定时抓取成功", [

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -20,7 +20,7 @@ binding = "AI"
 # Worker code auto-skips the inactive hour, so this follows LinkedIn's reset.
 # ---------------------------------------------------------------------------
 [triggers]
-crons = ["1,3,7,10,15,20 7,8 * * *"]
+crons = ["1,3,7,10,15,20,25 7,8 * * *"]
 
 # ---------------------------------------------------------------------------
 # Shared vars (non-secret).  Secrets are set via `wrangler secret put`.


### PR DESCRIPTION
## Summary\n- Add a :25 Worker cron pass after the primary fetch window\n- Check the production site summary after the Worker has fetched today's answer\n- Revalidate once, then send a deduped early Feishu/Slack alert if the formal site is still stale\n- Document the watchdog and updated production cron window\n\n## Verification\n- npm run typecheck (worker)\n- npm run deploy:dry (worker)\n- Deployed production Worker version 00053830-76e9-451b-86f0-20069e63a0fe