### PR TITLE
Record Pinpoint publish failure summaries

### DIFF
--- a/lib/puzzles/publish-failure-summary.d.ts
+++ b/lib/puzzles/publish-failure-summary.d.ts
@@ -1,0 +1,55 @@
+import type { PublishGateIssue, PublishMode } from "./publish-eligibility";
+
+export type SourceConfidence = "confirmed" | "manual" | "inferred" | "weak" | "unknown";
+
+export type LightweightPublishFailureSummary = {
+  version: 1;
+  kind: "pinpoint-lightweight-publish-failure-summary";
+  generatedAt: string;
+  slug: string;
+  logicalGameDate: string;
+  puzzleNumber?: number;
+  publishMode: PublishMode | "unknown";
+  issueCodes: string[];
+  blockingIssueCodes: string[];
+  issues: Array<Pick<PublishGateIssue, "code" | "level" | "message" | "field">>;
+  sourceConfidence: SourceConfidence;
+  retryCount: number;
+  reason: string;
+  nextAction: string;
+};
+
+export type LightweightPublishFailureStreak = {
+  version: 1;
+  count: number;
+  threshold: number;
+  triggered: boolean;
+  lastLogicalGameDate: string;
+  lastSlug: string;
+  lastPublishMode: PublishMode | "unknown";
+  lastIssueCodes: string[];
+  updatedAt: string;
+};
+
+export function buildLightweightPublishFailureSummary(input?: {
+  slug?: string;
+  logicalGameDate?: string;
+  puzzleDate?: string;
+  puzzleNumber?: number;
+  publishMode?: PublishMode | "unknown";
+  issues?: PublishGateIssue[];
+  sourceConfidence?: SourceConfidence;
+  retryCount?: number;
+  reason?: string;
+  nextAction?: string;
+  generatedAt?: string;
+}): LightweightPublishFailureSummary;
+
+export function updateLightweightPublishFailureStreak(
+  previous?: Partial<LightweightPublishFailureStreak> | null,
+  summary?: Partial<LightweightPublishFailureSummary>,
+  options?: {
+    threshold?: number;
+    updatedAt?: string;
+  },
+): LightweightPublishFailureStreak;

--- a/lib/puzzles/publish-failure-summary.shared.d.mts
+++ b/lib/puzzles/publish-failure-summary.shared.d.mts
@@ -1,0 +1,55 @@
+import type { PublishGateIssue, PublishMode } from "./publish-eligibility.shared.mjs";
+
+export type SourceConfidence = "confirmed" | "manual" | "inferred" | "weak" | "unknown";
+
+export type LightweightPublishFailureSummary = {
+  version: 1;
+  kind: "pinpoint-lightweight-publish-failure-summary";
+  generatedAt: string;
+  slug: string;
+  logicalGameDate: string;
+  puzzleNumber?: number;
+  publishMode: PublishMode | "unknown";
+  issueCodes: string[];
+  blockingIssueCodes: string[];
+  issues: Array<Pick<PublishGateIssue, "code" | "level" | "message" | "field">>;
+  sourceConfidence: SourceConfidence;
+  retryCount: number;
+  reason: string;
+  nextAction: string;
+};
+
+export type LightweightPublishFailureStreak = {
+  version: 1;
+  count: number;
+  threshold: number;
+  triggered: boolean;
+  lastLogicalGameDate: string;
+  lastSlug: string;
+  lastPublishMode: PublishMode | "unknown";
+  lastIssueCodes: string[];
+  updatedAt: string;
+};
+
+export declare function buildLightweightPublishFailureSummary(input?: {
+  slug?: string;
+  logicalGameDate?: string;
+  puzzleDate?: string;
+  puzzleNumber?: number;
+  publishMode?: PublishMode | "unknown";
+  issues?: PublishGateIssue[];
+  sourceConfidence?: SourceConfidence;
+  retryCount?: number;
+  reason?: string;
+  nextAction?: string;
+  generatedAt?: string;
+}): LightweightPublishFailureSummary;
+
+export declare function updateLightweightPublishFailureStreak(
+  previous?: Partial<LightweightPublishFailureStreak> | null,
+  summary?: Partial<LightweightPublishFailureSummary>,
+  options?: {
+    threshold?: number;
+    updatedAt?: string;
+  },
+): LightweightPublishFailureStreak;

