### PR TITLE
Add shared Pinpoint publish eligibility gate

### DIFF
--- a/lib/puzzles/publish-eligibility.d.ts
+++ b/lib/puzzles/publish-eligibility.d.ts
@@ -1,0 +1,42 @@
+export type PublishMode = "answer-first" | "full-analysis" | "failed";
+
+export type PublishIssueLevel = "blocking" | "warning" | "info";
+
+export type PublishGateIssue = {
+  code: string;
+  level: PublishIssueLevel;
+  message: string;
+  slug?: string;
+  puzzleNumber?: number;
+  field?: string;
+  sourceConfidence?: "confirmed" | "manual" | "inferred" | "weak" | "unknown";
+  publishMode?: PublishMode;
+};
+
+export type PublishGateResult = {
+  ok: boolean;
+  slug: string;
+  puzzleNumber?: number;
+  publishMode?: PublishMode;
+  issues: PublishGateIssue[];
+};
+
+export const publishModes: PublishMode[];
+export function isPublishMode(value: unknown): value is PublishMode;
+export function resolvePublishMode(input?: {
+  detail?: Record<string, unknown>;
+  registryEntry?: Record<string, unknown>;
+}): {
+  mode: PublishMode;
+  inferred: boolean;
+  issues: PublishGateIssue[];
+};
+export function validatePublishEligibility(input?: {
+  slug?: string;
+  registryEntry?: Record<string, unknown>;
+  detail?: Record<string, unknown>;
+  expectedMode?: PublishMode;
+  answerFirstPublicEnabled?: boolean;
+  sourceConfidence?: "confirmed" | "manual" | "inferred" | "weak" | "unknown";
+}): PublishGateResult;
+export function formatPublishGateIssues(issues: PublishGateIssue[]): string;

--- a/lib/puzzles/publish-eligibility.shared.d.mts
+++ b/lib/puzzles/publish-eligibility.shared.d.mts
@@ -1,0 +1,42 @@
+export type PublishMode = "answer-first" | "full-analysis" | "failed";
+
+export type PublishIssueLevel = "blocking" | "warning" | "info";
+
+export type PublishGateIssue = {
+  code: string;
+  level: PublishIssueLevel;
+  message: string;
+  slug?: string;
+  puzzleNumber?: number;
+  field?: string;
+  sourceConfidence?: "confirmed" | "manual" | "inferred" | "weak" | "unknown";
+  publishMode?: PublishMode;
+};
+
+export type PublishGateResult = {
+  ok: boolean;
+  slug: string;
+  puzzleNumber?: number;
+  publishMode?: PublishMode;
+  issues: PublishGateIssue[];
+};
+
+export declare const publishModes: PublishMode[];
+export declare function isPublishMode(value: unknown): value is PublishMode;
+export declare function resolvePublishMode(input?: {
+  detail?: Record<string, unknown>;
+  registryEntry?: Record<string, unknown>;
+}): {
+  mode: PublishMode;
+  inferred: boolean;
+  issues: PublishGateIssue[];
+};
+export declare function validatePublishEligibility(input?: {
+  slug?: string;
+  registryEntry?: Record<string, unknown>;
+  detail?: Record<string, unknown>;
+  expectedMode?: PublishMode;
+  answerFirstPublicEnabled?: boolean;
+  sourceConfidence?: "confirmed" | "manual" | "inferred" | "weak" | "unknown";
+}): PublishGateResult;
+export declare function formatPublishGateIssues(issues: PublishGateIssue[]): string;

