### PR TITLE
Add Pinpoint Evidence V1 dry-run guards

### DIFF
--- a/lib/puzzles/pinpoint-evidence-v1.d.ts
+++ b/lib/puzzles/pinpoint-evidence-v1.d.ts
@@ -1,0 +1,60 @@
+export type EvidenceSupportLevelV1 = "deterministic" | "manual" | "weak";
+export type EvidenceFitConfidenceV1 = "confirmed" | "manual" | "weak";
+export type EvidenceAnswerConfidenceV1 = "confirmed" | "manual" | "inferred" | "weak";
+export type EvidenceTimezoneSourceV1 = "assumption" | "verified" | "manual";
+export type EvidenceSourceProviderV1 = "graphql" | "manual" | "cached" | "unknown";
+
+export type PinpointEvidenceV1Issue = {
+  level: "error";
+  code: string;
+  message: string;
+  field?: string;
+};
+
+export type PinpointEvidenceV1 = {
+  schemaVersion: 1;
+  slug: string;
+  puzzleNumber: number;
+  logicalGameDate: string;
+  source: {
+    provider: EvidenceSourceProviderV1;
+    fetchedAt: string;
+    timezone: string;
+    timezoneSource: EvidenceTimezoneSourceV1;
+    rawResponseHash?: string;
+    rawResponse?: string;
+  };
+  answer: {
+    value: string;
+    confidence: EvidenceAnswerConfidenceV1;
+    confirmedAt?: string;
+  };
+  clues: Array<{
+    index: number;
+    text: string;
+    fit?: string;
+    evidenceRef: string;
+    supportLevel: EvidenceSupportLevelV1;
+    fitConfidence: EvidenceFitConfidenceV1;
+    phraseExample?: string;
+  }>;
+  manualReview?: {
+    reviewer?: string;
+    timestamp?: string;
+    reason?: string;
+    changedFields?: string[];
+  };
+};
+
+export function isFixtureEvidencePath(path: unknown): boolean;
+
+export function validatePinpointEvidenceV1(input?: {
+  evidence?: PinpointEvidenceV1 | Record<string, unknown> | null;
+  artifactPath?: string;
+  production?: boolean;
+  slug?: string;
+  puzzleNumber?: number;
+  logicalGameDate?: string;
+  detail?: Record<string, unknown>;
+  registryEntry?: Record<string, unknown>;
+}): PinpointEvidenceV1Issue[];

--- a/lib/puzzles/pinpoint-evidence-v1.shared.d.mts
+++ b/lib/puzzles/pinpoint-evidence-v1.shared.d.mts
@@ -1,0 +1,60 @@
+export type EvidenceSupportLevelV1 = "deterministic" | "manual" | "weak";
+export type EvidenceFitConfidenceV1 = "confirmed" | "manual" | "weak";
+export type EvidenceAnswerConfidenceV1 = "confirmed" | "manual" | "inferred" | "weak";
+export type EvidenceTimezoneSourceV1 = "assumption" | "verified" | "manual";
+export type EvidenceSourceProviderV1 = "graphql" | "manual" | "cached" | "unknown";
+
+export type PinpointEvidenceV1Issue = {
+  level: "error";
+  code: string;
+  message: string;
+  field?: string;
+};
+
+export type PinpointEvidenceV1 = {
+  schemaVersion: 1;
+  slug: string;
+  puzzleNumber: number;
+  logicalGameDate: string;
+  source: {
+    provider: EvidenceSourceProviderV1;
+    fetchedAt: string;
+    timezone: string;
+    timezoneSource: EvidenceTimezoneSourceV1;
+    rawResponseHash?: string;
+    rawResponse?: string;
+  };
+  answer: {
+    value: string;
+    confidence: EvidenceAnswerConfidenceV1;
+    confirmedAt?: string;
+  };
+  clues: Array<{
+    index: number;
+    text: string;
+    fit?: string;
+    evidenceRef: string;
+    supportLevel: EvidenceSupportLevelV1;
+    fitConfidence: EvidenceFitConfidenceV1;
+    phraseExample?: string;
+  }>;
+  manualReview?: {
+    reviewer?: string;
+    timestamp?: string;
+    reason?: string;
+    changedFields?: string[];
+  };
+};
+
+export declare function isFixtureEvidencePath(path: unknown): boolean;
+
+export declare function validatePinpointEvidenceV1(input?: {
+  evidence?: PinpointEvidenceV1 | Record<string, unknown> | null;
+  artifactPath?: string;
+  production?: boolean;
+  slug?: string;
+  puzzleNumber?: number;
+  logicalGameDate?: string;
+  detail?: Record<string, unknown>;
+  registryEntry?: Record<string, unknown>;
+}): PinpointEvidenceV1Issue[];

