### PR TITLE
Phase 0 SEO integrity fixes

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -9,12 +9,30 @@ function withTrailingSlash(path: string): string {
   return path.endsWith("/") ? path : `${path}/`;
 }
 
+function getNewestDate(values: Array<Date | string | null | undefined>): Date | null {
+  const dates = values
+    .map((value) => (value instanceof Date ? value : value ? new Date(value) : null))
+    .filter((value): value is Date => value instanceof Date && !Number.isNaN(value.getTime()))
+    .sort((left, right) => right.getTime() - left.getTime());
+
+  return dates[0] ?? null;
+}
+
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3004";
+  const detailItems = getSitemapDetailEntries();
+  const newestDetailDate = getNewestDate(detailItems.map((item) => item.updatedAt));
+  const newestPreviewDate = getStaticRouteLastModified(routes.preview);
+  const dynamicIndexLastModified = newestDetailDate ?? getStaticRouteLastModified(routes.home);
+
   const primaryRoutes = [
-    { path: routes.home, lastModified: getStaticRouteLastModified(routes.home), priority: 1.0 },
-    { path: routes.archive, lastModified: getStaticRouteLastModified(routes.archive), priority: 0.9 },
-    { path: routes.preview, lastModified: getStaticRouteLastModified(routes.preview), priority: 0.8 },
+    { path: routes.home, lastModified: dynamicIndexLastModified, priority: 1.0 },
+    { path: routes.archive, lastModified: dynamicIndexLastModified, priority: 0.9 },
+    {
+      path: routes.preview,
+      lastModified: getNewestDate([newestPreviewDate, dynamicIndexLastModified]) ?? newestPreviewDate,
+      priority: 0.8,
+    },
     { path: routes.about, lastModified: getStaticRouteLastModified(routes.about), priority: 0.6 },
   ];
 
@@ -37,7 +55,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     })),
   ];
 