--- a/lib/puzzles/publish-failure-summary.shared.mjs
+++ b/lib/puzzles/publish-failure-summary.shared.mjs
@@ -1,0 +1,118 @@
+const sourceConfidenceValues = new Set(["confirmed", "manual", "inferred", "weak", "unknown"]);
+
+function normalizeString(value) {
+  return String(value ?? "").trim();
+}
+
+function normalizeSourceConfidence(value) {
+  const normalized = normalizeString(value);
+  return sourceConfidenceValues.has(normalized) ? normalized : "unknown";
+}
+
+function normalizeIssue(issue) {
+  const row = issue && typeof issue === "object" ? issue : {};
+  const code = normalizeString(row.code) || "publishGate.unknown";
+  const level = normalizeString(row.level) || "blocking";
+  const message = normalizeString(row.message) || code;
+  return {
+    code,
+    level,
+    message,
+    ...(normalizeString(row.field) ? { field: normalizeString(row.field) } : {}),
+  };
+}
+
+function normalizeIssueCodes(issues) {
+  const codes = [];
+  for (const issue of Array.isArray(issues) ? issues : []) {
+    const code = normalizeString(issue?.code);
+    if (code && !codes.includes(code)) {
+      codes.push(code);
+    }
+  }
+  return codes;
+}
+
+export function buildLightweightPublishFailureSummary(input = {}) {
+  const issues = (Array.isArray(input.issues) ? input.issues : []).map(normalizeIssue);
+  const blockingIssues = issues.filter((issue) => issue.level === "blocking" || issue.level === "error");
+  const issueCodes = normalizeIssueCodes(issues);
+  const blockingIssueCodes = normalizeIssueCodes(blockingIssues);
+  const slug = normalizeString(input.slug);
+  const logicalGameDate = normalizeString(input.logicalGameDate || input.puzzleDate);
+  const publishMode = normalizeString(input.publishMode) || "unknown";
+  const sourceConfidence = normalizeSourceConfidence(input.sourceConfidence);
+  const reason = normalizeString(input.reason) || "publish eligibility blocked";
+  const nextAction =
+    normalizeString(input.nextAction) ||
+    (blockingIssueCodes.length > 0
+      ? "review payload against publish eligibility issue codes before retrying public write"
+      : "review publish failure summary before retrying public write");
+  const retryCount = Number.isFinite(input.retryCount) && input.retryCount >= 0
+    ? Math.floor(input.retryCount)
+    : 0;
+  const puzzleNumber = Number(input.puzzleNumber);
+
+  return {
+    version: 1,
+    kind: "pinpoint-lightweight-publish-failure-summary",
+    generatedAt: normalizeString(input.generatedAt) || new Date().toISOString(),
+    slug,
+    logicalGameDate,
+    ...(Number.isInteger(puzzleNumber) && puzzleNumber > 0 ? { puzzleNumber } : {}),
+    publishMode,
+    issueCodes,
+    blockingIssueCodes,
+    issues,
+    sourceConfidence,
+    retryCount,
+    reason,
+    nextAction,
+  };
+}
+
+function dateOrdinal(date) {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(normalizeString(date));
+  if (!match) return null;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const utc = Date.UTC(year, month - 1, day);
+  if (!Number.isFinite(utc)) return null;
+  return Math.floor(utc / 86_400_000);
+}
+
+export function updateLightweightPublishFailureStreak(previous = null, summary = {}, options = {}) {
+  const threshold = Number.isFinite(options.threshold) && options.threshold > 0
+    ? Math.floor(options.threshold)
+    : 3;
+  const previousRecord = previous && typeof previous === "object" ? previous : {};
+  const previousDate = normalizeString(previousRecord.lastLogicalGameDate);
+  const currentDate = normalizeString(summary.logicalGameDate);
+  const previousOrdinal = dateOrdinal(previousDate);
+  const currentOrdinal = dateOrdinal(currentDate);
+  const previousCount = Number.isFinite(previousRecord.count) && previousRecord.count > 0
+    ? Math.floor(previousRecord.count)
+    : 0;
+  const count = previousDate && currentDate === previousDate
+    ? Math.max(previousCount, 1)
+    : previousOrdinal !== null && currentOrdinal !== null && currentOrdinal === previousOrdinal + 1
+      ? previousCount + 1
+      : 1;
+
+  return {
+    version: 1,
+    count,
+    threshold,
+    triggered: count >= threshold,
+    lastLogicalGameDate: currentDate,
+    lastSlug: normalizeString(summary.slug),
+    lastPublishMode: normalizeString(summary.publishMode) || "unknown",
+    lastIssueCodes: Array.isArray(summary.blockingIssueCodes) && summary.blockingIssueCodes.length > 0
+      ? summary.blockingIssueCodes
+      : Array.isArray(summary.issueCodes)
+        ? summary.issueCodes
+        : [],
+    updatedAt: normalizeString(options.updatedAt) || new Date().toISOString(),
+  };
+}