--- a/lib/puzzles/pinpoint-evidence-v1.shared.mjs
+++ b/lib/puzzles/pinpoint-evidence-v1.shared.mjs
@@ -1,0 +1,215 @@
+const SUPPORT_LEVELS_V1 = new Set(["deterministic", "manual", "weak"]);
+const FIT_CONFIDENCE_V1 = new Set(["confirmed", "manual", "weak"]);
+const ANSWER_CONFIDENCE_V1 = new Set(["confirmed", "manual", "inferred", "weak"]);
+const TIMEZONE_SOURCE_V1 = new Set(["assumption", "verified", "manual"]);
+const SOURCE_PROVIDERS_V1 = new Set(["graphql", "manual", "cached", "unknown"]);
+
+function normalizeString(value) {
+  return String(value ?? "").replace(/\s+/g, " ").trim();
+}
+
+function normalizeLoose(value) {
+  return normalizeString(value)
+    .toLowerCase()
+    .replace(/["“”'’()\-_,!?:.;/]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function pushIssue(issues, code, message, field) {
+  issues.push({
+    level: "error",
+    code,
+    message,
+    ...(field ? { field } : {}),
+  });
+}
+
+function isIsoUtc(value) {
+  const normalized = normalizeString(value);
+  return /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/.test(normalized);
+}
+
+function hasSecretLikeRawResponse(value) {
+  const normalized = normalizeString(value).toLowerCase();
+  return Boolean(
+    normalized &&
+      (normalized.includes("authorization") ||
+        normalized.includes("cookie") ||
+        normalized.includes("li_at=") ||
+        normalized.includes("session") ||
+        normalized.includes("token")),
+  );
+}
+
+function normalizeCluesFromDetail(detail = {}, registryEntry = {}) {
+  const detailClues = Array.isArray(detail.clues) ? detail.clues : [];
+  const registryClues = Array.isArray(registryEntry.clues) ? registryEntry.clues : [];
+  return (detailClues.length > 0 ? detailClues : registryClues)
+    .map((clue) => normalizeString(clue))
+    .filter(Boolean);
+}
+
+function normalizeAnswerFromDetail(detail = {}, registryEntry = {}) {
+  return normalizeString(detail.answer || detail.mainAnswer || registryEntry.mainAnswer);
+}
+
+export function isFixtureEvidencePath(path) {
+  const normalized = normalizeString(path);
+  return normalized.includes("tests/fixtures/") || normalized.includes(".fixture.");
+}
+
+export function validatePinpointEvidenceV1(input = {}) {
+  const issues = [];
+  const evidence = input.evidence && typeof input.evidence === "object" ? input.evidence : null;
+  const detail = input.detail && typeof input.detail === "object" ? input.detail : {};
+  const registryEntry = input.registryEntry && typeof input.registryEntry === "object" ? input.registryEntry : {};
+  const artifactPath = normalizeString(input.artifactPath);
+  const production = Boolean(input.production);
+
+  if (production && artifactPath && isFixtureEvidencePath(artifactPath)) {
+    pushIssue(
+      issues,
+      "evidence.fixtureInProduction",
+      "fixture evidence cannot be used for production publish eligibility",
+      "evidenceArtifactPath",
+    );
+  }
+
+  if (!evidence) {
+    pushIssue(issues, "evidence.missingArtifact", "full-analysis requires a Pinpoint evidence artifact", "evidence");
+    return issues;
+  }
+
+  if (Number(evidence.schemaVersion) !== 1) {
+    pushIssue(issues, "evidence.schemaVersionInvalid", "evidence.schemaVersion must be 1", "schemaVersion");
+  }
+
+  const expectedSlug = normalizeString(input.slug || detail.slug || registryEntry.slug);
+  const evidenceSlug = normalizeString(evidence.slug);
+  if (!evidenceSlug) {
+    pushIssue(issues, "evidence.slugMissing", "evidence.slug is required", "slug");
+  } else if (expectedSlug && evidenceSlug !== expectedSlug) {
+    pushIssue(issues, "evidence.slugMismatch", "evidence.slug must match the publish payload slug", "slug");
+  }
+
+  const expectedPuzzleNumber = Number(detail.puzzleNumber || registryEntry.puzzleNumber || input.puzzleNumber);
+  const evidencePuzzleNumber = Number(evidence.puzzleNumber);
+  if (!Number.isInteger(evidencePuzzleNumber) || evidencePuzzleNumber <= 0) {
+    pushIssue(issues, "evidence.puzzleNumberMissing", "evidence.puzzleNumber is required", "puzzleNumber");
+  } else if (Number.isInteger(expectedPuzzleNumber) && expectedPuzzleNumber > 0 && evidencePuzzleNumber !== expectedPuzzleNumber) {
+    pushIssue(issues, "evidence.puzzleNumberMismatch", "evidence.puzzleNumber must match the publish payload", "puzzleNumber");
+  }
+
+  const expectedDate = normalizeString(input.logicalGameDate || registryEntry.publishDate || detail.publishDate || detail.isoDate);
+  const logicalGameDate = normalizeString(evidence.logicalGameDate);
+  if (!logicalGameDate) {
+    pushIssue(issues, "evidence.logicalGameDateMissing", "evidence.logicalGameDate is required", "logicalGameDate");
+  } else if (expectedDate && logicalGameDate !== expectedDate) {
+    pushIssue(issues, "evidence.logicalGameDateMismatch", "evidence.logicalGameDate must match the publish payload date", "logicalGameDate");
+  }
+
+  const source = evidence.source && typeof evidence.source === "object" ? evidence.source : {};
+  const sourceProvider = normalizeString(source.provider || "unknown");
+  if (!SOURCE_PROVIDERS_V1.has(sourceProvider)) {
+    pushIssue(issues, "evidence.sourceProviderInvalid", "evidence.source.provider is not supported in V1", "source.provider");
+  }
+  if (!isIsoUtc(source.fetchedAt)) {
+    pushIssue(issues, "evidence.sourceFetchedAtInvalid", "evidence.source.fetchedAt must be an ISO UTC timestamp", "source.fetchedAt");
+  }
+  if (!normalizeString(source.timezone)) {
+    pushIssue(issues, "evidence.timezoneMissing", "evidence.source.timezone is required", "source.timezone");
+  }
+  if (!TIMEZONE_SOURCE_V1.has(normalizeString(source.timezoneSource))) {
+    pushIssue(issues, "evidence.timezoneSourceMissing", "evidence.source.timezoneSource is required", "source.timezoneSource");
+  }
+  if (source.rawResponse && hasSecretLikeRawResponse(source.rawResponse)) {
+    pushIssue(issues, "evidence.rawResponseSecret", "raw response must be redacted or represented by hash only", "source.rawResponse");
+  }
+
+  const expectedAnswer = normalizeAnswerFromDetail(detail, registryEntry);
+  const answer = evidence.answer && typeof evidence.answer === "object" ? evidence.answer : {};
+  const answerValue = normalizeString(answer.value);
+  const answerConfidence = normalizeString(answer.confidence);
+  if (!answerValue) {
+    pushIssue(issues, "evidence.answerMissing", "evidence.answer.value is required", "answer.value");
+  } else if (expectedAnswer && normalizeLoose(answerValue) !== normalizeLoose(expectedAnswer)) {
+    pushIssue(issues, "evidence.answerMismatch", "evidence answer must match the publish payload answer", "answer.value");
+  }
+  if (!ANSWER_CONFIDENCE_V1.has(answerConfidence)) {
+    pushIssue(issues, "evidence.answerConfidenceInvalid", "evidence.answer.confidence is not supported in V1", "answer.confidence");
+  }
+
+  const expectedClues = normalizeCluesFromDetail(detail, registryEntry);
+  const evidenceClues = Array.isArray(evidence.clues) ? evidence.clues : [];
+  if (evidenceClues.length !== 5) {
+    pushIssue(issues, "evidence.clueCountMismatch", "evidence.clues must contain exactly 5 rows", "clues");
+  }
+  if (expectedClues.length === 5 && evidenceClues.length === 5) {
+    evidenceClues.forEach((row, index) => {
+      const rowIndex = Number(row?.index);
+      const fieldPrefix = `clues[${index}]`;
+      if (rowIndex !== index) {
+        pushIssue(issues, "evidence.clueIndexMismatch", "evidence clue index must match its 0-based position", `${fieldPrefix}.index`);
+      }
+      if (normalizeLoose(row?.text) !== normalizeLoose(expectedClues[index])) {
+        pushIssue(issues, "evidence.clueTextMismatch", "evidence clue text must match the publish payload clue order", `${fieldPrefix}.text`);
+      }
+      const evidenceRef = normalizeString(row?.evidenceRef);
+      const supportLevel = normalizeString(row?.supportLevel);
+      const fitConfidence = normalizeString(row?.fitConfidence);
+      if (!evidenceRef) {
+        pushIssue(issues, "evidence.missingRef", "each evidence clue row must include evidenceRef", `${fieldPrefix}.evidenceRef`);
+      }
+      if (!SUPPORT_LEVELS_V1.has(supportLevel)) {
+        pushIssue(issues, "evidence.supportLevelInvalid", "evidence clue supportLevel is not supported in V1", `${fieldPrefix}.supportLevel`);
+      }
+      if (!FIT_CONFIDENCE_V1.has(fitConfidence)) {
+        pushIssue(issues, "evidence.fitConfidenceInvalid", "evidence clue fitConfidence is not supported in V1", `${fieldPrefix}.fitConfidence`);
+      }
+      if (supportLevel === "weak" || fitConfidence === "weak") {
+        pushIssue(issues, "evidence.weakFit", "weak evidence cannot support full-analysis", `${fieldPrefix}.supportLevel`);
+      }
+    });
+  }
+
+  const evidenceRefs = new Set(
+    evidenceClues
+      .map((row) => normalizeString(row?.evidenceRef))
+      .filter(Boolean),
+  );
+  const clueRows = Array.isArray(detail.clueRows) ? detail.clueRows : [];
+  if (clueRows.length > 0) {
+    clueRows.forEach((row, index) => {
+      const fieldPrefix = `clueRows[${index}]`;
+      const evidenceRef = normalizeString(row?.evidenceRef);
+      if (!evidenceRef) {
+        pushIssue(issues, "evidence.clueRowRefMissing", "full-analysis clueRows must include evidenceRef", `${fieldPrefix}.evidenceRef`);
+      } else if (!evidenceRefs.has(evidenceRef)) {
+        pushIssue(issues, "evidence.clueRowRefUnknown", "clueRows evidenceRef must exist in the evidence artifact", `${fieldPrefix}.evidenceRef`);
+      }
+    });
+  }
+
+  const usesManual =
+    sourceProvider === "manual" ||
+    answerConfidence === "manual" ||
+    evidenceClues.some((row) => normalizeString(row?.supportLevel) === "manual" || normalizeString(row?.fitConfidence) === "manual");
+  const manualReview = evidence.manualReview && typeof evidence.manualReview === "object" ? evidence.manualReview : null;
+  if (usesManual) {
+    if (!normalizeString(manualReview?.reviewer)) {
+      pushIssue(issues, "evidence.manualReviewerMissing", "manual evidence requires manualReview.reviewer", "manualReview.reviewer");
+    }
+    if (!normalizeString(manualReview?.reason)) {
+      pushIssue(issues, "evidence.manualReasonMissing", "manual evidence requires manualReview.reason", "manualReview.reason");
+    }
+    if (!isIsoUtc(manualReview?.timestamp)) {
+      pushIssue(issues, "evidence.manualTimestampInvalid", "manual evidence requires an ISO UTC manualReview.timestamp", "manualReview.timestamp");
+    }
+    if (!Array.isArray(manualReview?.changedFields) || manualReview.changedFields.length === 0) {
+      pushIssue(issues, "evidence.manualChangedFieldsMissing", "manual evidence requires manualReview.changedFields", "manualReview.changedFields");
+    }
+  }
+
+  return issues;
+}

--- a/lib/puzzles/pinpoint-evidence-v1.ts
+++ b/lib/puzzles/pinpoint-evidence-v1.ts
@@ -1,0 +1,14 @@
+export {
+  isFixtureEvidencePath,
+  validatePinpointEvidenceV1,
+} from "./pinpoint-evidence-v1.shared.mjs";
+
+export type {
+  EvidenceAnswerConfidenceV1,
+  EvidenceFitConfidenceV1,
+  EvidenceSourceProviderV1,
+  EvidenceSupportLevelV1,
+  EvidenceTimezoneSourceV1,
+  PinpointEvidenceV1,
+  PinpointEvidenceV1Issue,
+} from "./pinpoint-evidence-v1.shared.mjs";

--- a/lib/puzzles/publish-eligibility.d.ts
+++ b/lib/puzzles/publish-eligibility.d.ts
@@ -38,5 +38,9 @@ export function validatePublishEligibility(input?: {
   expectedMode?: PublishMode;
   answerFirstPublicEnabled?: boolean;
   sourceConfidence?: "confirmed" | "manual" | "inferred" | "weak" | "unknown";
+  evidenceArtifact?: Record<string, unknown> | null;
+  evidenceArtifactPath?: string;
+  requireEvidenceForFullAnalysis?: boolean;
+  productionEvidence?: boolean;
 }): PublishGateResult;
 export function formatPublishGateIssues(issues: PublishGateIssue[]): string;

--- a/lib/puzzles/publish-eligibility.shared.d.mts
+++ b/lib/puzzles/publish-eligibility.shared.d.mts
@@ -38,5 +38,9 @@ export declare function validatePublishEligibility(input?: {
   expectedMode?: PublishMode;
   answerFirstPublicEnabled?: boolean;
   sourceConfidence?: "confirmed" | "manual" | "inferred" | "weak" | "unknown";
+  evidenceArtifact?: Record<string, unknown> | null;
+  evidenceArtifactPath?: string;
+  requireEvidenceForFullAnalysis?: boolean;
+  productionEvidence?: boolean;
 }): PublishGateResult;
 export declare function formatPublishGateIssues(issues: PublishGateIssue[]): string;

--- a/lib/puzzles/publish-eligibility.shared.mjs
+++ b/lib/puzzles/publish-eligibility.shared.mjs
@@ -1,3 +1,5 @@
+import { validatePinpointEvidenceV1 } from "./pinpoint-evidence-v1.shared.mjs";
+
 export const publishModes = ["answer-first", "full-analysis", "failed"];
 
 const publicDetailStates = new Set(["published", "fallback_full"]);
@@ -118,6 +120,10 @@ export function validatePublishEligibility(input) {
     expectedMode,
     answerFirstPublicEnabled = false,
     sourceConfidence = "unknown",
+    evidenceArtifact,
+    evidenceArtifactPath,
+    requireEvidenceForFullAnalysis = false,
+    productionEvidence = false,
   } = input ?? {};
   const normalizedSlug = normalizeString(slug || detail.slug || registryEntry.slug);
   const puzzleNumber = Number(detail.puzzleNumber || registryEntry.puzzleNumber);
@@ -274,6 +280,30 @@ export function validatePublishEligibility(input) {
       }));
     }
 
