### PR TITLE
Harden admin and outbound API security

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,9 +4,19 @@ NEXT_PUBLIC_TWITTER_HANDLE=
 NEXT_PUBLIC_ENABLE_GA=false
 NEXT_PUBLIC_GA_ID=
 
+# Admin API auth tokens
+# Production should set API_SECRET_TOKEN and/or ADMIN_PASSPHRASE.
+# Local development may set DEV_ADMIN_TOKEN; do not use the placeholder value.
+API_SECRET_TOKEN=change-me
+ADMIN_PASSPHRASE=change-me
+DEV_ADMIN_TOKEN=change-me-to-a-random-string
+
 # ISR on-demand revalidation (generate a random string, e.g. openssl rand -hex 32)
 # Send it via Authorization: Bearer <secret> or x-revalidate-secret.
 REVALIDATE_SECRET=
+
+# IndexNow submission key
+INDEXNOW_KEY=change-me
 
 # Contact form delivery webhook
 # Preferred: a dedicated JSON webhook endpoint that persists or forwards the feedback.

--- a/app/api/admin/generate-draft/route.ts
+++ b/app/api/admin/generate-draft/route.ts
@@ -21,12 +21,8 @@ import {
   validateSlotContract,
   type SlotContractInput,
 } from "@/lib/puzzles/slot-contract";