--- a/scripts/check-pinpoint-guardrails.ts
+++ b/scripts/check-pinpoint-guardrails.ts
@@ -10,6 +10,10 @@ import {
   validateDraftStructure,
 } from "../lib/puzzles/draft-validator";
 import { validateEvidenceContract } from "../lib/puzzles/evidence-contract";
+import {
+  buildLightweightPublishFailureSummary,
+  updateLightweightPublishFailureStreak,
+} from "../lib/puzzles/publish-failure-summary.shared.mjs";
 import { validatePublishEligibility } from "../lib/puzzles/publish-eligibility.shared.mjs";
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
@@ -2127,6 +2131,96 @@ function checkPublishEligibilityBlocksShortPublishedAsFullAnalysis() {
   console.log("ok: publish eligibility blocks short published payloads as full-analysis");
 }
 
+function checkLightweightPublishFailureSummary() {
+  const gateResult = validatePublishEligibility({
+    slug: "pinpoint-answer-750",
+    expectedMode: "full-analysis",
+    answerFirstPublicEnabled: false,
+    registryEntry: {
+      puzzleNumber: 750,
+      slug: "pinpoint-answer-750",
+      publishDate: "2026-05-20",
+      status: "live",
+      detailState: "published",
+      clues: ["False", "Paper", "Nature", "Campaign", "Breadcrumb"],
+      mainAnswer: "Types of trails",
+    },
+    detail: {
+      slug: "pinpoint-answer-750",
+      detailState: "published",
+      bodyMode: "short",
+      pageExperienceMode: "light-explainer",
+      answer: "Types of trails",
+      clues: ["False", "Paper", "Nature", "Campaign", "Breadcrumb"],
+    },
+  });
+
+  const summary = buildLightweightPublishFailureSummary({
+    slug: gateResult.slug,
+    logicalGameDate: "2026-05-20",
+    puzzleNumber: gateResult.puzzleNumber,
+    publishMode: gateResult.publishMode,
+    issues: gateResult.issues,
+    sourceConfidence: "unknown",
+    generatedAt: "2026-05-20T18:30:00.000Z",
+    reason: "publish eligibility blocked",
+  });
+
+  assert.equal(summary.kind, "pinpoint-lightweight-publish-failure-summary");
+  assert.equal(summary.slug, "pinpoint-answer-750");
+  assert.equal(summary.logicalGameDate, "2026-05-20");
+  assert.equal(summary.puzzleNumber, 750);
+  assert.equal(summary.publishMode, "answer-first");
+  assert.equal(summary.sourceConfidence, "unknown");
+  assert.ok(
+    summary.blockingIssueCodes.includes("publishMode.answerFirstDisabled"),
+    "failure summary should preserve blocking issue codes",
+  );
+  assert.ok(
+    summary.nextAction.includes("publish eligibility issue codes"),
+    "failure summary should include an actionable next step",
+  );
+
+  const day1 = updateLightweightPublishFailureStreak(null, {
+    ...summary,
+    logicalGameDate: "2026-05-20",
+  }, {
+    threshold: 3,
+    updatedAt: "2026-05-20T18:30:00.000Z",
+  });
+  const sameDay = updateLightweightPublishFailureStreak(day1, {
+    ...summary,
+    logicalGameDate: "2026-05-20",
+  }, {
+    threshold: 3,
+    updatedAt: "2026-05-20T18:45:00.000Z",
+  });
+  const day2 = updateLightweightPublishFailureStreak(sameDay, {
+    ...summary,
+    logicalGameDate: "2026-05-21",
+    slug: "pinpoint-answer-751",
+  }, {
+    threshold: 3,
+    updatedAt: "2026-05-21T18:30:00.000Z",
+  });
+  const day3 = updateLightweightPublishFailureStreak(day2, {
+    ...summary,
+    logicalGameDate: "2026-05-22",
+    slug: "pinpoint-answer-752",
+  }, {
+    threshold: 3,
+    updatedAt: "2026-05-22T18:30:00.000Z",
+  });
+
+  assert.equal(day1.count, 1, "first failure should start the streak");
+  assert.equal(sameDay.count, 1, "same-day retries should not inflate the failure streak");
+  assert.equal(day2.count, 2, "next-day failure should increment the streak");
+  assert.equal(day3.count, 3, "third consecutive day should reach the streak threshold");
+  assert.equal(day3.triggered, true, "third consecutive failure should trigger the alert");
+
+  console.log("ok: lightweight publish failure summary preserves issue codes and streaks");
+}
+
 async function main() {
   await checkProductionDetailUsesRemoteFirst();
   await checkCurrentPuzzleSkipsNonPublicLiveEntry();
@@ -2144,6 +2238,7 @@ async function main() {
   await checkValidateDraftDoesNotNormalizeIncompleteSlotRows();
   await checkAdminApiRateLimit();
   checkPublishEligibilityBlocksShortPublishedAsFullAnalysis();
+  checkLightweightPublishFailureSummary();
   console.log("Pinpoint guardrail regression passed.");
 }
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -15,6 +15,10 @@ import {
   validatePublishEligibility,
 } from "../../lib/puzzles/publish-eligibility.shared.mjs";
 import {
+  buildLightweightPublishFailureSummary,
+  updateLightweightPublishFailureStreak,
+} from "../../lib/puzzles/publish-failure-summary.shared.mjs";
+import {
   generatePuzzleDraft,
   regeneratePuzzleDraft,
   type EnrichInput,
@@ -82,10 +86,44 @@ type Doc = {
 
 type JsonRecord = Record<string, unknown>;
 
+type PublishGateIssueRecord = {
+  code: string;
+  level: "blocking" | "warning" | "info";
+  message: string;
+  field?: string;
+};
+
+type PublishGateResultRecord = {
+  ok: boolean;
+  slug?: string;
+  puzzleNumber?: number;
+  publishMode?: "answer-first" | "full-analysis" | "failed";
+  issues: PublishGateIssueRecord[];
+};
+
+type LightweightPublishFailureSummaryRecord = {
+  version: 1;
+  kind: "pinpoint-lightweight-publish-failure-summary";
+  generatedAt: string;
+  slug: string;
+  logicalGameDate: string;
+  puzzleNumber?: number;
+  publishMode: "answer-first" | "full-analysis" | "failed" | "unknown";
+  issueCodes: string[];
+  blockingIssueCodes: string[];
+  sourceConfidence: "confirmed" | "manual" | "inferred" | "weak" | "unknown";
+  retryCount: number;
+  reason: string;
+  nextAction: string;
+};
+
 class PublishEligibilityBlockedError extends Error {
-  constructor(message: string) {
+  result?: PublishGateResultRecord;
+
+  constructor(message: string, result?: PublishGateResultRecord) {
     super(message);
     this.name = "PublishEligibilityBlockedError";
+    this.result = result;
   }
 }
 
@@ -3278,6 +3316,7 @@ async function publishToNewSiteGitHub(
     if (!eligibility.ok) {
       throw new PublishEligibilityBlockedError(
         `[new-site] publish eligibility failed for ${slugPath}: ${formatPublishGateIssues(eligibility.issues)}`,
+        eligibility as PublishGateResultRecord,
       );
     }
   }
@@ -4036,6 +4075,7 @@ async function enrichPublishToSite(
     };
   } catch (error) {
     if (error instanceof PublishEligibilityBlockedError) {
+      await recordPublishEligibilityBlocked(env, puzzleDate, puzzleNumber, error);
       await options.onDetailStateChange?.("failed", error.message);
       throw error;
     }
@@ -4520,6 +4560,113 @@ async function notifyCron(env: Env, title: string, lines: string[]): Promise<voi
   if (tasks.length > 0) {
     await Promise.all(tasks);
   }
+}
+
+const publishFailureSummaryKeyOf = (logicalGameDate: string, slug: string) =>
+  `publish:failure-summary:${logicalGameDate}:${slug}`;
+const publishFailureStreakKeyOf = () => "publish:failure-streak:pinpoint";
+const publishFailureStreakNotifyKeyOf = (logicalGameDate: string, count: number) =>
+  `notify:publish-failure-streak:${logicalGameDate}:${count}`;
+const publishEligibilityBlockedNotifyKeyOf = (
+  logicalGameDate: string,
+  slug: string,
+  issueCodes: string[],
+) => {
+  const issueSignature = (issueCodes.length > 0 ? issueCodes : ["unknown"])
+    .map((code) => encodeURIComponent(code))
+    .join("|")
+    .slice(0, 180);
+  return `notify:publish-eligibility-blocked:${logicalGameDate}:${slug}:${issueSignature}`;
+};
+
+async function persistLightweightPublishFailureSummary(
+  env: Env,
+  summary: LightweightPublishFailureSummaryRecord,
+): Promise<void> {
+  if (!summary.logicalGameDate || !summary.slug) return;
+
+  const summaryKey = publishFailureSummaryKeyOf(summary.logicalGameDate, summary.slug);
+  await env.PP_DATA.put(summaryKey, JSON.stringify(summary), {
+    expirationTtl: 60 * 60 * 24 * 400,
+  }).catch((error) => {
+    console.warn("[new-site] failed to persist lightweight publish failure summary", error);
+  });
+
+  const streakKey = publishFailureStreakKeyOf();
+  const previousRaw = await env.PP_DATA.get(streakKey).catch(() => null);
+  let previous: JsonRecord | null = null;
+  if (previousRaw) {
+    try {
+      previous = JSON.parse(previousRaw) as JsonRecord;
+    } catch {
+      previous = null;
+    }
+  }
+
+  const streak = updateLightweightPublishFailureStreak(previous, summary, { threshold: 3 });
+  await env.PP_DATA.put(streakKey, JSON.stringify(streak), {
+    expirationTtl: 60 * 60 * 24 * 45,
+  }).catch((error) => {
+    console.warn("[new-site] failed to persist lightweight publish failure streak", error);
+  });
+
+  if (streak.triggered) {
+    const notifyKey = publishFailureStreakNotifyKeyOf(streak.lastLogicalGameDate, streak.count);
+    const alreadyNotified = await env.PP_DATA.get(notifyKey).then((value) => value !== null).catch(() => false);
+    if (!alreadyNotified) {
+      await env.PP_DATA.put(notifyKey, "1", { expirationTtl: 60 * 60 * 24 * 7 }).catch(() => undefined);
+      await notifyCron(env, "🚨 Pinpoint 连续发布降级/失败告警", [
+        `连续次数: ${streak.count}`,
+        `最近日期: ${streak.lastLogicalGameDate}`,
+        `最近页面: ${streak.lastSlug}`,
+        `最近模式: ${streak.lastPublishMode}`,
+        `阻断码: ${streak.lastIssueCodes.join(", ") || "unknown"}`,
+        "下一步: 聚合最近失败摘要，优先修复共性 publish eligibility 问题。",
+      ]);
+    }
+  }
+}
+
+async function recordPublishEligibilityBlocked(
+  env: Env,
+  puzzleDate: string,
+  puzzleNumber: number,
+  error: PublishEligibilityBlockedError,
+): Promise<LightweightPublishFailureSummaryRecord> {
+  const slug = error.result?.slug || `pinpoint-answer-${puzzleNumber}`;
+  const summary = buildLightweightPublishFailureSummary({
+    slug,
+    logicalGameDate: puzzleDate,
+    puzzleNumber: error.result?.puzzleNumber || puzzleNumber,
+    publishMode: error.result?.publishMode || "unknown",
+    issues: error.result?.issues || [],
+    sourceConfidence: "unknown",
+    reason: error.message,
+    retryCount: 0,
+  }) as LightweightPublishFailureSummaryRecord;
+
+  await persistLightweightPublishFailureSummary(env, summary);
+  const blockingIssueCodes = summary.blockingIssueCodes.length > 0 ? summary.blockingIssueCodes : summary.issueCodes;
+  const notifyKey = publishEligibilityBlockedNotifyKeyOf(
+    summary.logicalGameDate,
+    summary.slug,
+    blockingIssueCodes,
+  );
+  const alreadyNotified = await env.PP_DATA.get(notifyKey).then((value) => value !== null).catch(() => false);
+  if (!alreadyNotified) {
+    await env.PP_DATA.put(notifyKey, "1", { expirationTtl: 60 * 60 * 48 }).catch(() => undefined);
+    await notifyCron(env, "⛔ 新站 publish eligibility 阻断", [
+      `日期: ${summary.logicalGameDate}`,
+      `谜题: #${summary.puzzleNumber ?? puzzleNumber}`,
+      `页面: ${summary.slug}`,
+      `模式: ${summary.publishMode}`,
+      `Source confidence: ${summary.sourceConfidence}`,
+      `阻断码: ${blockingIssueCodes.join(", ") || "unknown"}`,
+      `下一步: ${summary.nextAction}`,
+    ]);
+  }
+
+  return summary;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds lightweight publish failure summary helpers for eligibility-blocked Pinpoint payloads.
- Persists blocked publish summaries to KV with slug, logical game date, publish mode, source confidence, and issue codes.
- Tracks consecutive logical-day publish failures/degradations and sends a deduped high-priority alert at the threshold.
- Prevents eligibility-blocked final payloads from recursively writing public `failed` fallback payloads.

## Scope

- Approved PR2 only: final payload failure handling, issue-code notification, lightweight summary, and continuous-failure alerting.
- Does not add Evidence V1, override behavior, rendered HTML checks, SLA cron, candidate branches, or model routing.

## Validation

- `npm run test:pinpoint-guardrails`
- `npm run typecheck`
- `npm run validate:data`
- `cd worker && npm run typecheck`

## Stack

- Depends on PR1: `codex/content-gate-pr1`
- PR3 base: `codex/content-gate-pr2`