+    if (publishMode === "full-analysis" && (requireEvidenceForFullAnalysis || evidenceArtifact || evidenceArtifactPath)) {
+      const evidenceIssues = validatePinpointEvidenceV1({
+        evidence: evidenceArtifact,
+        artifactPath: evidenceArtifactPath,
+        production: productionEvidence,
+        slug: normalizedSlug,
+        puzzleNumber,
+        logicalGameDate: registryEntry.publishDate || detail.publishDate || detail.isoDate,
+        detail,
+        registryEntry,
+      });
+      for (const issue of evidenceIssues) {
+        issues.push(makeIssue({
+          code: issue.code,
+          level: "blocking",
+          message: issue.message,
+          slug: normalizedSlug,
+          puzzleNumber,
+          field: issue.field,
+          sourceConfidence,
+          publishMode,
+        }));
+      }
+    }
   }
 
   const blockingIssues = issues.filter((issue) => issue.level === "blocking");

--- a/lib/puzzles/release-override.d.ts
+++ b/lib/puzzles/release-override.d.ts
@@ -1,0 +1,31 @@
+export type ReleaseOverrideIssue = {
+  level: "blocking";
+  code: string;
+  message: string;
+  field?: string;
+};
+
+export type ReleaseOverride = {
+  slug: string;
+  issueCodes: string[];
+  reviewer: string;
+  reason: string;
+  createdAt: string;
+  expiresAt: string;
+  incidentUrl?: string;
+};
+
+export type ReleaseOverrideDryRunResult = {
+  ok: boolean;
+  productionEffective: false;
+  issues: ReleaseOverrideIssue[];
+};
+
+export const disallowedReleaseOverrideCodes: string[];
+
+export function validateReleaseOverrideDryRun(input?: {
+  override?: Partial<ReleaseOverride> | Record<string, unknown> | null;
+  slug?: string;
+  activeIssueCodes?: string[];
+  nowMs?: number;
+}): ReleaseOverrideDryRunResult;