-
-const ADMIN_TOKENS = [
-  process.env.API_SECRET_TOKEN,
-  process.env.ADMIN_PASSPHRASE,
-  process.env.NODE_ENV === "production" ? null : "admin-secret-dev",
-].filter(Boolean);
+import { authenticateAdmin } from "@/lib/site/admin-auth";
+import { enforceAdminRateLimit } from "@/lib/site/admin-rate-limit";
 
 const DISALLOWED_LANGUAGE_PATTERN = /[\u3400-\u9FFF\uF900-\uFAFF\u3040-\u30FF\uAC00-\uD7AF]/;
 const LOCALIZE_LABELS: Record<string, string> = {
@@ -622,11 +618,14 @@ function autoFixDraft(puzzleData: PuzzleDataForAI, ai: unknown) {
 
 export async function POST(req: NextRequest) {
   try {
+    const rateLimited = enforceAdminRateLimit(req);
+    if (rateLimited) return rateLimited;
+
     const authHeader = req.headers.get("authorization");
     const adminPassHeader = req.headers.get("x-admin-pass");
     const token = authHeader?.replace("Bearer ", "") || adminPassHeader;
 
-    if (!token || !ADMIN_TOKENS.includes(token)) {
+    if (!token || !authenticateAdmin(token)) {
       return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
     }
 

--- a/app/api/admin/validate-draft/route.ts
+++ b/app/api/admin/validate-draft/route.ts
@@ -9,12 +9,8 @@ import {
   validateDraftLanguage,
   validateDraftStructure,
 } from "@/lib/puzzles/draft-validator";
-
-const ADMIN_TOKENS = [
-  process.env.API_SECRET_TOKEN,
-  process.env.ADMIN_PASSPHRASE,
-  process.env.NODE_ENV === "production" ? null : "admin-secret-dev",
-].filter(Boolean);
+import { authenticateAdmin } from "@/lib/site/admin-auth";
+import { enforceAdminRateLimit } from "@/lib/site/admin-rate-limit";
 
 function asRecord(value: unknown): Record<string, unknown> | null {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
@@ -68,11 +64,14 @@ function hasMinimumSlotsForNormalization(candidate: unknown): boolean {
  */
 export async function POST(req: NextRequest) {
   try {
+    const rateLimited = enforceAdminRateLimit(req);
+    if (rateLimited) return rateLimited;
+
     const authHeader = req.headers.get("authorization");
     const adminPassHeader = req.headers.get("x-admin-pass");
     const token = authHeader?.replace("Bearer ", "") || adminPassHeader;
 
-    if (!token || !ADMIN_TOKENS.includes(token)) {
+    if (!token || !authenticateAdmin(token)) {
       return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
     }
 

--- a/app/api/fallback/worker-pinpoint/route.ts
+++ b/app/api/fallback/worker-pinpoint/route.ts
@@ -5,6 +5,8 @@ import {
   normalizeWorkerFallbackMode,
   type WorkerFallbackMode,
 } from "@/lib/puzzles/worker-fallback";
+import { buildNoStoreHeaders } from "@/lib/api-headers";
+import { safeEqual } from "@/lib/site/admin-auth";
 
 type WorkerRequestBody = {
   date?: unknown;
@@ -20,19 +22,12 @@ function normalizeRequestedDate(input: unknown): string | null {
   return /^\d{4}-\d{2}-\d{2}$/.test(value) ? value : null;
 }
 
-function buildNoStoreHeaders(extra?: HeadersInit): HeadersInit {
-  return {
-    "Cache-Control": "no-store",
-    ...extra,
-  };
-}
-
 export async function POST(req: Request) {
   try {
     const expectedSecret = String(process.env.FALLBACK_WEBHOOK_SECRET || "").trim();
     const providedSecret = String(req.headers.get("x-webhook-secret") || "").trim();
 
-    if (expectedSecret && providedSecret !== expectedSecret) {
+    if (expectedSecret && !safeEqual(providedSecret, expectedSecret)) {
       return new NextResponse("unauthorized", { status: 401 });
     }
 

--- a/app/api/feedback/route.ts
+++ b/app/api/feedback/route.ts
@@ -1,34 +1,18 @@
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
+import { createInMemoryRateLimiter, readPositiveIntegerEnv } from "@/lib/rate-limit";
+import { parseAndValidateUrl, validateUrlAgainstAllowlist } from "@/lib/security/url-allowlist";
 import { feedbackWebhookSource, supportEmail } from "@/lib/site/config";
 
 export const runtime = "nodejs";
 
-function readPositiveIntegerEnv(name: string, fallback: number): number {
-  const raw = process.env[name]?.trim();
-  if (!raw) {
-    return fallback;
-  }
-
-  const parsed = Number.parseInt(raw, 10);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
-}
-
 const feedbackRateLimitWindowMs = readPositiveIntegerEnv("FEEDBACK_RATE_LIMIT_WINDOW_MS", 10 * 60 * 1000);
 const feedbackRateLimitMaxRequests = readPositiveIntegerEnv("FEEDBACK_RATE_LIMIT_MAX", 5);
-
-type RateLimitBucket = {
-  count: number;
-  resetAt: number;
-};
-
-const globalForRateLimit = globalThis as typeof globalThis & {
-  __feedbackRateLimitStore?: Map<string, RateLimitBucket>;
-};
-
-const feedbackRateLimitStore =
-  globalForRateLimit.__feedbackRateLimitStore
-  ?? (globalForRateLimit.__feedbackRateLimitStore = new Map<string, RateLimitBucket>());
+const getRateLimitRetryAfter = createInMemoryRateLimiter({
+  storeKey: "feedback",
+  windowMs: feedbackRateLimitWindowMs,
+  maxRequests: feedbackRateLimitMaxRequests,
+});
 
 const feedbackSchema = z.object({
   name: z.string().trim().max(80).optional().default(""),
@@ -67,50 +51,6 @@ function hasInvalidOrigin(req: NextRequest): boolean {
   }
 }
 
-function getFeedbackRateLimitKey(req: NextRequest): string {
-  const cfConnectingIp = req.headers.get("cf-connecting-ip")?.trim();
-  const forwardedFor = req.headers.get("x-forwarded-for")?.split(",")[0]?.trim();
-  const realIp = req.headers.get("x-real-ip")?.trim();
-  const userAgent = req.headers.get("user-agent")?.trim() || "unknown";
-  return `${cfConnectingIp || forwardedFor || realIp || "unknown"}::${userAgent}`;
-}
-
-function getRateLimitRetryAfter(req: NextRequest): number | null {
-  const now = Date.now();
-
-  for (const [key, bucket] of feedbackRateLimitStore.entries()) {
-    if (bucket.resetAt <= now) {
-      feedbackRateLimitStore.delete(key);
-    }
-  }
-
-  const rateLimitKey = getFeedbackRateLimitKey(req);
-  const currentBucket = feedbackRateLimitStore.get(rateLimitKey);
-  if (!currentBucket) {
-    feedbackRateLimitStore.set(rateLimitKey, {
-      count: 1,
-      resetAt: now + feedbackRateLimitWindowMs,
-    });
-    return null;
-  }
-
-  if (currentBucket.resetAt <= now) {
-    feedbackRateLimitStore.set(rateLimitKey, {
-      count: 1,
-      resetAt: now + feedbackRateLimitWindowMs,
-    });
-    return null;
-  }
-
-  if (currentBucket.count >= feedbackRateLimitMaxRequests) {
-    return Math.max(1, Math.ceil((currentBucket.resetAt - now) / 1000));
-  }
-
-  currentBucket.count += 1;
-  feedbackRateLimitStore.set(rateLimitKey, currentBucket);
-  return null;
-}
-
 function isFeishuWebhook(url: string): boolean {
   const normalized = url.toLowerCase();
   return normalized.includes("feishu.cn") || normalized.includes("lark");
@@ -118,6 +58,79 @@ function isFeishuWebhook(url: string): boolean {
 
 function isSlackWebhook(url: string): boolean {
   return url.toLowerCase().includes("hooks.slack.com");
+}
+
+function normalizeGenericWebhookUrl(raw: string): string {
+  return parseAndValidateUrl(
+    raw,
+    {
+      allowedSchemes: ["https:"],
+      allowAnyHost: true,
+      allowLocalhost: process.env.NODE_ENV !== "production",
+    },
+    "FEEDBACK_WEBHOOK_URL",
+  ).toString();
+}
+
+function normalizeFeishuWebhookUrl(raw: string): string {
+  const url = parseAndValidateUrl(
+    raw,
+    {
+      allowedSchemes: ["https:"],
+      allowedHostSuffixes: [".feishu.cn", ".larksuite.com", ".larksuite.com.cn"],
+      allowLocalhost: process.env.NODE_ENV !== "production",
+    },
+    "FEISHU_WEBHOOK_URL",
+  );
+  return url.toString();
+}
+
+function normalizeSlackWebhookUrl(raw: string): string {
+  const url = parseAndValidateUrl(
+    raw,
+    {
+      allowedSchemes: ["https:"],
+      allowedHosts: ["hooks.slack.com"],
+      allowLocalhost: process.env.NODE_ENV !== "production",
+    },
+    "SLACK_WEBHOOK_URL",
+  );
+  return url.toString();
+}
+
+function normalizeAlertWebhookUrl(raw: string): string {
+  const url = parseAndValidateUrl(
+    raw,
+    {
+      allowedSchemes: ["https:"],
+      allowAnyHost: true,
+      allowLocalhost: process.env.NODE_ENV !== "production",
+    },
+    "ALERT_WEBHOOK_URL",
+  );
+  if (isFeishuWebhook(url.toString())) {
+    validateUrlAgainstAllowlist(
+      url,
+      {
+        allowedSchemes: ["https:"],
+        allowedHostSuffixes: [".feishu.cn", ".larksuite.com", ".larksuite.com.cn"],
+        allowLocalhost: process.env.NODE_ENV !== "production",
+      },
+      "ALERT_WEBHOOK_URL",
+    );
+  }
+  if (isSlackWebhook(url.toString())) {
+    validateUrlAgainstAllowlist(
+      url,
+      {
+        allowedSchemes: ["https:"],
+        allowedHosts: ["hooks.slack.com"],
+        allowLocalhost: process.env.NODE_ENV !== "production",
+      },
+      "ALERT_WEBHOOK_URL",
+    );
+  }
+  return url.toString();
 }
 
 function buildFeedbackLines(payload: {
@@ -238,14 +251,14 @@ async function sendFeedbackWebhook(payload: {
   const webhookUrl = process.env.FEEDBACK_WEBHOOK_URL?.trim();
   const secret = process.env.FEEDBACK_WEBHOOK_SECRET?.trim();
   if (webhookUrl) {
-    await postJsonWebhook(webhookUrl, payload, secret);
+    await postJsonWebhook(normalizeGenericWebhookUrl(webhookUrl), payload, secret);
     return;
   }
 
   const candidateUrls = [
-    process.env.FEISHU_WEBHOOK_URL?.trim(),
-    process.env.ALERT_WEBHOOK_URL?.trim(),
-    process.env.SLACK_WEBHOOK_URL?.trim(),
+    process.env.FEISHU_WEBHOOK_URL?.trim() ? normalizeFeishuWebhookUrl(process.env.FEISHU_WEBHOOK_URL.trim()) : null,
+    process.env.ALERT_WEBHOOK_URL?.trim() ? normalizeAlertWebhookUrl(process.env.ALERT_WEBHOOK_URL.trim()) : null,
+    process.env.SLACK_WEBHOOK_URL?.trim() ? normalizeSlackWebhookUrl(process.env.SLACK_WEBHOOK_URL.trim()) : null,
   ].filter(Boolean) as string[];
 
   const deliveries: Promise<void>[] = [];

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,4 +1,6 @@
 import { NextResponse } from "next/server";
+import { buildCachedHeaders, buildNoStoreHeaders } from "@/lib/api-headers";
+import { parseAndValidateUrl } from "@/lib/security/url-allowlist";
 
 export const runtime = "nodejs";
 export const revalidate = 60;
@@ -8,24 +10,19 @@ const DEFAULT_WORKER_HEALTH_URL = "https://pinpoint-worker.2296744453m.workers.d
 function resolveWorkerHealthUrl(): URL {
   const raw = String(process.env.PINPOINT_WORKER_HEALTH_URL || DEFAULT_WORKER_HEALTH_URL).trim();
   try {
-    return new URL(raw);
+    return parseAndValidateUrl(
+      raw,
+      {
+        allowedSchemes: ["https:"],
+        allowedHosts: ["pinpoint-worker.2296744453m.workers.dev"],
+        allowedHostSuffixes: [".workers.dev"],
+        allowLocalhost: process.env.NODE_ENV !== "production",
+      },
+      "PINPOINT_WORKER_HEALTH_URL",
+    );
   } catch {
     return new URL(DEFAULT_WORKER_HEALTH_URL);
   }
-}
-
-function buildCachedHeaders(contentType?: string | null): Headers {
-  const headers = new Headers({
-    "Cache-Control": "public, max-age=60, s-maxage=60, stale-while-revalidate=300",
-  });
-  if (contentType) headers.set("content-type", contentType);
-  return headers;
-}
-
-function buildNoStoreHeaders(contentType?: string | null): Headers {
-  const headers = new Headers({ "Cache-Control": "no-store" });
-  if (contentType) headers.set("content-type", contentType);
-  return headers;
 }
 
 /**
@@ -46,10 +43,9 @@ export async function GET() {
       status: upstream.status,
       headers: upstream.ok ? buildCachedHeaders(contentType) : buildNoStoreHeaders(contentType),
     });
-  } catch (error) {
-    const message = error instanceof Error ? error.message : "upstream unavailable";
+  } catch {
     return NextResponse.json(
-      { error: message, workerHealthUrl: workerHealthUrl.toString() },
+      { error: "upstream unavailable" },
       { status: 503, headers: buildNoStoreHeaders("application/json") },
     );
   }

--- a/app/api/pinpoint/today/route.ts
+++ b/app/api/pinpoint/today/route.ts
@@ -1,4 +1,6 @@
 import { NextResponse } from "next/server";
+import { buildCachedHeaders, buildNoStoreHeaders } from "@/lib/api-headers";
+import { parseAndValidateUrl } from "@/lib/security/url-allowlist";
 
 export const runtime = "nodejs";
 export const revalidate = 60;
@@ -8,7 +10,16 @@ const DEFAULT_WORKER_HEALTH_URL = "https://pinpoint-worker.2296744453m.workers.d
 function resolveWorkerBaseUrl(): URL {
   const raw = String(process.env.PINPOINT_WORKER_HEALTH_URL || DEFAULT_WORKER_HEALTH_URL).trim();
   try {
-    const url = new URL(raw);
+    const url = parseAndValidateUrl(
+      raw,
+      {
+        allowedSchemes: ["https:"],
+        allowedHosts: ["pinpoint-worker.2296744453m.workers.dev"],
+        allowedHostSuffixes: [".workers.dev"],
+        allowLocalhost: process.env.NODE_ENV !== "production",
+      },
+      "PINPOINT_WORKER_HEALTH_URL",
+    );
     url.pathname = "";
     url.search = "";
     url.hash = "";
@@ -16,20 +27,6 @@ function resolveWorkerBaseUrl(): URL {
   } catch {
     return new URL("https://pinpoint-worker.2296744453m.workers.dev");
   }
-}
-
-function buildCachedHeaders(contentType?: string | null): Headers {
-  const headers = new Headers({
-    "Cache-Control": "public, max-age=60, s-maxage=60, stale-while-revalidate=300",
-  });
-  if (contentType) headers.set("content-type", contentType);
-  return headers;
-}
-
-function buildNoStoreHeaders(contentType?: string | null): Headers {
-  const headers = new Headers({ "Cache-Control": "no-store" });
-  if (contentType) headers.set("content-type", contentType);
-  return headers;
 }
 
 /**
@@ -53,10 +50,9 @@ export async function GET(req: Request) {
       status: upstream.status,
       headers: upstream.ok ? buildCachedHeaders(contentType) : buildNoStoreHeaders(contentType),
     });
-  } catch (error) {
-    const message = error instanceof Error ? error.message : "upstream unavailable";
+  } catch {
     return NextResponse.json(
-      { error: message, upstreamUrl: upstreamUrl.toString() },
+      { error: "upstream unavailable" },
       { status: 503, headers: buildNoStoreHeaders("application/json") },
     );
   }

--- a/app/api/revalidate/route.ts
+++ b/app/api/revalidate/route.ts
@@ -1,6 +1,7 @@
 import { revalidatePath, revalidateTag } from "next/cache";
 import { type NextRequest, NextResponse } from "next/server";
 import { getPuzzleBySlug } from "@/lib/puzzles/data";
+import { safeEqual } from "@/lib/site/admin-auth";
 
 async function pingIndexNow(urls: string[]) {
   const key = process.env.INDEXNOW_KEY;
@@ -46,7 +47,7 @@ export async function POST(request: NextRequest) {
   const secret = bearerSecret || headerSecret;
 
   const stored = (process.env.REVALIDATE_SECRET ?? "").trim();
-  if (!stored || secret !== stored) {
+  if (!stored || !safeEqual(secret, stored)) {
     return NextResponse.json({ error: "Invalid secret" }, { status: 401 });
   }
 

--- a/lib/api-headers.ts
+++ b/lib/api-headers.ts
@@ -1,0 +1,39 @@
+/**
+ * Shared HTTP response header helpers for API routes.
+ *
+ * DRY extraction from:
+ * - app/api/health/route.ts
+ * - app/api/pinpoint/today/route.ts
+ * - app/api/fallback/worker-pinpoint/route.ts
+ */
+
+export function buildCachedHeaders(contentType?: string | null): Headers {
+  const headers = new Headers({
+    "Cache-Control": "public, max-age=60, s-maxage=60, stale-while-revalidate=300",
+  });
+  if (contentType) headers.set("content-type", contentType);
+  return headers;
+}
+
+/**
+ * Build a no-store Cache-Control header set.
+ *
+ * Accepts either:
+ * - a content-type string (e.g. "application/json")
+ * - a HeadersInit record (e.g. { "Retry-After": "300" })
+ */
+export function buildNoStoreHeaders(extra?: string | HeadersInit): HeadersInit {
+  if (typeof extra === "string") {
+    return { "Cache-Control": "no-store", "content-type": extra };
+  }
+  return {
+    "Cache-Control": "no-store",
+    ...Object.fromEntries(
+      extra instanceof Headers
+        ? extra.entries()
+        : Array.isArray(extra)
+          ? extra
+          : Object.entries(extra ?? {}),
+    ),
+  };
+}

--- a/lib/puzzles/data-sources.ts
+++ b/lib/puzzles/data-sources.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { cache } from "react";
 import { getBundledRegistryEntries } from "@/lib/puzzles/registry-bundled";
+import { parseAndValidateUrl } from "@/lib/security/url-allowlist";
 import {
   puzzleDetailContentSchema,
   registrySchema,
@@ -10,7 +11,21 @@ import {
 } from "@/lib/puzzles/schema";
 
 function getGithubRawBase(): string {
-  return process.env.GITHUB_RAW_BASE?.trim() ?? "";
+  const raw = process.env.GITHUB_RAW_BASE?.trim() ?? "";
+  if (!raw) return "";
+  const url = parseAndValidateUrl(
+    raw,
+    {
+      allowedSchemes: ["https:"],
+      allowedHosts: ["githubusercontent.com"],
+      allowedHostSuffixes: [".githubusercontent.com"],
+      allowLocalhost:
+        process.env.NODE_ENV !== "production" ||
+        process.env.PINPOINT_ALLOW_LOCAL_DATA_SOURCE === "true",
+    },
+    "GITHUB_RAW_BASE",
+  );
+  return url.toString().replace(/\/+$/, "");
 }
 
 function hasRemotePuzzleDataSource(): boolean {

--- a/lib/puzzles/data/live-worker.ts
+++ b/lib/puzzles/data/live-worker.ts
@@ -21,6 +21,7 @@ import {
   pickLiveTurningPoint,
 } from "@/lib/puzzles/live-fallback";
 import { buildSharedFallbackSolutionNarrative } from "@/lib/puzzles/fallback-copy";
+import { parseAndValidateUrl } from "@/lib/security/url-allowlist";
 
 type LiveWorkerPuzzleRecord = {
   puzzleDate: string;
@@ -39,7 +40,21 @@ function asRecord(value: unknown): Record<string, unknown> | null {
 }
 
 function getPinpointWorkerHealthUrl(): string {
-  return (process.env.PINPOINT_WORKER_HEALTH_URL ?? DEFAULT_PINPOINT_WORKER_HEALTH_URL).trim();
+  const raw = (process.env.PINPOINT_WORKER_HEALTH_URL ?? DEFAULT_PINPOINT_WORKER_HEALTH_URL).trim();
+  try {
+    return parseAndValidateUrl(
+      raw,
+      {
+        allowedSchemes: ["https:"],
+        allowedHosts: ["pinpoint-worker.2296744453m.workers.dev"],
+        allowedHostSuffixes: [".workers.dev"],
+        allowLocalhost: process.env.NODE_ENV !== "production",
+      },
+      "PINPOINT_WORKER_HEALTH_URL",
+    ).toString();
+  } catch {
+    return DEFAULT_PINPOINT_WORKER_HEALTH_URL;
+  }
 }
 
 function parseLiveWorkerPuzzleRecord(raw: unknown): LiveWorkerPuzzleRecord | null {

--- a/lib/puzzles/worker-fallback.ts
+++ b/lib/puzzles/worker-fallback.ts
@@ -1,4 +1,5 @@
 import { getPuzzleBySlug, getPuzzleSlugByPublishDate } from "@/lib/puzzles/data";
+import { parseAndValidateUrl } from "@/lib/security/url-allowlist";
 
 export type WorkerFallbackAnswer = {
   rank: number;
@@ -98,7 +99,16 @@ export async function loadBundledWorkerFallback(date: string): Promise<WorkerFal
 
 function normalizeCompetitorUrl(input: string | undefined): string {
   const raw = String(input || "").trim() || DEFAULT_COMPETITOR_URL;
-  return raw.endsWith("/") ? raw : `${raw}/`;
+  const url = parseAndValidateUrl(
+    raw.endsWith("/") ? raw : `${raw}/`,
+    {
+      allowedSchemes: ["https:"],
+      allowedHosts: ["pinpointanswer.today"],
+      allowLocalhost: process.env.NODE_ENV !== "production",
+    },
+    "PINPOINT_BASE_URL",
+  );
+  return url.toString();
 }
 
 function extractCompetitorTodayBlock(html: string): CompetitorSnapshot {

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -1,0 +1,75 @@
+type RateLimitBucket = {
+  count: number;
+  resetAt: number;
+};
+
+type InMemoryRateLimitOptions = {
+  storeKey: string;
+  windowMs: number;
+  maxRequests: number;
+};
+
+const globalForRateLimit = globalThis as typeof globalThis & {
+  __pinpointRateLimitStores?: Map<string, Map<string, RateLimitBucket>>;
+};
+
+function getStore(storeKey: string): Map<string, RateLimitBucket> {
+  const stores =
+    globalForRateLimit.__pinpointRateLimitStores
+    ?? (globalForRateLimit.__pinpointRateLimitStores = new Map<string, Map<string, RateLimitBucket>>());
+
+  const store = stores.get(storeKey);
+  if (store) return store;
+
+  const nextStore = new Map<string, RateLimitBucket>();
+  stores.set(storeKey, nextStore);
+  return nextStore;
+}
+
+export function readPositiveIntegerEnv(name: string, fallback: number): number {
+  const raw = process.env[name]?.trim();
+  if (!raw) return fallback;
+
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+export function getRequestRateLimitKey(req: Request): string {
+  const cfConnectingIp = req.headers.get("cf-connecting-ip")?.trim();
+  const forwardedFor = req.headers.get("x-forwarded-for")?.split(",")[0]?.trim();
+  const realIp = req.headers.get("x-real-ip")?.trim();
+  const userAgent = req.headers.get("user-agent")?.trim() || "unknown";
+  return `${cfConnectingIp || forwardedFor || realIp || "unknown"}::${userAgent}`;
+}
+
+export function createInMemoryRateLimiter(options: InMemoryRateLimitOptions) {
+  const store = getStore(options.storeKey);
+
+  return function getRateLimitRetryAfter(req: Request): number | null {
+    const now = Date.now();
+
+    for (const [key, bucket] of store.entries()) {
+      if (bucket.resetAt <= now) {
+        store.delete(key);
+      }
+    }
+
+    const rateLimitKey = getRequestRateLimitKey(req);
+    const currentBucket = store.get(rateLimitKey);
+    if (!currentBucket || currentBucket.resetAt <= now) {
+      store.set(rateLimitKey, {
+        count: 1,
+        resetAt: now + options.windowMs,
+      });
+      return null;
+    }
+
+    if (currentBucket.count >= options.maxRequests) {
+      return Math.max(1, Math.ceil((currentBucket.resetAt - now) / 1000));
+    }
+
+    currentBucket.count += 1;
+    store.set(rateLimitKey, currentBucket);
+    return null;
+  };
+}

--- a/lib/security/url-allowlist.ts
+++ b/lib/security/url-allowlist.ts
@@ -1,0 +1,67 @@
+type UrlAllowlistRule = {
+  allowedSchemes: readonly string[];
+  allowedHosts?: readonly string[];
+  allowedHostSuffixes?: readonly string[];
+  allowAnyHost?: boolean;
+  allowLocalhost?: boolean;
+};
+
+const LOCALHOSTS = new Set(["localhost", "127.0.0.1", "::1", "0.0.0.0"]);
+
+function normalizeHostname(hostname: string): string {
+  return hostname.trim().replace(/\.$/, "").toLowerCase();
+}
+
+function isLocalhost(hostname: string): boolean {
+  return LOCALHOSTS.has(normalizeHostname(hostname));
+}
+
+function matchesHostSuffix(hostname: string, suffix: string): boolean {
+  const normalizedHost = normalizeHostname(hostname);
+  const normalizedSuffix = suffix.startsWith(".")
+    ? suffix.toLowerCase()
+    : `.${suffix.toLowerCase()}`;
+  return normalizedHost.endsWith(normalizedSuffix);
+}
+
+export function validateUrlAgainstAllowlist(
+  url: URL,
+  rule: UrlAllowlistRule,
+  label: string,
+): void {
+  if (url.username || url.password) {
+    throw new Error(`URL allowlist [${label}]: credentials are not allowed`);
+  }
+
+  if (rule.allowLocalhost && isLocalhost(url.hostname)) {
+    if (url.protocol === "http:" || url.protocol === "https:") {
+      return;
+    }
+    throw new Error(`URL allowlist [${label}]: scheme ${url.protocol} is not allowed`);
+  }
+
+  if (!rule.allowedSchemes.includes(url.protocol)) {
+    throw new Error(`URL allowlist [${label}]: scheme ${url.protocol} is not allowed`);
+  }
+
+  const allowedHosts = (rule.allowedHosts ?? []).map(normalizeHostname);
+  const host = normalizeHostname(url.hostname);
+  const hostOk =
+    rule.allowAnyHost === true ||
+    allowedHosts.includes(host) ||
+    (rule.allowedHostSuffixes ?? []).some((suffix) => matchesHostSuffix(host, suffix));
+
+  if (!hostOk) {
+    throw new Error(`URL allowlist [${label}]: host ${url.hostname} is not allowed`);
+  }
+}
+
+export function parseAndValidateUrl(
+  raw: string,
+  rule: UrlAllowlistRule,
+  label: string,
+): URL {
+  const url = new URL(raw);
+  validateUrlAgainstAllowlist(url, rule, label);
+  return url;
+}

--- a/lib/site/admin-auth.ts
+++ b/lib/site/admin-auth.ts
@@ -1,0 +1,36 @@
+/**
+ * Shared admin authentication tokens.
+ *
+ * Used by /api/admin/generate-draft and /api/admin/validate-draft
+ * to avoid duplicating the token list.
+ */
+
+import { createHash, timingSafeEqual } from "node:crypto";
+
+const ADMIN_TOKENS = [
+  process.env.API_SECRET_TOKEN,
+  process.env.ADMIN_PASSPHRASE,
+  process.env.NODE_ENV === "production" ? null : process.env.DEV_ADMIN_TOKEN,
+].filter(Boolean) as string[];
+
+if (
+  process.env.NODE_ENV !== "production" &&
+  (process.env.DEV_ADMIN_TOKEN === "admin-secret-dev" ||
+    process.env.DEV_ADMIN_TOKEN === "change-me-to-a-random-string")
+) {
+  console.warn("[admin-auth] DEV_ADMIN_TOKEN is using a weak placeholder value.");
+}
+
+function hashSecret(value: string): Buffer {
+  return createHash("sha256").update(value, "utf8").digest();
+}
+
+export function safeEqual(a: string, b: string): boolean {
+  return timingSafeEqual(hashSecret(a), hashSecret(b));
+}
+
+export function authenticateAdmin(token: string): boolean {
+  return ADMIN_TOKENS.some((adminToken) => safeEqual(token, adminToken));
+}
+
+export { ADMIN_TOKENS };

--- a/lib/site/admin-rate-limit.ts
+++ b/lib/site/admin-rate-limit.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+import { createInMemoryRateLimiter, readPositiveIntegerEnv } from "@/lib/rate-limit";
+
+const adminRateLimitWindowMs = readPositiveIntegerEnv("ADMIN_RATE_LIMIT_WINDOW_MS", 10 * 60 * 1000);
+const adminRateLimitMaxRequests = readPositiveIntegerEnv("ADMIN_RATE_LIMIT_MAX", 20);
+
+const getAdminRateLimitRetryAfter = createInMemoryRateLimiter({
+  storeKey: "admin-api",
+  windowMs: adminRateLimitWindowMs,
+  maxRequests: adminRateLimitMaxRequests,
+});
+
+export function enforceAdminRateLimit(req: Request): NextResponse | null {
+  const retryAfter = getAdminRateLimitRetryAfter(req);
+  if (retryAfter === null) return null;
+
+  return NextResponse.json(
+    {
+      message: "Too many admin requests. Please wait a few minutes and try again.",
+    },
+    {
+      status: 429,
+      headers: {
+        "retry-after": String(retryAfter),
+      },
+    },
+  );
+}

--- a/scripts/check-pinpoint-guardrails.ts
+++ b/scripts/check-pinpoint-guardrails.ts
@@ -13,6 +13,8 @@ import { validateEvidenceContract } from "../lib/puzzles/evidence-contract";
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(SCRIPT_DIR, "..");
+const GUARDRAIL_ADMIN_TOKEN = process.env.DEV_ADMIN_TOKEN || "guardrail-local-admin-token";
+process.env.DEV_ADMIN_TOKEN = GUARDRAIL_ADMIN_TOKEN;
 
 type RegistryEntry = {
   puzzleNumber: number;
@@ -350,11 +352,166 @@ async function checkTodayRouteShowsPublishingPlaceholder() {
   console.log("ok: /pinpoint/today returns a 503 publishing placeholder for unpublished worker puzzles");
 }
 
+async function checkWorkerProxyErrorsDoNotExposeInternalUrls() {
+  const previousWorkerHealthUrl = process.env.PINPOINT_WORKER_HEALTH_URL;
+  const internalWorkerUrl = "https://pinpoint-worker.2296744453m.workers.dev.invalid/health";
+  process.env.PINPOINT_WORKER_HEALTH_URL = internalWorkerUrl;
+
+  try {
+    const healthRouteModulePath = `../app/api/health/route.ts?proxy-error-guardrail=${Date.now()}`;
+    const todayRouteModulePath = `../app/api/pinpoint/today/route.ts?proxy-error-guardrail=${Date.now()}`;
+    const healthRouteModule = (await import(healthRouteModulePath)) as {
+      GET: () => Promise<Response>;
+    };
+    const todayRouteModule = (await import(todayRouteModulePath)) as {
+      GET: (request: NextRequest) => Promise<Response>;
+    };
+
+    const healthResponse = await healthRouteModule.GET();
+    const todayResponse = await todayRouteModule.GET(
+      new NextRequest("http://localhost/api/pinpoint/today", { method: "GET" }),
+    );
+
+    for (const [label, response] of [
+      ["health", healthResponse],
+      ["today", todayResponse],
+    ] as const) {
+      assert.equal(response.status, 503, `${label} proxy should return 503 when the worker fetch fails`);
+      const body = await response.text();
+      assert.doesNotMatch(body, /workers\.dev/i, `${label} proxy error must not expose workers.dev URLs`);
+      assert.doesNotMatch(body, /workerHealthUrl|upstreamUrl/i, `${label} proxy error must not expose internal URL keys`);
+      assert.match(body, /upstream unavailable/i, `${label} proxy error should keep a generic public message`);
+    }
+  } finally {
+    if (previousWorkerHealthUrl === undefined) {
+      delete process.env.PINPOINT_WORKER_HEALTH_URL;
+    } else {
+      process.env.PINPOINT_WORKER_HEALTH_URL = previousWorkerHealthUrl;
+    }
+  }
+
+  console.log("ok: worker proxy errors do not expose internal URLs");
+}
+
+async function checkRemoteUrlAllowlistsRejectUnsafeHosts() {
+  const env = process.env as Record<string, string | undefined>;
+  const previousNodeEnv = process.env.NODE_ENV;
+  const previousGithubRawBase = process.env.GITHUB_RAW_BASE;
+  const previousPinpointBaseUrl = process.env.PINPOINT_BASE_URL;
+  const previousAllowLocalDataSource = process.env.PINPOINT_ALLOW_LOCAL_DATA_SOURCE;
+
+  try {
+    env.NODE_ENV = "production";
+    delete env.PINPOINT_ALLOW_LOCAL_DATA_SOURCE;
+    env.GITHUB_RAW_BASE = "https://githubusercontent.com.evil.test/raw";
+    env.PINPOINT_BASE_URL = "https://pinpointanswer.today.evil.test/";
+
+    const dataModulePath = `../lib/puzzles/data.ts?unsafe-url-guardrail=${Date.now()}`;
+    const allowlistModulePath = `../lib/security/url-allowlist.ts?unsafe-url-guardrail=${Date.now()}`;
+    const workerFallbackModulePath = `../lib/puzzles/worker-fallback.ts?unsafe-url-guardrail=${Date.now()}`;
+    const dataModule = (await import(dataModulePath)) as {
+      getPuzzleBySlug: (
+        slug: string,
+        options?: { allowLiveWorkerFallback?: boolean },
+      ) => Promise<{ slug: string } | null>;
+    };
+    const allowlistModule = (await import(allowlistModulePath)) as {
+      parseAndValidateUrl: (raw: string, rule: {
+        allowedSchemes: readonly string[];
+        allowedHosts?: readonly string[];
+        allowedHostSuffixes?: readonly string[];
+      }, label: string) => URL;
+    };
+    const workerFallbackModule = (await import(workerFallbackModulePath)) as {
+      loadCompetitorWorkerFallback: (date?: string) => Promise<unknown>;
+    };
+
+    await assert.rejects(
+      () => dataModule.getPuzzleBySlug("pinpoint-answer-695", { allowLiveWorkerFallback: false }),
+      /GITHUB_RAW_BASE.*host/i,
+      "unsafe GITHUB_RAW_BASE host should be rejected",
+    );
+
+    assert.throws(
+      () => allowlistModule.parseAndValidateUrl(
+        "https://workers.dev.evil.test/health",
+        {
+          allowedSchemes: ["https:"],
+          allowedHosts: ["pinpoint-worker.2296744453m.workers.dev"],
+          allowedHostSuffixes: [".workers.dev"],
+        },
+        "PINPOINT_WORKER_HEALTH_URL",
+      ),
+      /PINPOINT_WORKER_HEALTH_URL.*host/i,
+      "unsafe worker health host should be rejected by allowlist",
+    );
+
+    assert.throws(
+      () => allowlistModule.parseAndValidateUrl(
+        "file:///etc/passwd",
+        {
+          allowedSchemes: ["https:"],
+          allowedHosts: ["pinpointanswer.today"],
+        },
+        "PINPOINT_BASE_URL",
+      ),
+      /PINPOINT_BASE_URL.*scheme/i,
+      "file URLs should be rejected by allowlist",
+    );
+
+    assert.throws(
+      () => allowlistModule.parseAndValidateUrl(
+        "https://user:password@pinpointanswer.today/",
+        {
+          allowedSchemes: ["https:"],
+          allowedHosts: ["pinpointanswer.today"],
+        },
+        "PINPOINT_BASE_URL",
+      ),
+      /PINPOINT_BASE_URL.*credentials/i,
+      "credential-bearing URLs should be rejected by allowlist",
+    );
+
+    await assert.rejects(
+      () => workerFallbackModule.loadCompetitorWorkerFallback(),
+      /PINPOINT_BASE_URL.*host/i,
+      "unsafe competitor URL host should be rejected",
+    );
+  } finally {
+    if (previousNodeEnv === undefined) {
+      delete env.NODE_ENV;
+    } else {
+      env.NODE_ENV = previousNodeEnv;
+    }
+
+    if (previousGithubRawBase === undefined) {
+      delete env.GITHUB_RAW_BASE;
+    } else {
+      env.GITHUB_RAW_BASE = previousGithubRawBase;
+    }
+
+    if (previousPinpointBaseUrl === undefined) {
+      delete env.PINPOINT_BASE_URL;
+    } else {
+      env.PINPOINT_BASE_URL = previousPinpointBaseUrl;
+    }
+
+    if (previousAllowLocalDataSource === undefined) {
+      delete env.PINPOINT_ALLOW_LOCAL_DATA_SOURCE;
+    } else {
+      env.PINPOINT_ALLOW_LOCAL_DATA_SOURCE = previousAllowLocalDataSource;
+    }
+  }
+
+  console.log("ok: remote URL allowlists reject unsafe hosts");
+}
+
 async function checkProductionDetailUsesRemoteFirst() {
   const slug = "pinpoint-answer-695";
   const env = process.env as Record<string, string | undefined>;
   const previousNodeEnv = process.env.NODE_ENV;
   const previousGithubRawBase = process.env.GITHUB_RAW_BASE;
+  const previousAllowLocalDataSource = process.env.PINPOINT_ALLOW_LOCAL_DATA_SOURCE;
   const registry = JSON.parse(
     await readFile(resolve(ROOT, "data", "puzzles", "registry.json"), "utf8"),
   ) as unknown;
@@ -385,6 +542,7 @@ async function checkProductionDetailUsesRemoteFirst() {
       async (mockBaseUrl) => {
         env.NODE_ENV = "production";
         env.GITHUB_RAW_BASE = mockBaseUrl;
+        env.PINPOINT_ALLOW_LOCAL_DATA_SOURCE = "true";
 
         const dataModulePath = `../lib/puzzles/data.ts?remote-detail=${Date.now()}`;
         const dataModule = (await import(dataModulePath)) as {
@@ -418,6 +576,12 @@ async function checkProductionDetailUsesRemoteFirst() {
     } else {
       env.GITHUB_RAW_BASE = previousGithubRawBase;
     }
+
+    if (previousAllowLocalDataSource === undefined) {
+      delete env.PINPOINT_ALLOW_LOCAL_DATA_SOURCE;
+    } else {
+      env.PINPOINT_ALLOW_LOCAL_DATA_SOURCE = previousAllowLocalDataSource;
+    }
   }
 
   console.log("ok: production detail lookups prefer remote JSON over local files");
@@ -427,6 +591,7 @@ async function checkCurrentPuzzleSkipsNonPublicLiveEntry() {
   const env = process.env as Record<string, string | undefined>;
   const previousNodeEnv = process.env.NODE_ENV;
   const previousGithubRawBase = process.env.GITHUB_RAW_BASE;
+  const previousAllowLocalDataSource = process.env.PINPOINT_ALLOW_LOCAL_DATA_SOURCE;
   const registry = JSON.parse(
     await readFile(resolve(ROOT, "data", "puzzles", "registry.json"), "utf8"),
   ) as Array<RegistryEntry & { detailState?: string }>;
@@ -460,6 +625,7 @@ async function checkCurrentPuzzleSkipsNonPublicLiveEntry() {
       async (mockBaseUrl) => {
         env.NODE_ENV = "production";
         env.GITHUB_RAW_BASE = mockBaseUrl;
+        env.PINPOINT_ALLOW_LOCAL_DATA_SOURCE = "true";
 
         const dataModulePath = `../lib/puzzles/data.ts?detail-state-current=${Date.now()}`;
         const dataModule = (await import(dataModulePath)) as {
@@ -496,6 +662,12 @@ async function checkCurrentPuzzleSkipsNonPublicLiveEntry() {
       delete env.GITHUB_RAW_BASE;
     } else {
       env.GITHUB_RAW_BASE = previousGithubRawBase;
+    }
+
+    if (previousAllowLocalDataSource === undefined) {
+      delete env.PINPOINT_ALLOW_LOCAL_DATA_SOURCE;
+    } else {
+      env.PINPOINT_ALLOW_LOCAL_DATA_SOURCE = previousAllowLocalDataSource;
     }
   }
 
@@ -1742,7 +1914,7 @@ async function checkValidateDraftDoesNotNormalizeEmptySlots() {
   const request = new NextRequest("http://localhost/api/admin/validate-draft", {
     method: "POST",
     headers: {
-      authorization: "Bearer admin-secret-dev",
+      authorization: `Bearer ${GUARDRAIL_ADMIN_TOKEN}`,
       "content-type": "application/json",
     },
     body: JSON.stringify({
@@ -1779,7 +1951,7 @@ async function checkValidateDraftDoesNotNormalizeIncompleteSlotRows() {
   const request = new NextRequest("http://localhost/api/admin/validate-draft", {
     method: "POST",
     headers: {
-      authorization: "Bearer admin-secret-dev",
+      authorization: `Bearer ${GUARDRAIL_ADMIN_TOKEN}`,
       "content-type": "application/json",
     },
     body: JSON.stringify({
@@ -1827,12 +1999,99 @@ async function checkValidateDraftDoesNotNormalizeIncompleteSlotRows() {
   console.log("ok: validate-draft rejects incomplete slot rows instead of template-normalizing them");
 }
 
+async function checkAdminApiRateLimit() {
+  const previousWindowMs = process.env.ADMIN_RATE_LIMIT_WINDOW_MS;
+  const previousMax = process.env.ADMIN_RATE_LIMIT_MAX;
+  process.env.ADMIN_RATE_LIMIT_WINDOW_MS = "600000";
+  process.env.ADMIN_RATE_LIMIT_MAX = "20";
+
+  try {
+    const cacheBust = Date.now();
+    const validateRouteModulePath = `../app/api/admin/validate-draft/route.ts?admin-rate-limit=${cacheBust}`;
+    const generateRouteModulePath = `../app/api/admin/generate-draft/route.ts?admin-rate-limit=${cacheBust}`;
+    const validateRouteModule = (await import(validateRouteModulePath)) as {
+      POST: (request: NextRequest) => Promise<Response>;
+    };
+    const generateRouteModule = (await import(generateRouteModulePath)) as {
+      POST: (request: NextRequest) => Promise<Response>;
+    };
+
+    function buildValidateRequest(index: number) {
+      return new NextRequest("http://localhost/api/admin/validate-draft", {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${GUARDRAIL_ADMIN_TOKEN}`,
+          "content-type": "application/json",
+          "x-forwarded-for": "203.0.113.20",
+          "user-agent": "admin-rate-limit-guardrail",
+        },
+        body: JSON.stringify({
+          puzzleNumber: 749,
+          rawWords: ["Thermal", "Laser", "3D", "Dot matrix", "Inkjet"],
+          mainAnswer: "Types of printers",
+          candidate: { slots: {}, requestIndex: index },
+        }),
+      });
+    }
+
+    for (let index = 1; index <= 20; index += 1) {
+      const response = await validateRouteModule.POST(buildValidateRequest(index));
+      assert.notEqual(response.status, 429, `admin request ${index} should be allowed before the limit`);
+    }
+
+    const limitedResponse = await generateRouteModule.POST(
+      new NextRequest("http://localhost/api/admin/generate-draft", {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${GUARDRAIL_ADMIN_TOKEN}`,
+          "content-type": "application/json",
+          "x-forwarded-for": "203.0.113.20",
+          "user-agent": "admin-rate-limit-guardrail",
+        },
+        body: JSON.stringify({
+          puzzleNumber: 749,
+          rawWords: ["Thermal", "Laser", "3D", "Dot matrix", "Inkjet"],
+          mainAnswer: "Types of printers",
+        }),
+      }),
+    );
+    const limitedBody = await limitedResponse.json() as { message?: string };
+
+    assert.equal(limitedResponse.status, 429, "admin routes should share the same rate-limit bucket");
+    assert.match(
+      limitedBody.message ?? "",
+      /too many admin requests/i,
+      "admin rate-limit response should include a clear public message",
+    );
+    assert.ok(
+      Number(limitedResponse.headers.get("retry-after")) > 0,
+      "admin rate-limit response should include retry-after",
+    );
+  } finally {
+    if (previousWindowMs === undefined) {
+      delete process.env.ADMIN_RATE_LIMIT_WINDOW_MS;
+    } else {
+      process.env.ADMIN_RATE_LIMIT_WINDOW_MS = previousWindowMs;
+    }
+
+    if (previousMax === undefined) {
+      delete process.env.ADMIN_RATE_LIMIT_MAX;
+    } else {
+      process.env.ADMIN_RATE_LIMIT_MAX = previousMax;
+    }
+  }
+
+  console.log("ok: admin APIs enforce shared rate limiting");
+}
+
 async function main() {
   await checkProductionDetailUsesRemoteFirst();
   await checkCurrentPuzzleSkipsNonPublicLiveEntry();
   await checkPublishedSummaryRoute();
   await checkRevalidateRejectsUnpublishedOrLiveRequests();
   await checkTodayRouteShowsPublishingPlaceholder();
+  await checkWorkerProxyErrorsDoNotExposeInternalUrls();
+  await checkRemoteUrlAllowlistsRejectUnsafeHosts();
   await checkWorkerDetailShape();
   await checkPhraseFallbackDirection();
   await checkEvidenceContractGuardsMeaningfulV2Fields();
@@ -1840,6 +2099,7 @@ async function main() {
   checkWorkerLlmSlotsOnlyDraftNormalizesBeforeValidation();
   await checkValidateDraftDoesNotNormalizeEmptySlots();
   await checkValidateDraftDoesNotNormalizeIncompleteSlotRows();
+  await checkAdminApiRateLimit();
   console.log("Pinpoint guardrail regression passed.");
 }
 

--- a/scripts/check-pinpoint-guardrails.ts
+++ b/scripts/check-pinpoint-guardrails.ts
@@ -354,7 +354,7 @@ async function checkTodayRouteShowsPublishingPlaceholder() {
 
 async function checkWorkerProxyErrorsDoNotExposeInternalUrls() {
   const previousWorkerHealthUrl = process.env.PINPOINT_WORKER_HEALTH_URL;
-  const internalWorkerUrl = "https://pinpoint-worker.2296744453m.workers.dev.invalid/health";
+  const internalWorkerUrl = "http://127.0.0.1:9/health";
   process.env.PINPOINT_WORKER_HEALTH_URL = internalWorkerUrl;
 
   try {

--- a/scripts/run-pinpoint-regression.mjs
+++ b/scripts/run-pinpoint-regression.mjs
@@ -6,7 +6,11 @@ import process from "node:process";
 const ROOT = process.cwd();
 const PORT = Number(process.env.PINPOINT_REGRESSION_PORT || 3004);
 const BASE_URL = process.env.PINPOINT_REGRESSION_BASE_URL || `http://127.0.0.1:${PORT}`;
-const ADMIN_TOKEN = process.env.PINPOINT_REGRESSION_ADMIN_TOKEN || process.env.ADMIN_PASSPHRASE || "admin-secret-dev";
+const ADMIN_TOKEN =
+  process.env.PINPOINT_REGRESSION_ADMIN_TOKEN ||
+  process.env.DEV_ADMIN_TOKEN ||
+  process.env.ADMIN_PASSPHRASE ||
+  "admin-secret-dev";
 
 const SAMPLE_SETS = {
   quick: [683, 682, 684, 679],
@@ -366,7 +370,11 @@ function startDevServer() {
   const child = spawn("npm", ["run", "dev"], {
     cwd: ROOT,
     stdio: ["ignore", "pipe", "pipe"],
-    env: { ...process.env, FORCE_COLOR: "0" },
+    env: {
+      ...process.env,
+      DEV_ADMIN_TOKEN: process.env.DEV_ADMIN_TOKEN || ADMIN_TOKEN,
+      FORCE_COLOR: "0",
+    },
   });
 
   child.stdout.on("data", () => {});


### PR DESCRIPTION
## Summary
- centralize admin auth, remove the hardcoded dev token from app auth, and compare secrets with timing-safe hashes
- add outbound URL allowlists for worker, GitHub raw, competitor, and webhook URLs
- stop health/today proxy errors from exposing internal Worker URLs
- extract shared in-memory rate limiting and apply it to feedback/admin APIs

## Verification
- npm run typecheck
- npm run lint
- npm run validate:data
- npm run test:pinpoint-guardrails
- npm run build
- git diff --check

## Notes
- No homepage changes included.
- No Next.js upgrade included.
- No sitemap/contact SEO changes included.
- HSTS was checked on production and is already provided once by Vercel (`strict-transport-security: max-age=63072000`), so this PR does not add an app-level HSTS header.