--- a/lib/puzzles/publish-eligibility.shared.mjs
+++ b/lib/puzzles/publish-eligibility.shared.mjs
@@ -1,0 +1,296 @@
+export const publishModes = ["answer-first", "full-analysis", "failed"];
+
+const publicDetailStates = new Set(["published", "fallback_full"]);
+
+function normalizeString(value) {
+  return String(value ?? "").trim();
+}
+
+function normalizeLower(value) {
+  return normalizeString(value).toLowerCase();
+}
+
+export function isPublishMode(value) {
+  return publishModes.includes(value);
+}
+
+export function resolvePublishMode({ detail = {}, registryEntry = {} } = {}) {
+  const explicitMode = normalizeString(detail.publishMode || registryEntry.publishMode);
+  if (isPublishMode(explicitMode)) {
+    return {
+      mode: explicitMode,
+      inferred: false,
+      issues: [],
+    };
+  }
+
+  const issues = [];
+  if (explicitMode) {
+    issues.push({
+      code: "publishMode.unsupported",
+      level: "blocking",
+      message: `Unsupported publishMode: ${explicitMode}`,
+      field: "publishMode",
+    });
+  }
+
+  const detailState = normalizeLower(detail.detailState || registryEntry.detailState || "published");
+  if (detailState === "failed") {
+    return { mode: "failed", inferred: true, issues };
+  }
+
+  const bodyMode = normalizeLower(detail.bodyMode);
+  const pageExperienceMode = normalizeLower(detail.pageExperienceMode);
+  if (bodyMode === "short" || pageExperienceMode === "light-explainer") {
+    return {
+      mode: "answer-first",
+      inferred: true,
+      issues: [
+        ...issues,
+        {
+          code: "publishMode.inferredLegacy",
+          level: "warning",
+          message: "Legacy short/light detail inferred as answer-first.",
+          field: bodyMode === "short" ? "bodyMode" : "pageExperienceMode",
+        },
+      ],
+    };
+  }
+
+  if (detailState === "fallback_full") {
+    return {
+      mode: "full-analysis",
+      inferred: true,
+      issues: [
+        ...issues,
+        {
+          code: "publishMode.legacyFallbackFull",
+          level: "warning",
+          message: "Legacy fallback_full inferred as full-analysis candidate.",
+          field: "detailState",
+        },
+      ],
+    };
+  }
+
+  return {
+    mode: "full-analysis",
+    inferred: true,
+    issues: [
+      ...issues,
+      {
+        code: "publishMode.inferredLegacy",
+        level: "warning",
+        message: "Legacy detail inferred as full-analysis candidate.",
+        field: "publishMode",
+      },
+    ],
+  };
+}
+
+function makeIssue({
+  code,
+  level = "blocking",
+  message,
+  slug,
+  puzzleNumber,
+  field,
+  sourceConfidence = "unknown",
+  publishMode,
+}) {
+  return {
+    code,
+    level,
+    message,
+    ...(slug ? { slug } : {}),
+    ...(Number.isInteger(puzzleNumber) ? { puzzleNumber } : {}),
+    ...(field ? { field } : {}),
+    sourceConfidence,
+    ...(publishMode ? { publishMode } : {}),
+  };
+}
+
+export function validatePublishEligibility(input) {
+  const {
+    slug,
+    registryEntry = {},
+    detail = {},
+    expectedMode,
+    answerFirstPublicEnabled = false,
+    sourceConfidence = "unknown",
+  } = input ?? {};
+  const normalizedSlug = normalizeString(slug || detail.slug || registryEntry.slug);
+  const puzzleNumber = Number(detail.puzzleNumber || registryEntry.puzzleNumber);
+  const issues = [];
+
+  const modeResult = resolvePublishMode({ detail, registryEntry });
+  const publishMode = modeResult.mode;
+  for (const issue of modeResult.issues) {
+    issues.push(makeIssue({
+      ...issue,
+      slug: normalizedSlug,
+      puzzleNumber,
+      sourceConfidence,
+      publishMode,
+    }));
+  }
+
+  if (!normalizedSlug) {
+    issues.push(makeIssue({
+      code: "slug.missing",
+      message: "Missing slug.",
+      field: "slug",
+      sourceConfidence,
+      publishMode,
+    }));
+  }
+
+  if (!Number.isInteger(puzzleNumber) || puzzleNumber <= 0) {
+    issues.push(makeIssue({
+      code: "puzzleNumber.missing",
+      message: "Missing puzzle number.",
+      slug: normalizedSlug,
+      field: "puzzleNumber",
+      sourceConfidence,
+      publishMode,
+    }));
+  }
+
+  if (!publishMode) {
+    issues.push(makeIssue({
+      code: "publishMode.missing",
+      message: "Missing publishMode.",
+      slug: normalizedSlug,
+      puzzleNumber,
+      field: "publishMode",
+      sourceConfidence,
+    }));
+  }
+
+  const detailState = normalizeLower(detail.detailState || registryEntry.detailState || "published");
+  if (publishMode !== "failed" && detailState && !publicDetailStates.has(detailState)) {
+    issues.push(makeIssue({
+      code: "detailState.notPublishable",
+      message: `detailState is not public: ${detailState}`,
+      slug: normalizedSlug,
+      puzzleNumber,
+      field: "detailState",
+      sourceConfidence,
+      publishMode,
+    }));
+  }
+
+  const answer = normalizeString(detail.answer || detail.mainAnswer || registryEntry.mainAnswer);
+  if (!answer) {
+    issues.push(makeIssue({
+      code: "answer.missing",
+      message: "Missing answer.",
+      slug: normalizedSlug,
+      puzzleNumber,
+      field: "answer",
+      sourceConfidence,
+      publishMode,
+    }));
+  }
+
+  const clues = Array.isArray(detail.clues)
+    ? detail.clues
+    : Array.isArray(detail.rawWords)
+      ? detail.rawWords
+      : registryEntry.clues;
+  if (!Array.isArray(clues) || clues.filter((clue) => normalizeString(clue)).length !== 5) {
+    issues.push(makeIssue({
+      code: "clues.countMismatch",
+      message: "Public Pinpoint payload must contain exactly 5 clues.",
+      slug: normalizedSlug,
+      puzzleNumber,
+      field: "clues",
+      sourceConfidence,
+      publishMode,
+    }));
+  }
+
+  if (publishMode === "failed") {
+    issues.push(makeIssue({
+      code: "publishMode.failedPublicPayload",
+      message: "failed payloads cannot be written to the public final payload path.",
+      slug: normalizedSlug,
+      puzzleNumber,
+      field: "publishMode",
+      sourceConfidence,
+      publishMode,
+    }));
+  }
+
+  if (publishMode === "answer-first" && !answerFirstPublicEnabled) {
+    issues.push(makeIssue({
+      code: "publishMode.answerFirstDisabled",
+      message: "answer-first public publishing is disabled.",
+      slug: normalizedSlug,
+      puzzleNumber,
+      field: "publishMode",
+      sourceConfidence,
+      publishMode,
+    }));
+  }
+
+  const expected = isPublishMode(expectedMode) ? expectedMode : undefined;
+  if (expected === "full-analysis") {
+    const bodyMode = normalizeLower(detail.bodyMode);
+    const pageExperienceMode = normalizeLower(detail.pageExperienceMode);
+    if (bodyMode === "short") {
+      issues.push(makeIssue({
+        code: "publishMode.bodyModeMismatch",
+        message: "short bodyMode cannot be published as full-analysis.",
+        slug: normalizedSlug,
+        puzzleNumber,
+        field: "bodyMode",
+        sourceConfidence,
+        publishMode,
+      }));
+    }
+
+    if (pageExperienceMode === "light-explainer") {
+      issues.push(makeIssue({
+        code: "publishMode.pageExperienceMismatch",
+        message: "light-explainer pageExperienceMode cannot be published as full-analysis.",
+        slug: normalizedSlug,
+        puzzleNumber,
+        field: "pageExperienceMode",
+        sourceConfidence,
+        publishMode,
+      }));
+    }
+
+    if (publishMode !== "full-analysis") {
+      issues.push(makeIssue({
+        code: "publishMode.expectedFullAnalysis",
+        message: `Expected full-analysis but resolved ${publishMode || "unknown"}.`,
+        slug: normalizedSlug,
+        puzzleNumber,
+        field: "publishMode",
+        sourceConfidence,
+        publishMode,
+      }));
+    }
+
+  }
+
+  const blockingIssues = issues.filter((issue) => issue.level === "blocking");
+  return {
+    ok: blockingIssues.length === 0,
+    slug: normalizedSlug,
+    ...(Number.isInteger(puzzleNumber) ? { puzzleNumber } : {}),
+    ...(publishMode ? { publishMode } : {}),
+    issues,
+  };
+}
+
+export function formatPublishGateIssues(issues) {
+  return (Array.isArray(issues) ? issues : [])
+    .map((issue) => {
+      const field = issue.field ? ` field=${issue.field}` : "";
+      return `${issue.code}${field}: ${issue.message}`;
+    })
+    .join("; ");
+}