-  const detailItems = getSitemapDetailEntries();
   const detailEntries = detailItems.map((item, index) => ({
     url: `${siteUrl}${withTrailingSlash(routes.detail(item.slug))}`,
     lastModified: new Date(item.updatedAt),

--- a/data/puzzles/registry.json
+++ b/data/puzzles/registry.json
@@ -228,6 +228,63 @@
     "updatedAt": "2026-05-09T07:02:02.295Z"
   },
   {
+    "puzzleNumber": 737,
+    "slug": "pinpoint-answer-737",
+    "publishDate": "2026-05-07",
+    "status": "archived",
+    "detailState": "published",
+    "clues": [
+      "Grip",
+      "Best Boy",
+      "Costumer",
+      "Director",
+      "Actor"
+    ],
+    "mainAnswer": "Jobs on a film set",
+    "category": "Jobs on a film set",
+    "difficultyLevel": "Moderate",
+    "shortSummary": "At first glance, Grip, Best Boy, Costumer do not look like one clean set. The solve only tightens once a later clue makes the shared category much harder to miss.",
+    "updatedAt": "2026-05-07T07:01:58.344Z"
+  },
+  {
+    "puzzleNumber": 736,
+    "slug": "pinpoint-answer-736",
+    "publishDate": "2026-05-06",
+    "status": "archived",
+    "detailState": "published",
+    "clues": [
+      "Hamilton",
+      "Sofia",
+      "Lima",
+      "Athens",
+      "Mexico City"
+    ],
+    "mainAnswer": "Capital cities",
+    "category": "Capital cities",
+    "difficultyLevel": "Moderate",
+    "shortSummary": "At first glance, Hamilton, Sofia, Lima do not look like one clean set. The solve only tightens once a later clue makes the shared category much harder to miss.",
+    "updatedAt": "2026-05-07T07:01:43.931Z"
+  },
+  {
+    "puzzleNumber": 735,
+    "slug": "pinpoint-answer-735",
+    "publishDate": "2026-05-05",
+    "status": "archived",
+    "detailState": "published",
+    "clues": [
+      "Vocal",
+      "Spinal",
+      "Extension",
+      "Rip",
+      "Bungee"
+    ],
+    "mainAnswer": "Types of cords",
+    "category": "Types of cords",
+    "difficultyLevel": "Moderate",
+    "shortSummary": "At first glance, this puzzle feels scattered. \"Vocal\" and \"Spinal\" seem unrelated to \"Rip\" or \"Bungee.\" But a hidden connection will soon emerge.",
+    "updatedAt": "2026-05-06T07:01:42.573Z"
+  },
+  {
     "puzzleNumber": 734,
     "slug": "pinpoint-answer-734",
     "publishDate": "2026-05-04",

--- a/scripts/validate-data.ts
+++ b/scripts/validate-data.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { readFile } from "node:fs/promises";
+import { readdir, readFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 import { validateEvidenceContract } from "../lib/puzzles/evidence-contract.shared.mjs";
@@ -64,6 +64,12 @@ const genericSpoilerHintPatterns = [
   /\bLook for the cleaner category fit instead of the first broad topic\b/i,
   /\bmakes the category specific enough to test instead of staying broad\b/i,
 ];
+const publicDetailStates = new Set(["published", "fallback_full"]);
+const publicRegistryStatuses = new Set(["live", "archived"]);
+const recentContinuityWindow = 30;
+const allowedRecentContinuityGaps = new Map([
+  // [750, "Documented reason for an intentional public numbering gap"],
+]);
 
 function countWords(value) {
   return value.trim().split(/\s+/).filter(Boolean).length;
@@ -300,6 +306,81 @@ function requiresPhase1StructuredValidation(entry, detail) {
   );
 }
 
+function resolveRegistryDetailState(entry) {
+  if (entry.detailState) {
+    return entry.detailState;
+  }
+
+  return entry.status === "draft" || entry.status === "preview" ? "draft" : "published";
+}
+
+function isPublicRegistryEntry(entry) {
+  return (
+    publicRegistryStatuses.has(entry.status) &&
+    publicDetailStates.has(resolveRegistryDetailState(entry)) &&
+    Boolean(entry.mainAnswer) &&
+    Boolean(entry.category)
+  );
+}
+
+async function readPublicDetailFileSlugs(dataDir) {
+  const fileNames = await readdir(dataDir);
+  const publicSlugs = [];
+
+  for (const fileName of fileNames) {
+    if (!/^pinpoint-answer-\d+\.json$/.test(fileName)) {
+      continue;
+    }
+
+    const rawDetail = await readFile(resolve(dataDir, fileName), "utf8");
+    const detail = puzzleDetailContentSchema.parse(JSON.parse(rawDetail));
+    const detailState = detail.detailState || "published";
+
+    if (publicDetailStates.has(detailState)) {
+      publicSlugs.push(detail.slug || fileName.replace(/\.json$/, ""));
+    }
+  }
+
+  return publicSlugs.sort();
+}
+
+function assertPublicDetailsAreRegistered(publicDetailSlugs, registrySlugs) {
+  const missing = publicDetailSlugs.filter((slug) => !registrySlugs.has(slug));
+
+  if (missing.length > 0) {
+    throw new Error(
+      `Public detail JSON missing from registry: ${missing.slice(0, 20).join(", ")}${missing.length > 20 ? `, ... (${missing.length} total)` : ""}`,
+    );
+  }
+}
+
+function assertRecentPublicRegistryContinuity(registry) {
+  const publicNumbers = registry
+    .filter(isPublicRegistryEntry)
+    .map((entry) => entry.puzzleNumber)
+    .filter((value) => Number.isInteger(value))
+    .sort((left, right) => right - left);
+  const latestNumber = publicNumbers[0];
+
+  if (!latestNumber) {
+    throw new Error("Expected at least one public registry entry for continuity validation.");
+  }
+
+  const publicNumberSet = new Set(publicNumbers);
+  const missing = [];
+  for (let number = latestNumber; number > latestNumber - recentContinuityWindow; number -= 1) {
+    if (!publicNumberSet.has(number) && !allowedRecentContinuityGaps.has(number)) {
+      missing.push(number);
+    }
+  }
+
+  if (missing.length > 0) {
+    throw new Error(
+      `Recent public registry puzzle numbers must be continuous for the latest ${recentContinuityWindow}; missing ${missing.join(", ")}. If a gap is intentional, add it to allowedRecentContinuityGaps with a reason.`,
+    );
+  }
+}
+
 function validateDetailContent(entry, detail) {
   const detailAnswer = typeof detail.answer === "string" ? detail.answer : "";
   const articleBlocks = Array.isArray(detail.articleBlocks) ? detail.articleBlocks : [];
@@ -470,9 +551,11 @@ async function main() {
   const registryPath = resolve(dataDir, "registry.json");
   const rawRegistry = await readFile(registryPath, "utf8");
   const registry = registrySchema.parse(JSON.parse(rawRegistry));
+  const publicDetailSlugs = await readPublicDetailFileSlugs(dataDir);
 
   const numbers = new Set();
   const slugs = new Set();
+  const publicRegistrySlugs = new Set();
   const dates = new Set();
   let liveCount = 0;
   let previewCount = 0;
@@ -498,6 +581,9 @@ async function main() {
     numbers.add(entry.puzzleNumber);
     slugs.add(entry.slug);
     dates.add(entry.publishDate);
+    if (isPublicRegistryEntry(entry)) {
+      publicRegistrySlugs.add(entry.slug);
+    }
 
     if (entry.status === "live") {
       liveCount += 1;
@@ -531,6 +617,9 @@ async function main() {
   if (previewCount > 1) {
     throw new Error(`Expected at most one preview puzzle, received ${previewCount}`);
   }
+
+  assertPublicDetailsAreRegistered(publicDetailSlugs, publicRegistrySlugs);
+  assertRecentPublicRegistryContinuity(registry);
 
   assertPublishedContractBacklogLimits();
   assertNoRepeatedPublishedLessonTitles();


### PR DESCRIPTION
## What changed\n- Restored registry entries for #735-#737\n- Updated sitemap lastmod to follow newest public detail activity for the primary public routes\n- Tightened validate:data guardrails so public detail JSON must map to public registry entries, and added an explicit continuity gap allowlist\n\n## Verification\n- npm run validate:data\n- npm run typecheck\n- git diff --check\n- npm run test:pinpoint-guardrails\n\n## Scope\nThis PR is limited to Phase 0 production integrity fixes only. It does not include homepage layout/title/schema/content changes.