--- a/lib/puzzles/release-override.shared.d.mts
+++ b/lib/puzzles/release-override.shared.d.mts
@@ -1,0 +1,31 @@
+export type ReleaseOverrideIssue = {
+  level: "blocking";
+  code: string;
+  message: string;
+  field?: string;
+};
+
+export type ReleaseOverride = {
+  slug: string;
+  issueCodes: string[];
+  reviewer: string;
+  reason: string;
+  createdAt: string;
+  expiresAt: string;
+  incidentUrl?: string;
+};
+
+export type ReleaseOverrideDryRunResult = {
+  ok: boolean;
+  productionEffective: false;
+  issues: ReleaseOverrideIssue[];
+};
+
+export declare const disallowedReleaseOverrideCodes: string[];
+
+export declare function validateReleaseOverrideDryRun(input?: {
+  override?: Partial<ReleaseOverride> | Record<string, unknown> | null;
+  slug?: string;
+  activeIssueCodes?: string[];
+  nowMs?: number;
+}): ReleaseOverrideDryRunResult;

--- a/lib/puzzles/release-override.shared.mjs
+++ b/lib/puzzles/release-override.shared.mjs
@@ -1,0 +1,104 @@
+const DISALLOWED_OVERRIDE_CODES = new Set([
+  "answer.missing",
+  "answer.unconfirmed",
+  "clues.countMismatch",
+  "evidence.missingArtifact",
+  "evidence.fixtureInProduction",
+  "publishMode.failedPublicPayload",
+  "slug.missing",
+  "puzzleNumber.missing",
+]);
+
+function normalizeString(value) {
+  return String(value ?? "").replace(/\s+/g, " ").trim();
+}
+
+function pushIssue(issues, code, message, field) {
+  issues.push({
+    level: "blocking",
+    code,
+    message,
+    ...(field ? { field } : {}),
+  });
+}
+
+function parseTime(value) {
+  const normalized = normalizeString(value);
+  if (!normalized) return Number.NaN;
+  const ms = Date.parse(normalized);
+  return Number.isFinite(ms) ? ms : Number.NaN;
+}
+
+export function validateReleaseOverrideDryRun(input = {}) {
+  const override = input.override && typeof input.override === "object" ? input.override : {};
+  const activeIssueCodes = new Set(
+    (Array.isArray(input.activeIssueCodes) ? input.activeIssueCodes : [])
+      .map((code) => normalizeString(code))
+      .filter(Boolean),
+  );
+  const nowMs = Number.isFinite(input.nowMs) ? input.nowMs : Date.now();
+  const issues = [];
+
+  const slug = normalizeString(override.slug);
+  const reviewer = normalizeString(override.reviewer);
+  const reason = normalizeString(override.reason);
+  const createdAt = normalizeString(override.createdAt);
+  const expiresAt = normalizeString(override.expiresAt);
+  const issueCodes = Array.isArray(override.issueCodes)
+    ? override.issueCodes.map((code) => normalizeString(code)).filter(Boolean)
+    : [];
+
+  if (!slug) {
+    pushIssue(issues, "override.slugMissing", "override.slug is required", "slug");
+  }
+  if (input.slug && slug && slug !== normalizeString(input.slug)) {
+    pushIssue(issues, "override.slugMismatch", "override.slug must match the dry-run target slug", "slug");
+  }
+  if (issueCodes.length === 0) {
+    pushIssue(issues, "override.issueCodesMissing", "override.issueCodes must list at least one issue code", "issueCodes");
+  }
+  if (!reviewer) {
+    pushIssue(issues, "override.reviewerMissing", "override.reviewer is required", "reviewer");
+  }
+  if (!reason) {
+    pushIssue(issues, "override.reasonMissing", "override.reason is required", "reason");
+  }
+  if (!createdAt) {
+    pushIssue(issues, "override.createdAtMissing", "override.createdAt is required", "createdAt");
+  }
+  if (!expiresAt) {
+    pushIssue(issues, "override.expiresAtMissing", "override.expiresAt is required", "expiresAt");
+  }
+
+  const createdAtMs = parseTime(createdAt);
+  const expiresAtMs = parseTime(expiresAt);
+  if (createdAt && !Number.isFinite(createdAtMs)) {
+    pushIssue(issues, "override.createdAtInvalid", "override.createdAt must be a valid timestamp", "createdAt");
+  }
+  if (expiresAt && !Number.isFinite(expiresAtMs)) {
+    pushIssue(issues, "override.expiresAtInvalid", "override.expiresAt must be a valid timestamp", "expiresAt");
+  }
+  if (Number.isFinite(expiresAtMs) && expiresAtMs <= nowMs) {
+    pushIssue(issues, "override.expired", "override.expiresAt is already expired", "expiresAt");
+  }
+  if (Number.isFinite(createdAtMs) && Number.isFinite(expiresAtMs) && expiresAtMs - createdAtMs > 48 * 60 * 60 * 1000) {
+    pushIssue(issues, "override.tooLong", "override expiresAt must be within 48 hours of createdAt", "expiresAt");
+  }
+
+  for (const code of issueCodes) {
+    if (activeIssueCodes.size > 0 && !activeIssueCodes.has(code)) {
+      pushIssue(issues, "override.issueCodeMismatch", `override issue code is not active: ${code}`, "issueCodes");
+    }
+    if (DISALLOWED_OVERRIDE_CODES.has(code)) {
+      pushIssue(issues, "override.disallowedIssueCode", `issue code cannot be overridden: ${code}`, "issueCodes");
+    }
+  }
+
+  return {
+    ok: issues.length === 0,
+    productionEffective: false,
+    issues,
+  };
+}
+
+export const disallowedReleaseOverrideCodes = Array.from(DISALLOWED_OVERRIDE_CODES);