--- a/lib/puzzles/schema.shared.d.mts
+++ b/lib/puzzles/schema.shared.d.mts
@@ -15,6 +15,7 @@ export declare const puzzleQuestionTypeSchema: z.ZodEnum<["phrase", "category", 
 export declare const puzzleDifficultyBandSchema: z.ZodEnum<["obvious", "medium", "hard"]>;
 export declare const puzzleDetailBodyModeSchema: z.ZodEnum<["short", "standard", "deep"]>;
 export declare const puzzlePageExperienceModeSchema: z.ZodEnum<["full-analysis", "light-explainer"]>;
+export declare const puzzlePublishModeSchema: z.ZodEnum<["answer-first", "full-analysis", "failed"]>;
 
 export declare const puzzleRegistryEntrySchema: z.ZodObject<{
   puzzleNumber: z.ZodNumber;
@@ -26,6 +27,7 @@ export declare const puzzleRegistryEntrySchema: z.ZodObject<{
   category: z.ZodNullable<z.ZodString>;
   difficultyLevel: z.ZodOptional<typeof difficultyLevelSchema>;
   detailState: z.ZodOptional<typeof puzzleDetailStateSchema>;
+  publishMode: z.ZodOptional<typeof puzzlePublishModeSchema>;
   shortSummary: z.ZodString;
   updatedAt: z.ZodString;
 }>;
@@ -101,6 +103,7 @@ export declare const puzzleWrongGuessCandidateSchema: z.ZodObject<{
 export declare const puzzleDetailContentSchema: z.ZodObject<{
   slug: z.ZodString;
   detailState: z.ZodOptional<typeof puzzleDetailStateSchema>;
+  publishMode: z.ZodOptional<typeof puzzlePublishModeSchema>;
   questionType: z.ZodOptional<typeof puzzleQuestionTypeSchema>;
   difficultyBand: z.ZodOptional<typeof puzzleDifficultyBandSchema>;
   bodyMode: z.ZodOptional<typeof puzzleDetailBodyModeSchema>;

--- a/lib/puzzles/schema.shared.mjs
+++ b/lib/puzzles/schema.shared.mjs
@@ -15,6 +15,7 @@ export const puzzleQuestionTypeSchema = z.enum(["phrase", "category", "associati
 export const puzzleDifficultyBandSchema = z.enum(["obvious", "medium", "hard"]);
 export const puzzleDetailBodyModeSchema = z.enum(["short", "standard", "deep"]);
 export const puzzlePageExperienceModeSchema = z.enum(["full-analysis", "light-explainer"]);
+export const puzzlePublishModeSchema = z.enum(["answer-first", "full-analysis", "failed"]);
 
 export const puzzleRegistryEntrySchema = z.object({
   puzzleNumber: z.number().int().positive(),
@@ -26,6 +27,7 @@ export const puzzleRegistryEntrySchema = z.object({
   category: z.string().min(1).nullable(),
   difficultyLevel: difficultyLevelSchema.optional(),
   detailState: puzzleDetailStateSchema.optional(),
+  publishMode: puzzlePublishModeSchema.optional(),
   shortSummary: z.string().min(1),
   updatedAt: z.string().datetime(),
 });
@@ -107,6 +109,7 @@ export const puzzleWrongGuessCandidateSchema = z.object({
 export const puzzleDetailContentSchema = z.object({
   slug: z.string().min(1),
   detailState: puzzleDetailStateSchema.optional(),
+  publishMode: puzzlePublishModeSchema.optional(),
   questionType: puzzleQuestionTypeSchema.optional(),
   difficultyBand: puzzleDifficultyBandSchema.optional(),
   bodyMode: puzzleDetailBodyModeSchema.optional(),

--- a/lib/puzzles/schema.ts
+++ b/lib/puzzles/schema.ts
@@ -8,6 +8,7 @@ import {
   faqItemSchema as sharedFaqItemSchema,
   lessonItemSchema as sharedLessonItemSchema,
   puzzlePageExperienceModeSchema as sharedPuzzlePageExperienceModeSchema,
+  puzzlePublishModeSchema as sharedPuzzlePublishModeSchema,
   puzzleSolvePathSchema as sharedPuzzleSolvePathSchema,
   puzzleTurningPointSchema as sharedPuzzleTurningPointSchema,
   puzzleClueRowSchema as sharedPuzzleClueRowSchema,
@@ -39,6 +40,8 @@ export const puzzleDetailBodyModeSchema =
   sharedPuzzleDetailBodyModeSchema as z.ZodEnum<["short", "standard", "deep"]>;
 export const puzzlePageExperienceModeSchema =
   sharedPuzzlePageExperienceModeSchema as z.ZodEnum<["full-analysis", "light-explainer"]>;
+export const puzzlePublishModeSchema =
+  sharedPuzzlePublishModeSchema as z.ZodEnum<["answer-first", "full-analysis", "failed"]>;
 export const puzzleRegistryEntrySchema = sharedPuzzleRegistryEntrySchema as z.ZodObject<{
   puzzleNumber: z.ZodNumber;
   slug: z.ZodString;
@@ -49,6 +52,7 @@ export const puzzleRegistryEntrySchema = sharedPuzzleRegistryEntrySchema as z.Zo
   category: z.ZodNullable<z.ZodString>;
   difficultyLevel: z.ZodOptional<typeof difficultyLevelSchema>;
   detailState: z.ZodOptional<typeof puzzleDetailStateSchema>;
+  publishMode: z.ZodOptional<typeof puzzlePublishModeSchema>;
   shortSummary: z.ZodString;
   updatedAt: z.ZodString;
 }>;
@@ -112,6 +116,7 @@ export const puzzleWrongGuessCandidateSchema = sharedPuzzleWrongGuessCandidateSc
 export const puzzleDetailContentSchema = sharedPuzzleDetailContentSchema as z.ZodObject<{
   slug: z.ZodString;
   detailState: z.ZodOptional<typeof puzzleDetailStateSchema>;
+  publishMode: z.ZodOptional<typeof puzzlePublishModeSchema>;
   questionType: z.ZodOptional<typeof puzzleQuestionTypeSchema>;
   difficultyBand: z.ZodOptional<typeof puzzleDifficultyBandSchema>;
   bodyMode: z.ZodOptional<typeof puzzleDetailBodyModeSchema>;
@@ -138,6 +143,7 @@ export type PuzzleDetailState = z.infer<typeof puzzleDetailStateSchema>;
 export type PuzzleQuestionType = z.infer<typeof puzzleQuestionTypeSchema>;
 export type PuzzleDifficultyBand = z.infer<typeof puzzleDifficultyBandSchema>;
 export type PuzzlePageExperienceMode = z.infer<typeof puzzlePageExperienceModeSchema>;
+export type PuzzlePublishMode = z.infer<typeof puzzlePublishModeSchema>;
 export type PuzzleRegistryEntryRecord = z.infer<typeof puzzleRegistryEntrySchema>;
 export type PuzzleDetailContentRecord = z.infer<typeof puzzleDetailContentSchema>;
 export type PuzzleDetailDisplayRecord = z.infer<typeof puzzleDetailDisplaySchema>;

--- a/scripts/check-pinpoint-guardrails.ts
+++ b/scripts/check-pinpoint-guardrails.ts
@@ -10,6 +10,7 @@ import {
   validateDraftStructure,
 } from "../lib/puzzles/draft-validator";
 import { validateEvidenceContract } from "../lib/puzzles/evidence-contract";
+import { validatePublishEligibility } from "../lib/puzzles/publish-eligibility.shared.mjs";
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(SCRIPT_DIR, "..");
@@ -2084,6 +2085,48 @@ async function checkAdminApiRateLimit() {
   console.log("ok: admin APIs enforce shared rate limiting");
 }
 
+function checkPublishEligibilityBlocksShortPublishedAsFullAnalysis() {
+  const result = validatePublishEligibility({
+    slug: "pinpoint-answer-750",
+    expectedMode: "full-analysis",
+    answerFirstPublicEnabled: false,
+    registryEntry: {
+      puzzleNumber: 750,
+      slug: "pinpoint-answer-750",
+      publishDate: "2026-05-20",
+      status: "live",
+      detailState: "published",
+      clues: ["False", "Paper", "Nature", "Campaign", "Breadcrumb"],
+      mainAnswer: "Types of trails",
+    },
+    detail: {
+      slug: "pinpoint-answer-750",
+      detailState: "published",
+      bodyMode: "short",
+      pageExperienceMode: "light-explainer",
+      answer: "Types of trails",
+      clues: ["False", "Paper", "Nature", "Campaign", "Breadcrumb"],
+    },
+  });
+
+  assert.equal(result.ok, false, "short/light detail must not pass as full-analysis");
+  const codes = result.issues.map((issue) => issue.code);
+  assert.ok(
+    codes.includes("publishMode.bodyModeMismatch"),
+    "short body mode should return publishMode.bodyModeMismatch",
+  );
+  assert.ok(
+    codes.includes("publishMode.pageExperienceMismatch"),
+    "light explainer should return publishMode.pageExperienceMismatch",
+  );
+  assert.ok(
+    codes.includes("publishMode.answerFirstDisabled"),
+    "answer-first should be blocked when public answer-first is disabled",
+  );
+
+  console.log("ok: publish eligibility blocks short published payloads as full-analysis");
+}
+
 async function main() {
   await checkProductionDetailUsesRemoteFirst();
   await checkCurrentPuzzleSkipsNonPublicLiveEntry();
@@ -2100,6 +2143,7 @@ async function main() {
   await checkValidateDraftDoesNotNormalizeEmptySlots();
   await checkValidateDraftDoesNotNormalizeIncompleteSlotRows();
   await checkAdminApiRateLimit();
+  checkPublishEligibilityBlocksShortPublishedAsFullAnalysis();
   console.log("Pinpoint guardrail regression passed.");
 }
 

--- a/scripts/release-production.mjs
+++ b/scripts/release-production.mjs
@@ -3,6 +3,10 @@ import process from "node:process";
 import { dirname, resolve } from "node:path";
 import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
+import {
+  formatPublishGateIssues,
+  validatePublishEligibility,
+} from "../lib/puzzles/publish-eligibility.shared.mjs";
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(SCRIPT_DIR, "..");
@@ -246,7 +250,20 @@ async function loadLiveRegistryEntry() {
   return liveEntry;
 }
 
-function assertReleaseEligibleDetail(slug, puzzle, contextLabel) {
+function assertReleaseEligibleDetail(slug, puzzle, contextLabel, registryEntry = {}) {
+  const eligibility = validatePublishEligibility({
+    slug,
+    detail: puzzle,
+    registryEntry,
+    expectedMode: "full-analysis",
+    answerFirstPublicEnabled: false,
+  });
+  if (!eligibility.ok) {
+    throw new Error(
+      `${contextLabel} failed publish eligibility for ${slug}: ${formatPublishGateIssues(eligibility.issues)}`,
+    );
+  }
+
   const detailState = String(puzzle?.detailState || "published").trim().toLowerCase();
   if (detailState !== "published" && detailState !== "fallback_full") {
     throw new Error(
@@ -254,12 +271,6 @@ function assertReleaseEligibleDetail(slug, puzzle, contextLabel) {
     );
   }
 
-  const bodyMode = String(puzzle?.bodyMode || "").trim().toLowerCase();
-  if (bodyMode === "short") {
-    throw new Error(
-      `${contextLabel} is still short mode for ${slug}. Production release only allows formal full detail pages.`,
-    );
-  }
 }
 
 function buildDetailVerificationStrings(puzzle) {
@@ -353,7 +364,7 @@ async function main() {
 
   const localLiveEntry = await loadLiveRegistryEntry();
   const localLivePuzzle = await loadPublishedPuzzle(localLiveEntry.slug);
-  assertReleaseEligibleDetail(localLiveEntry.slug, localLivePuzzle, "Local live detail JSON");
+  assertReleaseEligibleDetail(localLiveEntry.slug, localLivePuzzle, "Local live detail JSON", localLiveEntry);
 
   logStep("Installing worker dependencies");
   await run("npm", ["ci"], { cwd: WORKER_DIR });
@@ -391,7 +402,7 @@ async function main() {
   const summary = await checkSummaryApi(`${DEFAULT_SITE_URL}/api/puzzles/summary`);
   const workerHealth = await checkWorkerHealth(DEFAULT_WORKER_HEALTH_URL);
   const publishedPuzzle = await loadPublishedPuzzle(summary.latest.slug);
-  assertReleaseEligibleDetail(summary.latest.slug, publishedPuzzle, "Published detail JSON");
+  assertReleaseEligibleDetail(summary.latest.slug, publishedPuzzle, "Published detail JSON", summary.latest);
   const detail = await waitForLatestDetailContent(DEFAULT_SITE_URL, summary.latest.slug, publishedPuzzle);
 
   logStep("Production release finished");

--- a/scripts/validate-data.ts
+++ b/scripts/validate-data.ts
@@ -1,8 +1,15 @@
-// @ts-nocheck
+// @ts-nocheck — This build-time validation script accesses raw JSON fields
+// (e.g. detail.answer, detail.fullAnalysis) that exist on the parsed data
+// but are not represented in the Zod-inferred PuzzleDetailContentRecord type.
+// The runtime behavior is correct; the type gaps are schema-only.
 import { readdir, readFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 import { validateEvidenceContract } from "../lib/puzzles/evidence-contract.shared.mjs";
+import {
+  formatPublishGateIssues,
+  validatePublishEligibility,
+} from "../lib/puzzles/publish-eligibility.shared.mjs";
 import { puzzleDetailContentSchema, registrySchema } from "../lib/puzzles/schema.shared.mjs";
 import {
   CONTENT_CONTRACT,
@@ -11,6 +18,7 @@ import {
 } from "../lib/puzzles/content-contract";
 import { buildPuzzleSeoDescription } from "../lib/seo/metadata";
 import { buildPinpointDescription, buildPinpointTitle } from "../lib/seo/pinpoint";
+import type { PuzzleRegistryEntryRecord, PuzzleDetailContentRecord } from "../lib/puzzles/schema";
 
 const htmlTagPattern = /<\/?[a-z][^>]*>/i;
 const adjacentQuotePattern = /["“”]{2,}/;
@@ -55,9 +63,9 @@ const publishedContractBacklogLimits = new Map(
     "summary.promotionalTone": 4,
   }),
 );
-const publishedContractBacklogCounts = new Map();
-const publishedContractBacklogSamples = new Map();
-const publishedLessonTitleOccurrences = new Map();
+const publishedContractBacklogCounts = new Map<string, number>();
+const publishedContractBacklogSamples = new Map<string, string[]>();
+const publishedLessonTitleOccurrences = new Map<string, string[]>();
 const genericSpoilerHintPatterns = [
   /\bTreat this as one member of a narrower category\b/i,
   /\bThis clue becomes useful once you stop reading it literally\b/i,
@@ -71,17 +79,17 @@ const allowedRecentContinuityGaps = new Map([
   // [750, "Documented reason for an intentional public numbering gap"],
 ]);
 
-function countWords(value) {
+function countWords(value: string) {
   return value.trim().split(/\s+/).filter(Boolean).length;
 }
 
-function assertNoHtml(label, value) {
+function assertNoHtml(label: string, value: string) {
   if (htmlTagPattern.test(value)) {
     throw new Error(`${label} contains HTML markup and must be plain text.`);
   }
 }
 
-function assertNoLegacyTemplate(label, value) {
+function assertNoLegacyTemplate(label: string, value: string) {
   const normalized = String(value || "").toLowerCase();
   const matched = legacyTemplateMarkers.find((marker) => normalized.includes(marker));
   if (matched) {
@@ -89,13 +97,13 @@ function assertNoLegacyTemplate(label, value) {
   }
 }
 
-function assertNoAdjacentQuotes(label, value) {
+function assertNoAdjacentQuotes(label: string, value: string) {
   if (adjacentQuotePattern.test(String(value || ""))) {
     throw new Error(`${label} contains malformed adjacent quote characters.`);
   }
 }
 
-function assertNoWrappedQuotedAnswer(label, value, answer) {
+function assertNoWrappedQuotedAnswer(label: string, value: string, answer: string) {
   const text = String(value || "");
   const normalizedAnswer = String(answer || "").trim();
   if (!normalizedAnswer || !/["“”]/.test(normalizedAnswer)) {
@@ -112,7 +120,7 @@ function assertNoWrappedQuotedAnswer(label, value, answer) {
   }
 }
 
-function recordPublishedContractBacklog(code, sample) {
+function recordPublishedContractBacklog(code: string, sample: string) {
   publishedContractBacklogCounts.set(code, (publishedContractBacklogCounts.get(code) || 0) + 1);
   const samples = publishedContractBacklogSamples.get(code) || [];
   if (sample && samples.length < 5) {
@@ -137,14 +145,14 @@ function assertPublishedContractBacklogLimits() {
   }
 }
 
-function normalizeRepeatedLessonTitle(title) {
+function normalizeRepeatedLessonTitle(title: string) {
   return String(title || "")
     .replace(/\s+/g, " ")
     .trim()
     .toLowerCase();
 }
 
-function getRenderedLessonTitle(lesson) {
+function getRenderedLessonTitle(lesson: string | { title?: string; body?: string } | null) {
   if (!lesson) {
     return "";
   }
@@ -155,7 +163,7 @@ function getRenderedLessonTitle(lesson) {
   return String(lesson.title || "").trim();
 }
 
-function recordPublishedLessonTitle(entry, lesson, index) {
+function recordPublishedLessonTitle(entry: PuzzleRegistryEntryRecord, lesson: string | { title?: string; body?: string } | null, index: number) {
   const title = getRenderedLessonTitle(lesson);
   const normalizedTitle = normalizeRepeatedLessonTitle(title);
   if (!normalizedTitle) {
@@ -182,7 +190,7 @@ function assertNoRepeatedPublishedLessonTitles() {
   throw new Error(`Published lesson titles must be page-specific; repeated titles found. Samples: ${samples}`);
 }
 
-function normalizeLessonsForContract(lessons) {
+function normalizeLessonsForContract(lessons: PuzzleDetailContentRecord["lessons"]) {
   return (lessons || []).map((lesson) => {
     if (typeof lesson === "string") {
       return { title: "", body: lesson };
@@ -194,7 +202,7 @@ function normalizeLessonsForContract(lessons) {
   });
 }
 
-function toContractClueDetails(detail) {
+function toContractClueDetails(detail: PuzzleDetailContentRecord) {
   return Array.isArray(detail.clueRows)
     ? detail.clueRows.map((row) => ({
         clue: row?.clue,
@@ -204,7 +212,7 @@ function toContractClueDetails(detail) {
     : [];
 }
 
-function toContractFaqs(detail) {
+function toContractFaqs(detail: PuzzleDetailContentRecord) {
   const source = Array.isArray(detail.faqItems) && detail.faqItems.length > 0
     ? detail.faqItems
     : detail.faqs;
@@ -214,7 +222,7 @@ function toContractFaqs(detail) {
   }));
 }
 
-function validatePageSeoDescription(entry) {
+function validatePageSeoDescription(entry: PuzzleRegistryEntryRecord) {
   const pageSeoDescription = buildPuzzleSeoDescription(entry.puzzleNumber, entry.clues, entry.mainAnswer);
   const len = pageSeoDescription.length;
   if (pageSeoDescription.includes("Answer: ")) {
@@ -238,7 +246,7 @@ function validatePageSeoDescription(entry) {
   }
 }
 
-function validatePublishedContentContract(entry, detail, bodyParagraphs) {
+function validatePublishedContentContract(entry: PuzzleRegistryEntryRecord, detail: PuzzleDetailContentRecord, bodyParagraphs: string[]) {
   validatePageSeoDescription(entry);
   const solutionNarrative = Array.isArray(detail.solutionNarrative) ? detail.solutionNarrative : [];
   const contractInput = {
@@ -277,7 +285,7 @@ function validatePublishedContentContract(entry, detail, bodyParagraphs) {
   }
 }
 
-function getExpectedPublishDateForPuzzleNumber(puzzleNumber) {
+function getExpectedPublishDateForPuzzleNumber(puzzleNumber: number) {
   if (!Number.isInteger(puzzleNumber) || puzzleNumber < modernPuzzleDateBaseline.puzzleNumber) {
     return "";
   }
@@ -290,7 +298,7 @@ function getExpectedPublishDateForPuzzleNumber(puzzleNumber) {
   return publishDate.toISOString().slice(0, 10);
 }
 
-function requiresPhase1StructuredValidation(entry, detail) {
+function requiresPhase1StructuredValidation(entry: PuzzleRegistryEntryRecord, detail: PuzzleDetailContentRecord) {
   const pageExperienceMode =
     detail.pageExperienceMode === "light-explainer" || detail.bodyMode === "short"
       ? "light-explainer"
@@ -306,7 +314,7 @@ function requiresPhase1StructuredValidation(entry, detail) {
   );
 }
 
-function resolveRegistryDetailState(entry) {
+function resolveRegistryDetailState(entry: PuzzleRegistryEntryRecord) {
   if (entry.detailState) {
     return entry.detailState;
   }
@@ -314,7 +322,7 @@ function resolveRegistryDetailState(entry) {
   return entry.status === "draft" || entry.status === "preview" ? "draft" : "published";
 }
 
-function isPublicRegistryEntry(entry) {
+function isPublicRegistryEntry(entry: PuzzleRegistryEntryRecord) {
   return (
     publicRegistryStatuses.has(entry.status) &&
     publicDetailStates.has(resolveRegistryDetailState(entry)) &&
@@ -323,7 +331,7 @@ function isPublicRegistryEntry(entry) {
   );
 }
 
-async function readPublicDetailFileSlugs(dataDir) {
+async function readPublicDetailFileSlugs(dataDir: string) {
   const fileNames = await readdir(dataDir);
   const publicSlugs = [];
 
@@ -344,7 +352,7 @@ async function readPublicDetailFileSlugs(dataDir) {
   return publicSlugs.sort();
 }
 
-function assertPublicDetailsAreRegistered(publicDetailSlugs, registrySlugs) {
+function assertPublicDetailsAreRegistered(publicDetailSlugs: string[], registrySlugs: Set<string>) {
   const missing = publicDetailSlugs.filter((slug) => !registrySlugs.has(slug));
 
   if (missing.length > 0) {
@@ -354,7 +362,7 @@ function assertPublicDetailsAreRegistered(publicDetailSlugs, registrySlugs) {
   }
 }
 
-function assertRecentPublicRegistryContinuity(registry) {
+function assertRecentPublicRegistryContinuity(registry: PuzzleRegistryEntryRecord[]) {
   const publicNumbers = registry
     .filter(isPublicRegistryEntry)
     .map((entry) => entry.puzzleNumber)
@@ -381,7 +389,20 @@ function assertRecentPublicRegistryContinuity(registry) {
   }
 }
 
-function validateDetailContent(entry, detail) {
+function validateDetailContent(entry: PuzzleRegistryEntryRecord, detail: PuzzleDetailContentRecord) {
+  if (detail.publishMode || entry.publishMode) {
+    const eligibility = validatePublishEligibility({
+      slug: entry.slug,
+      registryEntry: entry,
+      detail,
+      expectedMode: detail.publishMode === "answer-first" ? "answer-first" : "full-analysis",
+      answerFirstPublicEnabled: false,
+    });
+    if (!eligibility.ok) {
+      throw new Error(`${entry.slug} failed publish eligibility: ${formatPublishGateIssues(eligibility.issues)}`);
+    }
+  }
+
   const detailAnswer = typeof detail.answer === "string" ? detail.answer : "";
   const articleBlocks = Array.isArray(detail.articleBlocks) ? detail.articleBlocks : [];
   const fullAnalysis = Array.isArray(detail.fullAnalysis) ? detail.fullAnalysis : [];
@@ -553,10 +574,10 @@ async function main() {
   const registry = registrySchema.parse(JSON.parse(rawRegistry));
   const publicDetailSlugs = await readPublicDetailFileSlugs(dataDir);
 
-  const numbers = new Set();
-  const slugs = new Set();
-  const publicRegistrySlugs = new Set();
-  const dates = new Set();
+  const numbers = new Set<number>();
+  const slugs = new Set<string>();
+  const publicRegistrySlugs = new Set<string>();
+  const dates = new Set<string>();
   let liveCount = 0;
   let previewCount = 0;
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -11,6 +11,10 @@ import {
 } from "../../lib/puzzles/fallback-copy";
 import { getPinpointUnlockUtcHour } from "../../lib/utils/pinpoint-unlock";
 import {
+  formatPublishGateIssues,
+  validatePublishEligibility,
+} from "../../lib/puzzles/publish-eligibility.shared.mjs";
+import {
   generatePuzzleDraft,
   regeneratePuzzleDraft,
   type EnrichInput,
@@ -77,6 +81,13 @@ type Doc = {
 };
 
 type JsonRecord = Record<string, unknown>;
+
+class PublishEligibilityBlockedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PublishEligibilityBlockedError";
+  }
+}
 
 type GraphQLOperation = {
   isPrimary?: boolean;
@@ -3248,6 +3259,27 @@ async function publishToNewSiteGitHub(
     if (!finalReadiness.ok) {
       throw new Error(`[new-site] final publish guard failed for ${slugPath}: ${finalReadiness.reason}`);
     }
+
+    const eligibility = validatePublishEligibility({
+      slug,
+      detail: detailRecord as Record<string, unknown>,
+      registryEntry: {
+        puzzleNumber,
+        slug,
+        publishDate: puzzleDate,
+        status: "live",
+        detailState,
+        clues: words,
+        mainAnswer: answer,
+      },
+      expectedMode: "full-analysis",
+      answerFirstPublicEnabled: false,
+    });
+    if (!eligibility.ok) {
+      throw new PublishEligibilityBlockedError(
+        `[new-site] publish eligibility failed for ${slugPath}: ${formatPublishGateIssues(eligibility.issues)}`,
+      );
+    }
   }
   const slugJson = JSON.stringify(omitLegacyFullAnalysisForStorage(detailRecord), null, 2);
   const slugProtection = resolveThinContentProtectionDecision({
@@ -4003,6 +4035,10 @@ async function enrichPublishToSite(
       detailState: publishDetailState,
     };
   } catch (error) {
+    if (error instanceof PublishEligibilityBlockedError) {
+      await options.onDetailStateChange?.("failed", error.message);
+      throw error;
+    }
     try {
       await publishToNewSiteGitHub(env, puzzleDate, doc, failedPayload, puzzleNumber);
       await options.onDetailStateChange?.(


### PR DESCRIPTION
## Summary

- Adds shared `publishMode` and `validatePublishEligibility` contract for Pinpoint public payloads.
- Wires release production, Worker final public write, and `validate:data` to the same eligibility rules.
- Blocks #750-style `short` / `light-explainer` payloads from being published as `full-analysis`.
- Keeps legacy data compatible by only applying repo-level publish eligibility when new publish mode fields are present.

## Scope

- Approved PR1 only: publish mode, shared eligibility, Worker/release/data validation alignment, and #750 regression guardrail.
- Does not add failure summaries, Evidence V1, override behavior, rendered HTML checks, SLA cron, candidate branches, or model routing.

## Validation

- `npm run test:pinpoint-guardrails`
- `npm run typecheck`
- `npm run validate:data`
- `cd worker && npm run typecheck`

## Stack

- PR1 base: `main`
- PR2 base: `codex/content-gate-pr1`
- PR3 base: `codex/content-gate-pr2`