--- a/lib/puzzles/release-override.ts
+++ b/lib/puzzles/release-override.ts
@@ -1,0 +1,10 @@
+export {
+  disallowedReleaseOverrideCodes,
+  validateReleaseOverrideDryRun,
+} from "./release-override.shared.mjs";
+
+export type {
+  ReleaseOverride,
+  ReleaseOverrideDryRunResult,
+  ReleaseOverrideIssue,
+} from "./release-override.shared.mjs";

--- a/lib/puzzles/schema.shared.d.mts
+++ b/lib/puzzles/schema.shared.d.mts
@@ -76,6 +76,9 @@ export declare const puzzleClueRowSchema: z.ZodObject<{
   resolvedPhraseOrMember: z.ZodString;
   nonObviousWhy: z.ZodString;
   searchableContext: z.ZodOptional<z.ZodString>;
+  evidenceRef: z.ZodOptional<z.ZodString>;
+  phraseExample: z.ZodOptional<z.ZodString>;
+  fitConfidence: z.ZodOptional<z.ZodEnum<["confirmed", "manual", "weak"]>>;
 }>;
 
 export declare const puzzleFaqIntentTypeSchema: z.ZodEnum<

--- a/lib/puzzles/schema.shared.mjs
+++ b/lib/puzzles/schema.shared.mjs
@@ -77,6 +77,9 @@ export const puzzleClueRowSchema = z.object({
   resolvedPhraseOrMember: z.string().min(1),
   nonObviousWhy: z.string().min(1),
   searchableContext: z.string().min(1).optional(),
+  evidenceRef: z.string().min(1).optional(),
+  phraseExample: z.string().min(1).optional(),
+  fitConfidence: z.enum(["confirmed", "manual", "weak"]).optional(),
 });
 
 export const puzzleFaqIntentTypeSchema = z.enum([

--- a/lib/puzzles/schema.ts
+++ b/lib/puzzles/schema.ts
@@ -93,6 +93,9 @@ export const puzzleClueRowSchema = sharedPuzzleClueRowSchema as z.ZodObject<{
   resolvedPhraseOrMember: z.ZodString;
   nonObviousWhy: z.ZodString;
   searchableContext: z.ZodOptional<z.ZodString>;
+  evidenceRef: z.ZodOptional<z.ZodString>;
+  phraseExample: z.ZodOptional<z.ZodString>;
+  fitConfidence: z.ZodOptional<z.ZodEnum<["confirmed", "manual", "weak"]>>;
 }>;
 export const puzzleFaqIntentTypeSchema = sharedPuzzleFaqIntentTypeSchema as z.ZodEnum<
   ["definition", "clue_background", "comparison", "solve_strategy", "category_context"]

--- a/scripts/check-pinpoint-guardrails.ts
+++ b/scripts/check-pinpoint-guardrails.ts
@@ -15,6 +15,8 @@ import {
   updateLightweightPublishFailureStreak,
 } from "../lib/puzzles/publish-failure-summary.shared.mjs";
 import { validatePublishEligibility } from "../lib/puzzles/publish-eligibility.shared.mjs";
+import { validatePinpointEvidenceV1 } from "../lib/puzzles/pinpoint-evidence-v1.shared.mjs";
+import { validateReleaseOverrideDryRun } from "../lib/puzzles/release-override.shared.mjs";
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(SCRIPT_DIR, "..");
@@ -2221,6 +2223,169 @@ function checkLightweightPublishFailureSummary() {
   console.log("ok: lightweight publish failure summary preserves issue codes and streaks");
 }
 
+async function checkPinpointEvidenceV1Guards724Mapping() {
+  const fixturePath = resolve(ROOT, "tests/fixtures/pinpoint/evidence/pinpoint-answer-724.evidence.fixture.json");
+  const badFixturePath = resolve(ROOT, "tests/fixtures/pinpoint/evidence/pinpoint-answer-724.bad-mapping.evidence.fixture.json");
+  const goodEvidence = JSON.parse(await readFile(fixturePath, "utf8"));
+  const badEvidence = JSON.parse(await readFile(badFixturePath, "utf8"));
+  const registryEntry = {
+    puzzleNumber: 724,
+    slug: "pinpoint-answer-724",
+    publishDate: "2026-04-24",
+    status: "live",
+    detailState: "published",
+    clues: ["Stand", "Shake", "Made", "Writing", "Kerchief"],
+    mainAnswer: "Words that come after “hand”",
+  };
+  const detail = {
+    slug: "pinpoint-answer-724",
+    puzzleNumber: 724,
+    publishDate: "2026-04-24",
+    detailState: "published",
+    publishMode: "full-analysis",
+    answer: "Words that come after “hand”",
+    clues: ["Stand", "Shake", "Made", "Writing", "Kerchief"],
+    clueRows: [
+      { clue: "Stand", resolvedPhraseOrMember: "Handstand", nonObviousWhy: "Stand combines with hand.", evidenceRef: "clue-0-stand" },
+      { clue: "Shake", resolvedPhraseOrMember: "Handshake", nonObviousWhy: "Shake combines with hand.", evidenceRef: "clue-1-shake" },
+      { clue: "Made", resolvedPhraseOrMember: "Handmade", nonObviousWhy: "Made combines with hand.", evidenceRef: "clue-2-made" },
+      { clue: "Writing", resolvedPhraseOrMember: "Handwriting", nonObviousWhy: "Writing combines with hand.", evidenceRef: "clue-3-writing" },
+      { clue: "Kerchief", resolvedPhraseOrMember: "Handkerchief", nonObviousWhy: "Kerchief combines with hand.", evidenceRef: "clue-4-kerchief" },
+    ],
+  };
+
+  const goodIssues = validatePinpointEvidenceV1({
+    evidence: goodEvidence,
+    artifactPath: "tests/fixtures/pinpoint/evidence/pinpoint-answer-724.evidence.fixture.json",
+    production: false,
+    detail,
+    registryEntry,
+  });
+  assert.deepEqual(goodIssues, [], "valid #724 evidence fixture should pass dry-run validation");
+
+  const badIssues = validatePinpointEvidenceV1({
+    evidence: badEvidence,
+    artifactPath: "tests/fixtures/pinpoint/evidence/pinpoint-answer-724.bad-mapping.evidence.fixture.json",
+    production: false,
+    detail,
+    registryEntry,
+  });
+  const badCodes = badIssues.map((issue) => issue.code);
+  assert.ok(
+    badCodes.includes("evidence.clueTextMismatch"),
+    "#724 bad fixture should catch swapped clue mapping",
+  );
+  assert.ok(
+    badCodes.includes("evidence.weakFit"),
+    "#724 bad fixture should catch weak clue support",
+  );
+
+  const productionFixtureIssues = validatePublishEligibility({
+    slug: "pinpoint-answer-724",
+    expectedMode: "full-analysis",
+    answerFirstPublicEnabled: false,
+    requireEvidenceForFullAnalysis: true,
+    productionEvidence: true,
+    evidenceArtifact: goodEvidence,
+    evidenceArtifactPath: "tests/fixtures/pinpoint/evidence/pinpoint-answer-724.evidence.fixture.json",
+    registryEntry,
+    detail,
+  });
+  assert.equal(productionFixtureIssues.ok, false, "fixture evidence must not pass production eligibility");
+  assert.ok(
+    productionFixtureIssues.issues.some((issue) => issue.code === "evidence.fixtureInProduction"),
+    "production eligibility should return evidence.fixtureInProduction for fixture paths",
+  );
+
+  const missingEvidence = validatePublishEligibility({
+    slug: "pinpoint-answer-724",
+    expectedMode: "full-analysis",
+    answerFirstPublicEnabled: false,
+    requireEvidenceForFullAnalysis: true,
+    registryEntry,
+    detail,
+  });
+  assert.equal(missingEvidence.ok, false, "required evidence should block full-analysis without an artifact");
+  assert.ok(
+    missingEvidence.issues.some((issue) => issue.code === "evidence.missingArtifact"),
+    "required evidence should produce evidence.missingArtifact",
+  );
+
+  console.log("ok: Pinpoint evidence V1 catches #724 mapping, weak support, and fixture production use");
+}
+
+function checkReleaseOverrideDryRunSchema() {
+  const nowMs = Date.parse("2026-05-21T00:00:00.000Z");
+  const missing = validateReleaseOverrideDryRun({
+    override: {
+      slug: "pinpoint-answer-750",
+      issueCodes: ["publishMode.inferredLegacy"],
+    },
+    slug: "pinpoint-answer-750",
+    activeIssueCodes: ["publishMode.inferredLegacy"],
+    nowMs,
+  });
+  const missingCodes = missing.issues.map((issue) => issue.code);
+  assert.ok(missingCodes.includes("override.reviewerMissing"), "override dry-run should require reviewer");
+  assert.ok(missingCodes.includes("override.reasonMissing"), "override dry-run should require reason");
+  assert.ok(missingCodes.includes("override.createdAtMissing"), "override dry-run should require createdAt");
+  assert.ok(missingCodes.includes("override.expiresAtMissing"), "override dry-run should require expiresAt");
+
+  const expired = validateReleaseOverrideDryRun({
+    override: {
+      slug: "pinpoint-answer-750",
+      issueCodes: ["publishMode.inferredLegacy"],
+      reviewer: "release-maintainer",
+      reason: "Dry-run fixture for non-blocking warning override.",
+      createdAt: "2026-05-18T00:00:00.000Z",
+      expiresAt: "2026-05-20T00:00:00.000Z",
+    },
+    slug: "pinpoint-answer-750",
+    activeIssueCodes: ["publishMode.inferredLegacy"],
+    nowMs,
+  });
+  assert.ok(
+    expired.issues.some((issue) => issue.code === "override.expired"),
+    "override dry-run should reject expired overrides",
+  );
+
+  const disallowed = validateReleaseOverrideDryRun({
+    override: {
+      slug: "pinpoint-answer-750",
+      issueCodes: ["answer.missing"],
+      reviewer: "release-maintainer",
+      reason: "Should never override missing answer.",
+      createdAt: "2026-05-21T00:00:00.000Z",
+      expiresAt: "2026-05-21T12:00:00.000Z",
+    },
+    slug: "pinpoint-answer-750",
+    activeIssueCodes: ["answer.missing"],
+    nowMs,
+  });
+  assert.ok(
+    disallowed.issues.some((issue) => issue.code === "override.disallowedIssueCode"),
+    "override dry-run should reject core blocking issue overrides",
+  );
+
+  const dryRunOk = validateReleaseOverrideDryRun({
+    override: {
+      slug: "pinpoint-answer-750",
+      issueCodes: ["publishMode.inferredLegacy"],
+      reviewer: "release-maintainer",
+      reason: "Dry-run only; production effectiveness remains disabled.",
+      createdAt: "2026-05-21T00:00:00.000Z",
+      expiresAt: "2026-05-22T00:00:00.000Z",
+    },
+    slug: "pinpoint-answer-750",
+    activeIssueCodes: ["publishMode.inferredLegacy"],
+    nowMs,
+  });
+  assert.equal(dryRunOk.ok, true, "well-formed warning override should pass dry-run schema validation");
+  assert.equal(dryRunOk.productionEffective, false, "PR3 override dry-run must not enable production bypass");
+
+  console.log("ok: release override schema validates dry-run only without production bypass");
+}
+
 async function main() {
   await checkProductionDetailUsesRemoteFirst();
   await checkCurrentPuzzleSkipsNonPublicLiveEntry();
@@ -2239,6 +2404,8 @@ async function main() {
   await checkAdminApiRateLimit();
   checkPublishEligibilityBlocksShortPublishedAsFullAnalysis();
   checkLightweightPublishFailureSummary();
+  await checkPinpointEvidenceV1Guards724Mapping();
+  checkReleaseOverrideDryRunSchema();
   console.log("Pinpoint guardrail regression passed.");
 }
 

--- a/tests/fixtures/pinpoint/evidence/pinpoint-answer-724.bad-mapping.evidence.fixture.json
+++ b/tests/fixtures/pinpoint/evidence/pinpoint-answer-724.bad-mapping.evidence.fixture.json
@@ -1,0 +1,71 @@
+{
+  "schemaVersion": 1,
+  "slug": "pinpoint-answer-724",
+  "puzzleNumber": 724,
+  "logicalGameDate": "2026-04-24",
+  "source": {
+    "provider": "manual",
+    "fetchedAt": "2026-04-24T18:00:00.000Z",
+    "timezone": "America/New_York",
+    "timezoneSource": "assumption",
+    "rawResponseHash": "sha256:fixture-pinpoint-answer-724-bad"
+  },
+  "answer": {
+    "value": "Words that come after “hand”",
+    "confidence": "manual",
+    "confirmedAt": "2026-04-24T18:00:00.000Z"
+  },
+  "clues": [
+    {
+      "index": 0,
+      "text": "Stand",
+      "fit": "Handstand",
+      "evidenceRef": "clue-0-stand",
+      "supportLevel": "manual",
+      "fitConfidence": "manual",
+      "phraseExample": "handstand"
+    },
+    {
+      "index": 1,
+      "text": "Made",
+      "fit": "Handmade",
+      "evidenceRef": "clue-1-made-wrong",
+      "supportLevel": "manual",
+      "fitConfidence": "manual",
+      "phraseExample": "handmade"
+    },
+    {
+      "index": 2,
+      "text": "Shake",
+      "fit": "Handshake",
+      "evidenceRef": "clue-2-shake-wrong",
+      "supportLevel": "manual",
+      "fitConfidence": "manual",
+      "phraseExample": "handshake"
+    },
+    {
+      "index": 3,
+      "text": "Writing",
+      "fit": "Handwriting",
+      "evidenceRef": "clue-3-writing",
+      "supportLevel": "weak",
+      "fitConfidence": "weak",
+      "phraseExample": "handwriting"
+    },
+    {
+      "index": 4,
+      "text": "Kerchief",
+      "fit": "Handkerchief",
+      "evidenceRef": "clue-4-kerchief",
+      "supportLevel": "manual",
+      "fitConfidence": "manual",
+      "phraseExample": "handkerchief"
+    }
+  ],
+  "manualReview": {
+    "reviewer": "pinpoint-editor",
+    "timestamp": "2026-04-24T18:05:00.000Z",
+    "reason": "Bad fixture intentionally swaps clue order and marks one clue as weak.",
+    "changedFields": ["clues", "answer"]
+  }
+}

--- a/tests/fixtures/pinpoint/evidence/pinpoint-answer-724.evidence.fixture.json
+++ b/tests/fixtures/pinpoint/evidence/pinpoint-answer-724.evidence.fixture.json
@@ -1,0 +1,71 @@
+{
+  "schemaVersion": 1,
+  "slug": "pinpoint-answer-724",
+  "puzzleNumber": 724,
+  "logicalGameDate": "2026-04-24",
+  "source": {
+    "provider": "manual",
+    "fetchedAt": "2026-04-24T18:00:00.000Z",
+    "timezone": "America/New_York",
+    "timezoneSource": "assumption",
+    "rawResponseHash": "sha256:fixture-pinpoint-answer-724"
+  },
+  "answer": {
+    "value": "Words that come after “hand”",
+    "confidence": "manual",
+    "confirmedAt": "2026-04-24T18:00:00.000Z"
+  },
+  "clues": [
+    {
+      "index": 0,
+      "text": "Stand",
+      "fit": "Handstand",
+      "evidenceRef": "clue-0-stand",
+      "supportLevel": "manual",
+      "fitConfidence": "manual",
+      "phraseExample": "handstand"
+    },
+    {
+      "index": 1,
+      "text": "Shake",
+      "fit": "Handshake",
+      "evidenceRef": "clue-1-shake",
+      "supportLevel": "manual",
+      "fitConfidence": "manual",
+      "phraseExample": "handshake"
+    },
+    {
+      "index": 2,
+      "text": "Made",
+      "fit": "Handmade",
+      "evidenceRef": "clue-2-made",
+      "supportLevel": "manual",
+      "fitConfidence": "manual",
+      "phraseExample": "handmade"
+    },
+    {
+      "index": 3,
+      "text": "Writing",
+      "fit": "Handwriting",
+      "evidenceRef": "clue-3-writing",
+      "supportLevel": "manual",
+      "fitConfidence": "manual",
+      "phraseExample": "handwriting"
+    },
+    {
+      "index": 4,
+      "text": "Kerchief",
+      "fit": "Handkerchief",
+      "evidenceRef": "clue-4-kerchief",
+      "supportLevel": "manual",
+      "fitConfidence": "manual",
+      "phraseExample": "handkerchief"
+    }
+  ],
+  "manualReview": {
+    "reviewer": "pinpoint-editor",
+    "timestamp": "2026-04-24T18:05:00.000Z",
+    "reason": "Fixture captures the known #724 clue-to-phrase mapping regression.",
+    "changedFields": ["clues", "answer"]
+  }
+}


### PR DESCRIPTION
## Summary

- Adds Pinpoint Evidence V1 dry-run validation for `deterministic`, `manual`, and `weak` support.
- Adds optional evidence parameters to shared publish eligibility without making evidence mandatory by default.
- Rejects fixture evidence in production mode and blocks weak evidence from supporting `full-analysis`.
- Adds #724 evidence fixtures to catch clue mapping regressions.
- Adds release override schema dry-run validation with required reviewer/reason/timestamps, 48-hour max duration, disallowed core issue codes, and `productionEffective: false`.

## Scope

- Approved PR3 only: Evidence V1 dry-run, #724 fixture coverage, fixture production guard, and override schema dry-run.
- Does not read production evidence from Worker, does not enable production-effective override, does not add KV/runtime override, and does not add rendered/link/schema blocking gates.

## Validation

- `npm run test:pinpoint-guardrails`
- `npm run typecheck`
- `npm run validate:data`
- `cd worker && npm run typecheck`

## Stack

- Depends on PR1: `codex/content-gate-pr1`
- Depends on PR2: `codex/content-gate-pr2`
