### PR TITLE
Document SEO audit and recovery records

### DIFF
--- a/docs/full-audit-remediation-plan-2026-05-19.md
+++ b/docs/full-audit-remediation-plan-2026-05-19.md
@@ -1,0 +1,476 @@
+# 全面审批修复方案 v3
+
+> 日期: 2026-05-19
+> 版本: v3（根据 agent 审批复核修订）
+> 状态: v3 已批准执行（按本文拆分顺序推进）
+> 基于: 5 团队并行审查 + 3 专家审批 + 2 个 agent 独立复核
+
+---
+
+## 背景
+
+对项目进行 5 个维度的全面审查后，发现多项需修复的问题。v2 方案覆盖面较完整，但 agent 复核发现它不能直接作为批准执行版使用：存在生产域名写错、部分 false positive、执行顺序污染 GSC 恢复窗口、PR 拆分不够干净等问题。
+
+本 v3 版本已修正审批阻断点，批准按本文拆分顺序推进。除紧急安全事项外，所有生产代码发布都必须避开 Phase 0 后的短期 GSC 归因窗口，保持每个 PR 独立、可验证、可回滚。
+
+> **Phase 0 已完成**（commit `94ff8c5`，2026-05-19 11:16 UTC），修复了 sitemap lastmod 动态化和 #735/#736/#737 registry 恢复。本方案描述的是 Phase 1-5 新增修复。
+
+---
+
+## v2 审批复核结论
+
+**结论：v2 不批准直接执行。**
+
+必须先修正以下阻断点：
+
+1. 生产验证域名统一为 `https://pinpointanswertoday.app`，不得使用 `pinpointanswertoday.com`。
+2. Next.js 升级方向成立，但不得默认作为 Phase 0 观察窗口内的第一项生产发布，除非安全负责人明确按紧急安全修复批准。
+3. `buildNoStoreHeaders` TypeScript 错误当前不可复现，不能列为 P0。
+4. `/pinpoint/:number-analysis` 重定向参数问题已验证不成立，不能作为修复项执行。
+5. `contact-us` 重新加入 sitemap 与既有 SEO 策略存在冲突，必须作为独立 SEO 决策，不得并入 P0/P1 快修。
+6. `npm audit` 验收不能简单写成“无 critical/high”，应区分生产依赖、Next 直连漏洞和剩余 dev/transitive 漏洞。
+7. Phase 2 安全项必须拆成独立 PR，不得把认证、SSRF、HSTS、URL 泄露、rate limit 混在同一 PR。
+
+---
+
+## Phase 1a: Next.js 安全升级（P0 安全项 — 独立 PR，需发布闸门）
+
+### 1a.1 升级 Next.js 15.0.5 → 15.5.18
+
+- **文件**: `package.json`
+- **操作**: `npm install next@15.5.18 eslint-config-next@15.5.18 react@19.2.6 react-dom@19.2.6`
+- **必须同步升级 `eslint-config-next`**：当前 `package.json` 第 40 行为 `"eslint-config-next": "^15.0.5"`，必须同步升级到 `^15.5.18`，否则 lint 规则与框架版本不匹配
+- **React 19.0.0 → 19.2.6 注意事项**：
+  - React 19.1+ 修改了 `useEffect` 清理行为和 Server Components 的一些边界情况
+  - `@types/react@^19.0.0` 和 `@types/react-dom@^19.0.0` 需确认兼容 19.2.x
+- **预评估步骤**（合并前必须完成）：
+  1. 阅读 Next.js 15.1-15.5 CHANGELOG，标记 breaking changes
+  2. 确认 `dynamic = "force-dynamic"`、`revalidateTag`/`revalidatePath`、中间件行为无变化
+  3. 确认 `next/image` 组件 API 无 breaking change
+  4. 记录 `npx next build` 升级前构建时间，升级后对比
+- **原因**: 当前 15.0.5 含 14 个已知安全漏洞，包括:
+  - 中间件授权绕过 (GHSA-f82v-jwr5-mffw)
+  - HTTP 请求走私 (GHSA-ggv3-7p47-pfv8)
+  - Server Components DoS (GHSA-q4gf-8mx6-v5v3, GHSA-8h8q-6873-q5fj)
+  - XSS (GHSA-ffhc-5mcf-pf4q, GHSA-gx5p-jg67-6x7h)
+  - 缓存投毒 (GHSA-3g8h-86w9-wvmq, GHSA-vfv6-92ff-j949, GHSA-wfc6-r584-vfw7)
+  - SSRF via WebSocket (GHSA-c4j6-fc7j-m34r)
+  - Image Optimization DoS (GHSA-h64f-5h5j-jqjh)
+  - PostCSS XSS (GHSA-qx2v-qp2m-jg93)
+- **验证**:
+  - `npx next build` 成功
+  - `npx tsc --noEmit` 通过
+  - `npx next lint` 零警告
+  - `npm audit --omit=dev` 无生产依赖 critical/high
+  - `npm audit` 中 Next.js 相关 critical/high 已清零；如仍存在 dev/transitive high，单独记录来源和修复计划
+  - 构建时间与升级前对比无显著退化
+- **发布闸门**:
+  - 默认不在 Phase 0 上线后 5 个完整自然日内发布，避免污染 GSC 恢复归因。
+  - 如安全负责人认定必须立即修复，则按紧急安全 PR 执行，并在 GSC 监控记录中明确标记“框架升级变量已引入”。
+- **回滚方案**:
+  1. `git revert <merge-commit-sha>`
+  2. 使用 git 中的 `package-lock.json` 恢复依赖锁定，不手动重新生成未审查 lockfile
+  3. `npx next build` 确认回滚后构建正常
+  4. 升级前记录当前 `package-lock.json` 的 git hash，便于验证回滚完整性
+
+---
+
+## Phase 1b: 移除硬编码开发密钥（P0 — 独立 PR）
+
+### 1b.1 替换硬编码 token
+
+- **涉及文件**:
+  - `lib/site/admin-auth.ts`（第 11 行）
+  - `scripts/check-pinpoint-guardrails.ts`（第 1745 行、第 1782 行）
+  - `scripts/run-pinpoint-regression.mjs`（第 9 行）
+- **当前代码**（`admin-auth.ts`）:
+  ```ts
+  process.env.NODE_ENV === "production" ? null : "admin-secret-dev",
+  ```
+- **修改为**:
+  ```ts
+  process.env.NODE_ENV === "production" ? null : process.env.DEV_ADMIN_TOKEN,
+  ```
+- **guardrails 脚本修改**: `authorization: "Bearer admin-secret-dev"` 改为读取 `process.env.DEV_ADMIN_TOKEN`
+- **regression 脚本修改**: 保留现有 `PINPOINT_REGRESSION_ADMIN_TOKEN` 优先级，推荐顺序改为 `PINPOINT_REGRESSION_ADMIN_TOKEN || process.env.DEV_ADMIN_TOKEN || process.env.ADMIN_PASSPHRASE || "admin-secret-dev"`。脚本场景下保留最后回退值可接受，因为脚本仅在本地运行。
+- **配套操作**:
+  - 在 `.env.example` 中添加 `DEV_ADMIN_TOKEN=change-me-to-a-random-string`（使用占位符，不用弱密钥作示例）
+  - 在 `admin-auth.ts` 中添加启动时检查：如果 `DEV_ADMIN_TOKEN` 值为 `admin-secret-dev` 或 `change-me-to-a-random-string`，输出 `console.warn` 警告
+  - 开发环境的 `.env.local` 中配置 `DEV_ADMIN_TOKEN=<实际值>`
+  - 生产环境不设置此变量，`filter(Boolean)` 自动过滤
+- **补充 `.env.example` 缺失变量**:
+  - `API_SECRET_TOKEN=change-me`
+  - `ADMIN_PASSPHRASE=change-me`
+  - `INDEXNOW_KEY=change-me`
+- **注意**: `.env.example` 当前已经包含 `NEXT_PUBLIC_TWITTER_HANDLE`，不要重复添加。
+- **验证**:
+  - 源码中搜索 `admin-secret-dev` 仅出现在 regression 脚本回退值和启动警告中
+  - 生产 `ADMIN_TOKENS` 不含硬编码值
+  - 本地 guardrails 脚本和 regression 脚本正常工作
+- **回滚方案**: `git revert <sha>`，开发者在 `.env.local` 中恢复 `DEV_ADMIN_TOKEN=admin-secret-dev`
+
+---
+
+## Phase 1c: 小型环境与 SEO 决策项（P1/P2 — 必须拆分）
+
+### 1c.1 `buildNoStoreHeaders` TypeScript 错误复核（不执行代码修改）
+
+- **文件**: `lib/api-headers.ts`（第 25 行）
+- **复核结论**: agent 只读验证 `tsc --noEmit` 当前通过，文档 v2 声称的 `app/api/health/route.ts:34` 和 `:40` TypeScript 错误不可复现。
+- **审批决定**: 不作为 P0 修复项执行。
+- **保留动作**: 若未来出现真实类型错误，可作为独立 cleanup PR 统一 `buildCachedHeaders` / `buildNoStoreHeaders` 返回类型；当前不进入执行序列。
+
+### 1c.2 是否将 Contact 页加入 Sitemap（SEO 决策项，暂不执行）
+
+- **文件**: `app/sitemap.ts`
+- **v2 原建议**: 在 `indexableLegalRoutes` 数组中添加（与 `disclaimer` 同类，非 `primaryRoutes`）:
+  ```ts
+  const indexableLegalRoutes = [
+    { path: routes.disclaimer, lastModified: getStaticRouteLastModified(routes.disclaimer) },
+    { path: routes.contact, lastModified: getStaticRouteLastModified(routes.contact) },
+  ];
+  ```
+- **复核问题**: 历史 SEO 文档曾明确将 `contact-us` 从 sitemap 移除；当前 GSC 恢复方案只要求强化 Trust/E-E-A-T 页面，没有批准将 Contact 重新纳入 sitemap。
+- **审批决定**: 暂不执行。必须先补一段 SEO 策略说明，解释为什么现在要推翻旧策略，以及它是否会影响 Phase 0 归因。
+- **如二次审批通过后的验证**:
+  - `curl http://localhost:3004/sitemap.xml | grep contact-us` 确认出现
+  - `curl -s https://pinpointanswertoday.app/sitemap.xml | grep contact-us` 确认生产出现
+
+### 1c.3 确认 `twitter:site` 环境变量
+
+- **操作**: 确认 Vercel 生产环境中 `NEXT_PUBLIC_TWITTER_HANDLE` 已设置
+- **格式要求**: 值必须包含 `@` 前缀（如 `@YourHandle`），代码中 `lib/site/config.ts:6` 只做 `trim()` 不做格式校验
+- **`.env.example` 状态**: 当前已包含 `NEXT_PUBLIC_TWITTER_HANDLE=` 和注释示例，不需要重复添加。
+- **验证**: `curl -s https://pinpointanswertoday.app | grep twitter:site`
+
+---
+
+## Phase 2: 安全加固（P1 — 必须拆为独立 PR）
+
+> v2 写成“可拆为 2-3 个独立 PR”，但实际包含多类互不相关的安全变量。v3 要求每个小节独立 PR，除非评审明确批准合并。
+
+### 2.1 密钥比较改用恒定时间算法
+
+- **涉及文件**:
+  - `app/api/revalidate/route.ts`（第 49 行）
+  - `app/api/fallback/worker-pinpoint/route.ts`（第 29 行）
+  - `app/api/admin/generate-draft/route.ts`（第 624 行）
+  - `app/api/admin/validate-draft/route.ts`（第 70 行）
+  - `lib/site/admin-auth.ts`
+- **方案**: 在 `lib/site/admin-auth.ts` 中添加 `safeEqual` 工具函数并导出:
+  ```ts
+  import { timingSafeEqual } from "crypto";
+
+  /**
+   * 恒定时间字符串比较。
+   * 注意：仅适用于 Node.js runtime，Edge Runtime 不支持 crypto.timingSafeEqual。
+   */
+  export function safeEqual(a: string, b: string): boolean {
+    const bufA = Buffer.from(a, "utf-8");
+    const bufB = Buffer.from(b, "utf-8");
+    if (bufA.length !== bufB.length) {
+      // 执行一次假比较以消除时序差异，防止攻击者通过响应时间推断密钥长度
+      timingSafeEqual(bufA, bufA);
+      return false;
+    }
+    return timingSafeEqual(bufA, bufB);
+  }
+  ```
+- **`admin-auth.ts` 添加 `authenticateAdmin` 函数**:
+  ```ts
+  export function authenticateAdmin(token: string): boolean {
+    return ADMIN_TOKENS.some((t) => safeEqual(token, t));
+  }
+  ```
+  > 注意：`some()` 在第 k 个匹配时返回，响应时间与全部不匹配不同。对于当前场景（低频管理 API、token 列表仅 2-3 项），此差异可接受。若需更高安全等级，可改用 HMAC 对 token 做固定长度哈希后再比较。
+- **revalidate/route.ts:49** 改为:
+  ```ts
+  if (!stored || !safeEqual(secret, stored)) {
+  ```
+- **worker-pinpoint/route.ts:29** 改为:
+  ```ts
+  if (expectedSecret && !safeEqual(providedSecret, expectedSecret)) {
+  ```
+- **generate-draft/route.ts:624** 和 **validate-draft/route.ts:70** 改为:
+  ```ts
+  if (!token || !authenticateAdmin(token)) {
+  ```
+- **Edge Runtime 兼容性标注**: 在使用 `safeEqual` 的文件头添加注释，标注此代码仅适用于 Node.js runtime。如果未来路由迁移到 Edge Runtime，需替换实现
+- **验证**:
+  - 手动调用 `/api/revalidate` 确认认证正常
+  - 手动调用 `/api/admin/generate-draft` 确认认证正常
+  - `npx tsc --noEmit` 通过
+- **回滚方案**: `git revert <sha>`
+
+### 2.2 SSRF 防护：URL scheme/域名白名单（独立 PR）
+
+- **涉及文件**:
+  - `lib/puzzles/worker-fallback.ts`（`normalizeCompetitorUrl` 函数）
+  - `lib/puzzles/data-sources.ts`（`getGithubRawBase` 函数）
+  - `app/api/health/route.ts`（`resolveWorkerHealthUrl` 函数）
+  - `app/api/pinpoint/today/route.ts`（`resolveUpstreamUrl` 函数或等效）
+  - `lib/puzzles/data/live-worker.ts`（Worker URL 构造）
+  - `app/api/feedback/route.ts`（webhook URL 构造）
+- **通用校验函数**（提取到 `lib/security/url-allowlist.ts`）:
+  ```ts
+  type UrlAllowlistRule = {
+    allowedSchemes: string[];           // e.g. ["https:"]
+    allowedHosts: string[];             // e.g. ["pinpointanswer.today"]
+    allowedHostSuffixes: string[];      // e.g. [".githubusercontent.com"]
+  };
+
+  export function validateUrlAgainstAllowlist(
+    url: URL,
+    rule: UrlAllowlistRule,
+    label: string,
+  ): void {
+    if (!rule.allowedSchemes.includes(url.protocol)) {
+      throw new Error(`SSRF protection [${label}]: scheme ${url.protocol} not allowed`);
+    }
+    const hostOk =
+      rule.allowedHosts.includes(url.hostname) ||
+      rule.allowedHostSuffixes.some((suffix) => url.hostname.endsWith(suffix) && url.hostname !== suffix.slice(1));
+    if (!hostOk) {
+      throw new Error(`SSRF protection [${label}]: host ${url.hostname} not in allowlist`);
+    }
+  }
+  ```
+  > **关键要求**：suffix 匹配必须带点边界。`hostname === "githubusercontent.com" || hostname.endsWith(".githubusercontent.com")` 是安全写法。注意：`evilgithubusercontent.com` 不会匹配 `.githubusercontent.com`，v2 中该示例表述不准确。
+- **各调用点配置**:
+
+  | 文件 | 环境变量 | allowedHosts | allowedHostSuffixes |
+  |------|----------|-------------|-------------------|
+  | `worker-fallback.ts` | `PINPOINT_BASE_URL` | `["pinpointanswer.today"]` | `[]` |
+  | `data-sources.ts` | `GITHUB_RAW_BASE` | `["githubusercontent.com"]` | `[".githubusercontent.com"]` |
+  | `health/route.ts` | `PINPOINT_WORKER_HEALTH_URL` | `["pinpoint-worker.2296744453m.workers.dev"]` | `[".workers.dev"]` |
+  | `today/route.ts` | `PINPOINT_WORKER_HEALTH_URL` | 同上 | 同上 |
+  | `live-worker.ts` | `PINPOINT_WORKER_HEALTH_URL` | 同上 | 同上 |
+  | `feedback/route.ts` | `FEEDBACK_WEBHOOK_URL` 等 | 待确认 | 待确认 |
+
+- **验证**:
+  - 执行前确认生产 `FEEDBACK_WEBHOOK_URL` / `FEISHU_WEBHOOK_URL` / `SLACK_WEBHOOK_URL` / `ALERT_WEBHOOK_URL` 的真实域名清单，避免白名单误杀现有反馈通道
+  - 设置非法环境变量（如 `file:///etc/passwd`、`http://githubusercontent.com.evil.test/payload`）验证报错
+  - `npx next build` 确认正常 URL 不受影响
+- **回滚方案**: `git revert <sha>`
+
+### 2.3 添加 HSTS 安全头（分步启用）
+
+- **文件**: `next.config.ts`，`securityHeaders` 数组中添加
+- **第一步**（本次 PR）：不含 preload
+  ```ts
+  {
+    key: "Strict-Transport-Security",
+    value: "max-age=300; includeSubDomains",
+  },
+  ```
+- **第二步**（运行 1-2 周确认无子域名被影响后）：加大 max-age
+  ```ts
+  {
+    key: "Strict-Transport-Security",
+    value: "max-age=63072000; includeSubDomains",
+  },
+  ```
+- **第三步**（可选，需评估后决定）：添加 `preload`
+- **preload 不可逆风险说明**: 一旦加入浏览器 HSTS preload 列表，移除需通过 hstspreload.org 提交请求，生效周期数周到数月。期间所有子域名强制 HTTPS，staging/内网环境如需 HTTP 将不可访问
+- **前置检查**: 确认 Vercel 平台层是否已设 HSTS 头，避免响应中出现两个 `Strict-Transport-Security` 头
+- **验证**: `curl -I https://pinpointanswertoday.app` 检查 `Strict-Transport-Security` 头存在且仅一个
+- **回滚方案**: `git revert <sha>`；注意浏览器已缓存的 HSTS 头在 max-age 过期前仍有效，短期 max-age (300s) 降低了此风险
+
+### 2.4 重定向参数名问题复核（不执行代码修改）
+
+- **文件**: `next.config.ts`（第 158-161 行）
+- **当前代码**:
+  ```ts
+  source: `/${locale}/pinpoint/:number(\\d+)-analysis`,
+  destination: "/pinpoint/:number-analysis",
+  ```
+- **复核结论**: agent 只读验证 Next 15.0.5 会将 `/pinpoint/:number-analysis` 正确解析为参数 `number` + 字面量 `-analysis`，目标为 `/pinpoint/123-analysis`。
+- **审批决定**: 不作为修复项执行。
+- **保留动作**: 将 `curl -v http://localhost:3004/en/pinpoint/123-analysis` 放入回归验证清单，防止未来 Next 升级后行为变化。
+
+### 2.5 移除 health/today 端点的内部 URL 泄露
+
+- **涉及文件**:
+  - `app/api/health/route.ts`（第 41 行）
+  - `app/api/pinpoint/today/route.ts`（第 47 行）
+- **当前代码**: 错误响应中包含 `workerHealthUrl: workerHealthUrl.toString()`，暴露内部 Cloudflare Worker URL（`pinpoint-worker.2296744453m.workers.dev`）
+- **修改**: 错误响应中移除内部 URL，或替换为通用错误消息
+  ```ts
+  // 修改前
+  { error: message, workerHealthUrl: workerHealthUrl.toString() }
+  // 修改后
+  { error: message }
+  ```
+- **验证**: `curl https://pinpointanswertoday.app/api/health` 在 Worker 不可用时，响应中不含 `workers.dev` URL
+- **回滚方案**: `git revert <sha>`
+
+### 2.6 管理员 API 添加速率限制
+
+- **涉及文件**: `app/api/admin/generate-draft/route.ts`、`app/api/admin/validate-draft/route.ts`
+- **方案**: 复用 `app/api/feedback/route.ts` 中已有的速率限制模式（基于内存的滑动窗口），提取为共享模块 `lib/rate-limit.ts`
+- **配置建议**: 10 分钟窗口内最多 20 次请求（管理员操作频率较低，但需高于 feedback 的 5 次）
+- **验证**: 快速连续发送超过 20 次请求，确认第 21 次返回 429
+- **回滚方案**: `git revert <sha>`
+
+---
+
+## Phase 3: SEO 修复（P1 — 独立 PR）
+
+> SEO 修复从原 P2 提升到 P1，因为 impressions 下降 86.5% 是生存级问题。
+
+### 3.1 归档页 ItemList JSON-LD 截断
+
+- **文件**: `lib/seo/archive-structured-data.ts`（第 29-38 行）
+- **当前问题**: `ItemList.itemListElement` 对全部 `archiveEntries` 做 `.map()`，无截断。复核时当前 registry 约 292 条，ItemList JSON 约 33KB；截断到 100 条预计约 11KB。修复目标是降低移动端 HTML/JSON-LD 体积和解析成本，不应把“Google 一定放弃解析”写成确定性结论。
+- **修改**:
+  ```ts
+  const ITEM_LIST_DISPLAY_LIMIT = 100;
+
+  // CollectionPage.hasPart 已有 20 条限制（COLLECTION_HAS_PART_LIMIT）
+  // ItemList 截断到最近 100 条，用 numberOfItems 声明总数
+  {
+    "@type": "ItemList",
+    numberOfItems: archiveEntries.length,
+    itemListElement: archiveEntries.slice(0, ITEM_LIST_DISPLAY_LIMIT).map((item, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      url: absoluteUrl(withTrailingSlash(routes.detail(item.slug))),
+      name: item.title,
+    })),
+  }
+  ```
+- **验证**:
+  - `curl http://localhost:3004/puzzles | grep 'application/ld+json'` 检查 JSON-LD 体积
+  - 确认 `numberOfItems` 正确反映全量条目数
+  - `npx next build` 通过
+- **回滚方案**: `git revert <sha>`
+
+### 3.2 详情页 OG 图片 URL 格式风险记录
+
+- **当前状态**: 详情页 `socialImagePath` 为 `${puzzleDetailPath}opengraph-image`，生成的 URL 无 `.png` 扩展名
+- **风险**: 部分社交平台（LinkedIn、X/Twitter 某些版本）可能因 URL 无图片扩展名而跳过或报错
+- **本次操作**: 仅在方案中记录此风险，不修改代码。需验证:
+  - 使用 [LinkedIn Post Inspector](https://www.linkedin.com/post-inspector/) 测试详情页 OG 图片
+  - 使用 [X Card Validator](https://cards-dev.twitter.com/validator) 测试
+  - 如果验证发现确实有问题，再作为独立 PR 修复
+- **验证**: 社交平台调试器可正确抓取详情页 OG 图片
+
+### 3.3 #735/#736/#737 恢复后 index 状态验证
+
+- **操作**: 确认 Phase 0 修复后这些页面返回 `index, follow`（而非误走 not-found 分支）
+- **验证**: `curl -s https://pinpointanswertoday.app/linkedin-pinpoint-answers/pinpoint-answer-735/ | grep robots` 确认 `index, follow`
+
+---
+
+## Phase 4: 项目维护（P2 — 独立 PR）
+
+### 4.1 提交 3 个未跟踪文档
+
+- **文件**:
+  - `docs/gsc-ranking-recovery-plan-2026-05-19.md`
+  - `docs/homepage-today-answer-strategy-review-2026-05-19.md`
+  - `docs/phase0-seo-integrity-day0-check-2026-05-19.md`
+- **操作**: `git add` + `git commit`
+- **理由**: 三个文档都是项目核心决策和验证记录，与现有 docs/ 文档体系一致
+
+### 4.2 创建项目级 CLAUDE.md
+
+- **文件**: `CLAUDE.md`（项目根目录，新建）
+- **原则**: 仅做索引，不复制内容，避免与 docs/ 不同步
+- **内容要点**:
+  - 项目简介：LinkedIn Pinpoint 答案站的第二代重构
+  - 技术栈：Next.js 15 + React 19 + Tailwind CSS 4 + Zod
+  - 核心目录结构说明（app/、lib/、worker/、scripts/、docs/）
+  - **索引引用**（非复制内容）:
+    - SEO 约束详见 `docs/seo-audit-2026-04-25.md`
+    - 发布流程详见 `docs/recommended-commit-plan-2026-03-31.md`
+    - 部署检查详见 `docs/deployment-release-checklist-2026-03-13.md`
+    - GSC 恢复方案详见 `docs/gsc-ranking-recovery-plan-2026-05-19.md`
+  - PR 拆分原则：不混合变量，每 PR 独立可回滚
+  - Worker 代码说明：Cloudflare Workers 环境限制导致 worker/src/ 内联了 lib/ 代码
+
+---
+
+## 不在本次修复范围内
+
+| 项目 | 原因 | 排期 |
+|------|------|------|
+| Worker 代码去重 | 需要构建工具改造（esbuild/tsup），影响范围大 | 独立 PR，本季度内 |
+| CSP `script-src` `unsafe-inline` 移除 | 需要 GA 脚本改用 nonce-based | Phase 2 后的下一次迭代，先调研 Next.js nonce-based CSP 方案 |
+| Countdown.tsx useEffect 合并 | 功能正确，纯优化 | 随需 |
+| `asRecord`/`asString` 去重 | 涉及 generate-draft 路由额外逻辑 | 随需 |
+| FAQ Schema 添加 | 需评估富结果风险 | Phase 2 后 14 天，根据 GSC rich result 报告决定是否测试 |
+| `resolveDefaultModel` 统一 | 两个版本逻辑不同 | 随需 |
+| ESLint 9 → flat config 迁移 | 当前可正常工作 | `eslint-config-next` 升级时处理 |
+| 首页 freshness 可见信号 | 属于 GSC 恢复方案 Phase 1 | 详见 `docs/gsc-ranking-recovery-plan-2026-05-19.md` |
+| 首页结构化数据增强 | 属于 GSC 恢复方案 Phase 3 实验 | 详见 `docs/gsc-ranking-recovery-plan-2026-05-19.md` |
+| E-E-A-T / Trust 页面 | 属于 GSC 恢复方案 Day 11-12 | 详见 `docs/gsc-ranking-recovery-plan-2026-05-19.md` |
+
+> SEO 恢复性修复的完整范围见 `docs/gsc-ranking-recovery-plan-2026-05-19.md` 和 `docs/homepage-today-answer-strategy-review-2026-05-19.md`，不在本审计修复方案范围内。
+
+---
+
+## 执行顺序和发布策略
+
+```
+Phase 1b → 独立 PR → 移除硬编码开发密钥，验证脚本和认证
+Phase 2.5 → 独立 PR → 移除 health/today 内部 URL 泄露
+Phase 2.1 → 独立 PR → 恒定时间密钥比较
+Phase 2.2 → 独立 PR → SSRF allowlist，先确认生产 webhook 域名
+Phase 2.3 → 独立 PR → HSTS 短 max-age 试运行
+Phase 2.6 → 独立 PR → 管理员 API rate limit
+Phase 3.1 → 独立 PR → 归档页 ItemList 截断
+Phase 1a → 独立 PR → Next.js 安全升级（默认等 Phase 0 观察窗口结束；紧急安全审批例外）
+Phase 1c.2 → 独立 SEO 决策 PR → Contact 是否进 sitemap，二次审批后执行
+Phase 4 → 独立 PR → 文档和项目索引，无需部署验证
+```
+
+**Phase 间依赖**:
+- Phase 1b、2、3、4 均不依赖 Phase 1a（Next.js 升级）
+- 如果 Phase 1a 延后，其余低风险安全与 SEO 体积修复仍可在 15.0.5 上执行
+- Phase 2.1 的 `safeEqual` 使用 `crypto.timingSafeEqual`，在 Node.js runtime 下 15.0.5 和 15.5.18 均可用
+
+---
+
+## 验证清单
+
+### 本地验证
+
+- [ ] `npx tsc --noEmit` 零错误
+- [ ] `npx next lint` 零警告
+- [ ] `npx next build` 成功
+- [ ] `npm audit --omit=dev` 无生产依赖 critical/high
+- [ ] `npm audit` 中 Next.js 相关 critical/high 已清零；剩余 dev/transitive high 单独记录
+- [ ] 源码中 `admin-secret-dev` 仅出现在 regression 脚本回退值和启动警告中
+- [ ] 重定向 `curl -v http://localhost:3004/en/pinpoint/123-analysis` 目标 URL 正确
+- [ ] `curl http://localhost:3004/en/pinpoint/123-analysis -I` 确认目标 URL 为 `/pinpoint/123-analysis`
+- [ ] 如 Contact sitemap 决策被批准，`curl http://localhost:3004/sitemap.xml | grep contact-us` 确认出现
+- [ ] 归档页 JSON-LD 体积 < 20KB
+- [ ] 设置非法环境变量验证 SSRF 防护报错
+- [ ] SSRF PR 执行前已确认生产 webhook 域名清单
+- [ ] 管理员 API 速率限制：连续请求确认 429
+
+### 生产部署后验证
+
+- [ ] Vercel 构建日志无 warning
+- [ ] `curl -I https://pinpointanswertoday.app` 确认 `Strict-Transport-Security` 头存在且仅一个
+- [ ] `curl -I https://pinpointanswertoday.app` 确认无重复 HSTS 头
+- [ ] `curl https://pinpointanswertoday.app/api/health` 错误响应中不含 `workers.dev` URL
+- [ ] `curl -s https://pinpointanswertoday.app | grep twitter:site` 确认输出
+- [ ] 如 Contact sitemap 决策被批准，`curl -s https://pinpointanswertoday.app/sitemap.xml | grep contact-us` 确认出现
+- [ ] 生产 `/api/revalidate` 用真实 secret 测试认证正常
+- [ ] #735/#736/#737 页面 `robots` 为 `index, follow`
+
+### SEO 恢复监控（与 GSC 恢复方案联动）
+
+| 维度 | 指标 | 验收标准 | 时间窗口 |
+|------|------|----------|----------|
+| 抓取 | Googlebot fetch 首页 | URL Inspection Live Test 通过 | Phase 0 后 48h |
+| 抓取 | #735/#736/#737 被 Google 发现 | GSC URL Inspection 显示可索引 | Phase 0 后 5 天 |
+| Sitemap | sitemap 首页 lastmod | 不早于最新 live puzzle updatedAt | 每日抽查 |
+| 结构化数据 | 归档页 JSON-LD 体积 | ItemList JSON-LD < 20KB | Phase 3 部署后 |
+| 社交 | 详情页 OG image | LinkedIn/X 共享调试器可正确抓取 | Phase 3 部署后 |
+| 排名 | 首页 `pinpoint answer today` position | 回到前 30（中期目标前 20） | Phase 0 后 14-28 天 |
+| 曝光 | 首页 mobile impressions | 恢复到 Phase 0 前 7 天均值的 2 倍+ | Phase 0 后 28 天 |
+
+> 完整 SEO 恢复监控方案见 `docs/gsc-ranking-recovery-plan-2026-05-19.md` 第 14 节。

--- a/docs/gsc-ranking-recovery-plan-2026-05-19.md
+++ b/docs/gsc-ranking-recovery-plan-2026-05-19.md
@@ -1,0 +1,1021 @@
+# Pinpoint Answer Today GSC 排名下降修复方案
+
+> 文档状态：审查版  
+> 生成日期：2026-05-19  
+> 目标站点：`https://pinpointanswertoday.app`  
+> GSC 属性：`sc-domain:pinpointanswertoday.app`  
+> 主要问题窗口：`2026-05-12` 到 `2026-05-18`  
+> 对比窗口：`2026-05-05` 到 `2026-05-11`  
+> 审查目标：确认修复优先级、范围、验收标准，再进入实现
+
+---
+
+## 1. 一句话结论
+
+这次下降不是 `robots`、`noindex`、canonical 错配或完全未索引导致的硬技术故障。
+
+最直接的表现是：Google 对 `pinpoint answer today`、`linkedin pinpoint answer today`、`pinpoint today` 这组核心查询重新排序，首页 `/` 在移动端的主要曝光几乎消失，剩余曝光更多来自低位桌面结果，导致全站平均排名显著恶化。
+
+但代码和数据链路里存在两个必须立即修复的技术风险：
+
+1. 首页和归档页 sitemap `lastmod` 长期停留在 2026-04-01 / 2026-03-31，与每日更新的实际内容不一致。
+2. `#735`、`#736`、`#737` 详情 JSON 文件存在，但 `registry.json` 缺失，导致生产 404、sitemap 漏页、归档漏页和旧路径失效。
+
+这两个问题不是已证实的 5 月 12 日触发器。它们被列为 P0 的原因是：它们是当前可验证、可修复、会削弱近期连续性/新鲜度/可靠性的生产问题。P0 修复应单独发布和监控，不能和首页大改版混在同一个发布窗口里，否则无法判断恢复或恶化来自哪一类变更。
+
+---
+
+## 2. 已证实数据
+
+### 2.1 全站趋势
+
+| 周期 | Clicks | Impressions | CTR | Avg position |
+| --- | ---: | ---: | ---: | ---: |
+| 2026-05-05 到 2026-05-11 | 3 | 1,978 | 0.15% | 10.94 |
+| 2026-05-12 到 2026-05-18 | 2 | 268 | 0.75% | 28.28 |
+
+解释：
+
+- Impressions 下降约 86.5%。
+- Avg position 从 10.94 掉到 28.28。
+- Clicks 样本极小，不能作为主要判断依据。
+- 这是排名和展示资格变化驱动的曝光损失，不是单纯 CTR 问题。
+
+### 2.2 首页是主要损失来源
+
+| URL | 周期 | Clicks | Impressions | Avg position |
+| --- | --- | ---: | ---: | ---: |
+| `/` | 2026-05-05 到 2026-05-11 | 2 | 1,646 | 11.66 |
+| `/` | 2026-05-12 到 2026-05-18 | 2 | 147 | 45.02 |
+
+首页 impressions 下降约 91.1%，贡献了全站曝光下降的大部分。
+
+### 2.3 核心查询断崖式下滑
+
+| Query | Before impressions | Before pos | After impressions | After pos |
+| --- | ---: | ---: | ---: | ---: |
+| `pinpoint answer today` | 1,046 | 9.51 | 15 | 48.40 |
+| `linkedin pinpoint answer today` | 145 | 10.08 | 10 | 61.70 |
+| `pinpoint today` | 115 | 10.44 | 11 | 44.55 |
+
+这三组查询合计减少约 1,270 impressions，占全站曝光损失约 74%。
+
+### 2.4 移动端是最大缺口
+
+首页设备表现：
+
+| Device | 2026-05-05 到 2026-05-11 | 2026-05-12 到 2026-05-18 |
+| --- | --- | --- |
+| Mobile | 1,442 impressions / pos 9.34 | 16 impressions / pos 14.31 |
+| Desktop | 133 impressions / pos 34.76 | 105 impressions / pos 55.49 |
+
+解释：
+
+- Before 周期里，首页移动端贡献约 87.6% 首页曝光。
+- After 周期里，首页移动端曝光几乎消失。
+- After 移动端只剩 16 impressions，平均排名不稳定；更准确的说法不是“移动端从第 9 名掉到第 14 名”，而是“首页在移动 SERP 上大面积不再进入可产生 impression 的结果集”。
+
+### 2.5 4 月底出现过类似波动
+
+| 周期 | 首页 impressions | 首页 avg position |
+| --- | ---: | ---: |
+| 2026-04-20 到 2026-04-28 | 5,448 | 9.80 |
+| 2026-04-29 到 2026-05-04 | 330 | 22.85 |
+| 2026-05-05 到 2026-05-11 | 1,646 | 11.66 |
+| 2026-05-12 到 2026-05-18 | 147 | 45.02 |
+
+解释：
+
+- 这不是第一次波动。
+- Google 可能在这个 query cluster 上反复测试或重算排名。
+- 5 月 12 之后的问题更严重，因为核心查询 position 也明显恶化。
+
+---
+
+## 3. 已排除或低概率根因
+
+### 3.1 不是 robots/noindex 阻断
+
+URL Inspection 抽查结果：
+
+- 首页 `/`：`Submitted and indexed`
+- `/puzzles`：`Submitted and indexed`
+- `/linkedin-pinpoint-answers/pinpoint-answer-741/`：`Submitted and indexed`
+- `/linkedin-pinpoint-answers/pinpoint-answer-742/`：`Submitted and indexed`
+- `/linkedin-pinpoint-answers/pinpoint-answer-743/`：`Submitted and indexed`
+
+共同状态：
+
+- `robotsTxtState`: `ALLOWED`
+- `indexingState`: `INDEXING_ALLOWED`
+- `pageFetchState`: `SUCCESSFUL`
+- `googleCanonical` 与 `userCanonical` 正常
+- `crawledAs`: `MOBILE`
+
+### 3.2 不是已公开的 5 月 Google Search 事故
+
+Google Search Status Dashboard 没有 2026-05-12 附近公开的 ranking/indexing/crawling 事故。最近公开的 Ranking 事件是 March 2026 core update，时间为 2026-03-27 到 2026-04-08，和本次下跌不完全重合。
+
+参考：
+
+- [Google Search Status Dashboard](https://status.search.google.com/summary)
+- [March 2026 core update](https://status.search.google.com/incidents/7eTbAa2jWdToLkraZj5y)
+
+### 3.3 不是单纯搜索需求下降
+
+如果只是用户搜索量下降，核心 query 的 average position 不应从 9-10 跌到 44-62。当前是曝光减少和排名恶化同时发生。
+
+---
+
+## 4. 根因假设与时间线补强
+
+### 4.1 关键修正：P0 技术问题不是已证实根因
+
+本方案将 sitemap `lastmod` 和 `#735/#736/#737` registry 缺失列为 P0，是因为它们是明确的生产缺陷，不是因为它们已经被证明直接触发了 2026-05-12 的下滑。
+
+必须保留这个边界：
+
+- sitemap 首页 lastmod 停在 2026-04-01，问题早于 5 月 12 日，不能单独解释“为什么 5 月 12 日断崖”。
+- `#735/#736/#737` 的 puzzle 日期是 2026-05-05 到 2026-05-07，但 registry 缺失由 `f5a67b8 fix: deprecate fullAnalysis field, migrate all data to articleBlocks` 在 2026-05-07 21:38:12 +0800 移除，流量在 5 月 8-9 仍有恢复表现，所以它也不能单独解释 5 月 12 日断崖。
+- 因此 P0 修复的预期是“消除明显负面信号和生产 404”，不是“修完必然恢复排名”。
+
+### 4.2 根因假设矩阵
+
+| 假设 | 当前证据 | 反证/缺口 | 当前判断 | 对应动作 |
+| --- | --- | --- | --- | --- |
+| Google 对 today query cluster 重新排序 | 核心查询 position 从 9-10 跌到 44-62；首页移动曝光几乎消失 | 需要 SERP 历史快照证明谁上位 | 最可能主因 | SERP 快照、竞品结构对照、内容/首页定位补强 |
+| 首页 freshness / trust 信号不足 | sitemap lastmod 过期；首页每日变化但 sitemap 静态；SERP snippet 可能滞后 | lastmod 早就过期，不能解释精确日期 | 重要放大因素 | P0 修 sitemap，P1 可见日期/验证信息 |
+| registry 缺页破坏近期连续性 | #735-#737 生产 404、sitemap 漏页、日期/数字 alias 失效 | 5 月 8-9 仍恢复过，不能单独解释 5 月 12 | 明确生产缺陷，非唯一根因 | P0 恢复 registry |
+| 移动端性能/CWV 事故 | 下滑主要来自移动端曝光消失 | 本地 Lighthouse 移动性能良好，尚无 CrUX 证据 | 暂无证据支持，但必须专项排查 | PageSpeed/CrUX、Googlebot Smartphone render、移动 SERP |
+| 竞争格局变化 | 当前 SERP 有多个专门站和强媒体站承接该意图 | 缺少 5 月 11 前 SERP 对照 | 高优先级外部假设 | 固定 SERP 快照和竞品分析 |
+| 4 月底同类波动自然回弹 | 4/29-5/4 掉，5/5-5/11 恢复 | 本次跌幅更深，核心词 position 更差 | 可参考但不能照搬 | 分阶段发布，避免过度改动 |
+
+### 4.3 为什么会在 2026-05-12 附近触发
+
+当前最合理解释不是单点故障，而是多因素叠加：
+
+1. 4 月底已经出现一次 query cluster 波动，说明 Google 对这个主题的排序本来就不稳定。
+2. 5 月 7 日的大规模内容字段迁移移除了 `#735/#736/#737` registry entries，但 5 月 8-9 仍出现短期恢复，说明缺页不是唯一触发器。
+3. 5 月 12 日发布 `#742`，并有 `Refresh Pinpoint content and legacy routing` 相关提交；同日开始首页核心 query 的移动曝光消失，桌面残留低位展现增加。
+4. 当前 SERP 里多家竞品把“今日答案 + 日期 + clues + reveal/author/更新时间”放在首屏，本站首页在 freshness、首屏意图和 trust 表达上弱于这些结果。
+
+因此当前根因链应表述为：
+
+```text
+Google 重新评估 today query cluster
+→ 首页移动端不再稳定进入可产生 impression 的结果集
+→ 过期 sitemap lastmod、近期 registry 断层、模板化内容和弱首屏信号放大了重新评估的不利结果
+```
+
+---
+
+## 5. 移动端专项检查
+
+### 5.1 已跑的移动性能基线
+
+PageSpeed Insights API 在本机访问超时，因此先使用本地 Lighthouse 移动模拟作为可复现基线。该结果不是 CrUX 真实用户数据，不能替代 PageSpeed/CrUX。
+
+| URL | Lighthouse mobile perf | FCP | LCP | CLS | TBT | Speed Index |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| `/` | 0.98 | 1.3s | 2.2s | 0 | 20ms | 3.3s |
+| `/linkedin-pinpoint-answers/pinpoint-answer-748/` | 0.98 | 1.2s | 2.0s | 0 | 0ms | 3.7s |
+
+初步判断：
+
+- 本地 Lighthouse 不支持“移动性能事故导致排名断崖”的假设。
+- 仍需用 PageSpeed Insights 或 CrUX 获取真实用户维度的 mobile CWV，尤其是 LCP、INP、CLS。
+
+### 5.2 必须补的移动排查任务
+
+P0 技术修复发布后，单独执行：
+
+1. PageSpeed Insights mobile：
+   - `/`
+   - 最新详情页
+   - `#742`
+   - `/puzzles`
+2. CrUX / field data：
+   - origin-level mobile LCP / INP / CLS
+   - URL-level mobile data，如有样本
+3. Googlebot Smartphone render：
+   - 首屏是否可见 puzzle number、日期、clues、hint/reveal 区块
+   - answer 文本是否在 SSR HTML 中可见或可被 Google 渲染
+   - mobile nav 是否隐藏关键内链
+4. 移动 SERP：
+   - 美国、英国、印度至少三地分别记录 `pinpoint answer today`、`linkedin pinpoint answer today`
+   - 标记是否有 AI overview、featured snippet、Top Stories、People also ask、视频或论坛结果
+
+如果 PageSpeed/CrUX 显示 mobile CWV fail，则移动性能修复优先级提升到 P0.5，并暂停首页结构改版。
+
+---
+
+## 6. 当前 SERP / 竞品快照
+
+> 快照时间：2026-05-19  
+> 方法：搜索工具的非个性化查询快照，不等同于正式 rank-tracking；需要后续用固定地区、固定设备、无登录环境复测。
+
+### 6.1 `pinpoint answer today` 可见竞争者
+
+当前可见结果中，强相关竞品包括：
+
+- [pinpointanswer.today](https://pinpointanswer.today/)
+- [The Word Finder - LinkedIn Pinpoint Answers](https://www.thewordfinder.com/linkedin-pinpoint-answers/)
+- [Try Hard Guides - LinkedIn Pinpoint Answer Today](https://tryhardguides.com/linkedin-pinpoint-answer-today/)
+- [linkedinpinpointanswer.today](https://linkedinpinpointanswer.today/)
+- [pinpointanswertoday.online](https://pinpointanswertoday.online/)
+- [PC Gamer 的 daily answer 类页面](https://www.pcgamer.com/games/puzzle/linked-in-pinpoint-answer-today/)
+
+搜索工具快照按返回顺序的前列结果是：
+
+1. `pinpointanswer.today`
+2. `The Word Finder`
+3. `Try Hard Guides`
+
+这不是正式 rank-tracking 结果，但足以说明：当前 SERP 不是空白市场，本站需要和多个专门页/强站争夺同一个 today-answer 意图。
+
+初步观察：
+
+- 竞品多采用“今日 puzzle 编号/日期 + clues + reveal/answer + recent answers”的首屏结构。
+- The Word Finder、Try Hard Guides 这类站点通常有明显作者/更新时间/编辑信号。
+- 若本站首页在当前 top visible set 中不可见，说明修复不能只看内部技术项；需要把首页重新对齐“今日答案”意图。
+
+### 6.2 SERP 快照要固定化
+
+后续每次复盘必须记录：
+
+| Query | Device | Country | Top 3 | Top 10 中是否有本站 | 结果类型变化 | 备注 |
+| --- | --- | --- | --- | --- | --- | --- |
+| `pinpoint answer today` | Mobile | US | 待记录 | 待记录 | 待记录 |  |
+| `linkedin pinpoint answer today` | Mobile | US | 待记录 | 待记录 | 待记录 |  |
+| `pinpoint today answer` | Mobile | US | 待记录 | 待记录 | 待记录 |  |
+| `pinpoint answer today` | Desktop | US | 待记录 | 待记录 | 待记录 |  |
+
+如果 top 3 被竞品固定占据，技术修复只能消除负面信号，真正恢复需要内容/首屏/信任结构升级。
+
+---
+
+## 7. 4 月底波动与 5 月 12 下滑对比
+
+### 7.1 4 月底掉量后为何恢复
+
+4 月 29 到 5 月 4 的下滑与 5 月 12 后的下滑不同。
+
+4 月底表现：
+
+- 首页 impressions 下降到 330。
+- 首页 avg position 为 22.85。
+- `pinpoint answer today` 在移动端仍能零散保持 7-15 名左右的结果。
+- 5 月 1 附近有多次内容/SEO 修复提交：
+  - `094fa68 fix: unblock daily pinpoint publish data`
+  - `968be84 feat: make spoiler hints and answer labels include specific clue/answer text`
+  - `11bd4c9 fix: remove unsupported rich result markup`
+  - `bae6180 fix: align sitemap and structured data guardrails`
+- 但无法证明恢复由这些提交直接触发，可能是自然回弹、query cluster 测试结束、或内容更新共同作用。
+
+5 月 12 后表现：
+
+- 首页 impressions 下降到 147，avg position 恶化到 45.02。
+- 核心 query 的 after position 进入 48-62 区间。
+- 移动端首页曝光几乎清零，剩余主要是桌面低位结果。
+- 这是比 4 月底更深的下滑，不应假设会自然恢复。
+
+### 7.2 可利用的判断
+
+如果 P0 技术修复后 7-14 天出现类似 5 月 5-11 的自然回弹，说明站点仍有被 Google 重新测试的机会。
+
+如果 P0 技术修复后 14-28 天仍无 mobile impressions 恢复，则应判定为结构性竞争/意图匹配问题，而不是继续等待。
+
+---
+
+## 8. 风险分级
+
+### P0：立即修复的技术风险
+
+#### P0-1 修复 sitemap 首页/归档 lastmod 数据源
+
+当前问题：
+
+- [app/sitemap.ts](/Users/elng/web/pinpoint-answer-today-new/app/sitemap.ts:15) 使用 `getStaticRouteLastModified(routes.home)` 生成首页 lastmod。
+- [data/static-page-metadata.json](/Users/elng/web/pinpoint-answer-today-new/data/static-page-metadata.json:4) 中 `/` 的 `lastModified` 仍是 `2026-04-01T02:12:46.000Z`。
+- 生产 sitemap 中首页 `<lastmod>` 仍输出 `2026-04-01T02:12:46.000Z`。
+- `/puzzles` 的 lastmod 也停在 `2026-03-31T12:59:06.000Z`。
+
+为什么重要：
+
+- 首页每天承接当前 puzzle，但 sitemap 却告诉 Google 首页已经 1 个多月没更新。
+- 这会和页面 title/H1/正文中每日变化的信号冲突。
+- Google 不保证一定使用 sitemap `lastmod`，但错误的 `lastmod` 仍是可避免的低质量抓取信号。
+
+修复方向：
+
+- 首页 `/` lastmod 取当前 live puzzle 的 `updatedAt`，fallback 到 `publishDate`。
+- `/puzzles` lastmod 取最新公开 puzzle 的 `updatedAt`，fallback 到最新公开 puzzle 的 `publishDate`。
+- `/next-pinpoint-preview` lastmod 取 preview 数据的更新时间；如果 preview 无更新时间，则用当前 live puzzle 的更新时间作为保守 fallback。
+- 静态 trust/legal 页面继续使用 `static-page-metadata.json`。
+
+建议实现位置：
+
+- 修改 [app/sitemap.ts](/Users/elng/web/pinpoint-answer-today-new/app/sitemap.ts:12)。
+- 复用现有 `getCurrentPuzzle()`、`getArchiveEntries()`、`getNextPreview()` 或底层 registry helper。
+
+验收标准：
+
+- `/sitemap.xml` 中 `/` 的 `<lastmod>` 不早于最新 live puzzle 的 `updatedAt`。
+- `/sitemap.xml` 中 `/puzzles` 的 `<lastmod>` 不早于最新公开 puzzle 的 `updatedAt`。
+- 最新 10 个详情页仍输出各自 `updatedAt`。
+- sitemap 不包含未发布、未验证或未来 puzzle 页面。
+
+#### P0-2 恢复 #735/#736/#737 registry 条目
+
+当前问题：
+
+- `data/puzzles/pinpoint-answer-735.json` 存在。
+- `data/puzzles/pinpoint-answer-736.json` 存在。
+- `data/puzzles/pinpoint-answer-737.json` 存在。
+- 但 [data/puzzles/registry.json](/Users/elng/web/pinpoint-answer-today-new/data/puzzles/registry.json:193) 从 `#738` 直接跳到 `#734`。
+
+生产表现：
+
+- `/linkedin-pinpoint-answers/pinpoint-answer-737/` 返回 404。
+- `/puzzles/737` 返回 404。
+- `/pinpoint/2026-05-07` 返回 404。
+- sitemap 有 `#738` 和 `#734`，但缺 `#737/#736/#735`。
+
+为什么重要：
+
+- 这是正式页面不可用，不只是 sitemap 漏报。
+- 这些页面处于 2026-05-05 到 2026-05-07，正好在下降前的近期连续区间。
+- 缺页会破坏 archive 连续性、内部链接连续性、日期路径和数字路径解析。
+
+修复方向：
+
+- 从对应 JSON 文件恢复 registry entries。
+- 状态应为 `published` 或 `archived`，不要标记为 draft。
+- 确保 `number`、`slug`、`publishDate`、`updatedAt`、`clues`、`answer` 和 category 信息与 JSON 一致。
+
+验收标准：
+
+- `/linkedin-pinpoint-answers/pinpoint-answer-735/` 返回 200。
+- `/linkedin-pinpoint-answers/pinpoint-answer-736/` 返回 200。
+- `/linkedin-pinpoint-answers/pinpoint-answer-737/` 返回 200。
+- `/puzzles/735`、`/puzzles/736`、`/puzzles/737` 正确跳转到 canonical detail URL。
+- `/pinpoint/2026-05-05`、`/pinpoint/2026-05-06`、`/pinpoint/2026-05-07` 正确跳转到 canonical detail URL。
+- sitemap 包含 `#735/#736/#737`。
+
+### P1：防回归工程健康度
+
+#### P1-1 增加数据完整性 CI
+
+当前问题：
+
+- 仓库允许 `data/puzzles/pinpoint-answer-*.json` 存在但 registry 缺条。
+- 当前 validation 没有阻断这种上线风险。
+- 这是防止未来复发的工程健康度措施，不是恢复当前排名的直接修复，因此不占用 Day 1 的 P0 发布窗口。
+
+修复方向：
+
+增加数据校验：
+
+1. 所有公开 detail JSON 都必须在 `data/puzzles/registry.json` 中存在。
+2. registry 中的公开条目必须有对应 JSON 文件。
+3. 最新 N 天 puzzle 编号和日期不能出现缺口，除非显式 allowlist。
+4. sitemap 生成结果必须包含所有公开 registry detail。
+5. 首页 sitemap lastmod 不得早于当前 live puzzle `updatedAt`。
+
+建议接入位置：
+
+- 现有 `npm run validate:data`。
+- 或新增 `scripts/check-seo-data-integrity.ts`，再挂到 build 前。
+
+验收标准：
+
+- 删除 registry 中任意公开条目时，CI fail。
+- 删除公开 JSON 文件时，CI fail。
+- 首页 sitemap lastmod 回退到静态日期时，CI fail。
+
+---
+
+## 9. 首页修复方案
+
+### 9.1 首页定位
+
+首页应该从“站点总览/guide landing page”收紧为“今日 Pinpoint 答案实时入口”。
+
+页面主任务：
+
+1. 明确告诉用户今天的 puzzle 编号和日期。
+2. 明确告诉用户答案、线索和 hint 在这里。
+3. 快速引导到今日详情页。
+4. 保留 archive 和 guide，但不要抢占首屏主意图。
+
+### 9.2 首屏结构建议
+
+建议顺序：
+
+1. H1
+2. 今日状态条
+3. 今日 clues + hint/reveal answer 区块
+4. Full breakdown CTA
+5. Yesterday / recent 7 days
+6. How we verify today’s answer
+7. What is LinkedIn Pinpoint / FAQ / archive / trust content
+
+建议 H1：
+
+```text
+LinkedIn Pinpoint Answer Today — Puzzle #748, May 18, 2026
+```
+
+注意：
+
+- 日期必须来自已验证 puzzle 数据。
+- 不要提前写未来日期或未来 puzzle。
+- 时区应明确，例如 `Last verified: May 18, 2026, 07:08 UTC` 或站点统一时区。
+
+### 9.3 Title 和 description
+
+当前 title：
+
+```text
+LinkedIn Pinpoint Answer Today | Hints & Solution
+```
+
+建议动态 title：
+
+```text
+LinkedIn Pinpoint Answer Today #748 — May 18, 2026 Hints & Answer
+```
+
+备选短版：
+
+```text
+LinkedIn Pinpoint #748 Answer Today — May 18, 2026
+```
+
+建议 description：
+
+```text
+Get today's LinkedIn Pinpoint #748 answer for May 18, 2026 with five clues, spoiler-safe hints, and a verified explanation before opening the full breakdown.
+```
+
+原则：
+
+- 包含 `LinkedIn Pinpoint`、`answer today`、puzzle number、日期。
+- 不要堆重复关键词。
+- 不要把答案本身直接放进 meta description，避免 zero-click 风险；答案应在页面可见 HTML 中存在。
+
+### 9.4 今日答案卡
+
+首屏今日答案卡应包含：
+
+- Puzzle number
+- Published date
+- Last updated / verified time
+- 5 clues
+- Spoiler-safe hint ladder
+- Reveal answer control
+- One-line answer logic
+- Link to full breakdown
+
+答案是否应该在 SSR HTML 中存在：
+
+- 可以用 reveal 控制视觉剧透。
+- 但答案文本应存在于初始 HTML 或服务端渲染结构中，避免 Googlebot 只能看到空交互壳。
+
+### 9.5 移除或下沉首页噪音
+
+当前首页底部有大量 directory badge / featured badge。
+
+修复建议：
+
+- 从首页移除 `FooterBadgeWall`，或下沉到 About/Press 页面。
+- 首页只保留和 daily answer 意图直接相关的 trust 信号。
+- 外链目录 badge 不应作为 E-E-A-T 主要证明。
+
+验收标准：
+
+- 首页首屏不再像工具目录展示页。
+- Googlebot 和用户在首屏立即看到当前 puzzle 编号、日期、clues、hint/reveal 区块。
+- 首页 title/H1/visible date/structured data 的日期一致。
+
+### 9.6 首页改版风险控制
+
+首页 H1、title、首屏顺序和模块权重都属于高影响 SEO 变更。当前 impressions 已经下降 86.5%，不应把首页大改版和 P0 技术修复放在同一个生产发布窗口。
+
+推荐发布策略：
+
+1. 第一批只发布 P0 技术修复：sitemap lastmod、registry 恢复、必要 revalidate。
+2. 观察至少 5 个完整自然日，记录核心 query、首页 mobile impressions、最新详情页 impressions。
+3. 如果 P0 后没有明显恶化，再单独发布首页首屏/metadata 改版。
+4. 首页改版 PR 必须包含 before/after HTML 快照、mobile screenshot、Lighthouse mobile baseline 和 SERP 监控计划。
+
+首页改版短期风险：
+
+- Google 重新理解页面主意图期间，title link 和 snippet 可能短期波动。
+- 如果 answer 文本、日期或验证信息实现不一致，可能进一步削弱 trust。
+- 如果首屏过度堆关键词，可能从“意图收紧”变成“关键词堆砌”。
+
+回滚条件：
+
+- 改版发布后 7 天内首页 mobile impressions 继续下降超过 50%，且最新详情页没有对应增长。
+- GSC 显示首页核心 query average position 继续恶化 20 名以上。
+- Google URL Inspection 渲染 HTML 缺失核心内容。
+
+---
+
+## 10. 每日详情页修复方案
+
+### 10.1 优先修复范围
+
+优先重写：
+
+1. `#742` 到最新页，因为下降从 2026-05-12 开始。
+2. `#735/#736/#737`，因为当前 registry 缺失导致生产不可用。
+3. 最近 30 天页面，因为它们对 `today`、`yesterday`、近期长尾和 archive 连续性影响最大。
+
+### 10.2 推荐页面结构
+
+每日详情页结构：
+
+1. H1：`LinkedIn Pinpoint #748 Answer & Hints — May 18, 2026`
+2. Puzzle facts：日期、编号、difficulty、turning clue、answer type。
+3. Quick answer box：答案、简短解释、spoiler control。
+4. Hint ladder：Hint 1 / Hint 2 / Hint 3。
+5. Clue-by-clue table：每个 clue 的具体解释。
+6. Wrong answer traps：常见误判和为什么不对。
+7. Full explanation：从线索到 category 的推理过程。
+8. Verification block：验证人、验证时间、数据来源说明。
+9. Correction history：如果修正过，记录修正时间和内容。
+10. Previous / next / archive 内链。
+
+### 10.3 内容质量要求
+
+每页必须避免只替换 clue 的模板化表达。
+
+不合格表达示例：
+
+```text
+Scale and Beaker both fit several loose themes, so it is better to wait for a more specific word.
+```
+
+合格表达应写具体推理：
+
+```text
+Scale can first suggest weight, music, or measurement. Beaker narrows the board toward lab equipment, and pH meter makes the chemistry-lab reading much stronger than a general measurement category.
+```
+
+每页至少补充：
+
+- 1 个 turning clue。
+- 2 个 plausible wrong answers。
+- 每个 clue 的具体 fit reason。
+- 1 段“为什么最终答案比其他候选更好”。
+
+### 10.4 结构化数据
+
+详情页当前已有 Article/Game/ItemList/BreadcrumbList，方向基本正确。
+
+需要补强：
+
+- `datePublished` 与页面可见 Published 一致。
+- `dateModified` 与页面可见 Updated/Verified 一致。
+- Breadcrumb 可见文本与 JSON-LD 一致。
+- Author/Publisher 信息稳定。
+
+参考：
+
+- [Google publication dates](https://developers.google.com/search/docs/appearance/publication-dates)
+- [Google structured data general guidelines](https://developers.google.com/search/docs/appearance/structured-data/sd-policies)
+
+---
+
+## 11. Trust / E-E-A-T 修复方案
+
+### 11.1 新增或强化页面
+
+建议新增或强化：
+
+- `/about-us`
+- `/contact-us`
+- `/how-we-verify`
+- `/corrections`
+- `/editorial-policy`
+
+### 11.2 Verification 文案统一
+
+当前页面可能混用：
+
+- `verified puzzle data`
+- `human editor`
+- `compact explainer`
+
+建议统一成：
+
+```text
+Verified by Pinpoint Answer Today editors after checking the live LinkedIn Pinpoint puzzle clues and answer.
+```
+
+如果没有真实人工验证，不要写 `human editor`。
+
+### 11.3 Corrections 机制
+
+每个详情页底部增加：
+
+- `Last verified`
+- `Corrections`
+- `Report an issue`
+
+示例：
+
+```text
+Last verified: May 18, 2026, 07:08 UTC.
+Correction history: No corrections recorded for this puzzle.
+```
+
+如果修正：
+
+```text
+Correction history:
+- May 18, 2026, 09:12 UTC: Updated the clue explanation for "Vindaloo" to clarify the category.
+```
+
+### 11.4 不建议把 directory badges 当 trust 主体
+
+目录站 badge 可以放在 About/Press 页面，但不应在首页作为主要信任证明。
+
+原因：
+
+- 它们和用户搜索 `LinkedIn Pinpoint answer today` 的意图不直接相关。
+- 它们可能稀释首页主题。
+- 部分目录链接如果是互换或推广性质，应审查是否需要 `nofollow` 或 `sponsored`。
+
+---
+
+## 12. 内链与信息架构修复方案
+
+### 12.1 首页内链
+
+首页应优先链接：
+
+- 今日详情页：`LinkedIn Pinpoint #748 answer`
+- 昨日详情页：`LinkedIn Pinpoint #747 answer`
+- 最近 7 天答案
+- Archive
+- How we verify
+
+避免泛锚文本：
+
+- `Open`
+- `View`
+- `Read more`
+
+推荐锚文本：
+
+- `Open LinkedIn Pinpoint #748 answer`
+- `View yesterday's Pinpoint #747 answer`
+- `Browse past LinkedIn Pinpoint answers`
+
+### 12.2 Archive 内链
+
+Archive 应支持：
+
+- 按 puzzle number 搜索。
+- 按 clue 搜索。
+- 按月份浏览。
+- 最近 30 天优先展示。
+
+Archive 页主意图应是旧题查找，不要和首页抢 `today answer`。
+
+### 12.3 Legacy route
+
+当前 legacy redirect 大方向正确，但 registry 缺条会导致旧数字/date 路径 404。
+
+修复 registry 后需要抽查：
+
+- `/puzzles/737`
+- `/pinpoint/2026-05-07`
+- `/linkedin-pinpoint/737`
+- `/pinpoint-answer-737`
+
+验收标准：
+
+- 所有存在的近期 puzzle number/date alias 最终都到 canonical detail URL。
+- 不存在的 puzzle 返回干净 404。
+- 不产生 3 跳以上重定向链。
+
+---
+
+## 13. 2 周执行路线图
+
+### 发布原则
+
+本轮必须拆成至少两个发布窗口：
+
+1. P0 技术修复单独发布。
+2. 首页结构/metadata 改版另开 PR，和 P0 至少间隔 5 个完整自然日。
+
+这样做的目的是保留归因能力：如果 P0 发布后恢复，可以确认明显生产缺陷修复有贡献；如果 P0 后无恢复，首页改版和内容升级才进入下一阶段。
+
+### Day 0：审查与冻结范围
+
+推荐决策：
+
+- 批准 P0 技术修复立即实现。
+- 推迟首页首屏改版，另开 PR。
+- 推迟 badge wall 迁移，和首页改版同 PR 或 trust PR 处理。
+- 批准 SERP 快照和移动专项检查。
+- 批准 `#742` 到最新页的内容重写，但不要和 P0 同日发布。
+
+输出：
+
+- 确定 P0 PR 只包含 sitemap lastmod、registry 恢复、必要 revalidate 验证。
+- 明确首页改版、内容重写、trust 页、CI 防回归均不进入 P0 PR。
+
+### Day 1：P0 技术修复 PR
+
+任务：
+
+- 恢复 `#735/#736/#737` registry entries。
+- 修改 sitemap lastmod 数据源。
+- 本地跑 validation/build。
+- 生成 preview，抽查 sitemap 和缺失页面。
+
+验收：
+
+- `npm run validate:data` 通过。
+- `npm run build` 通过。
+- Preview sitemap 中首页 lastmod 正确。
+- `#735/#736/#737` detail 路由可访问。
+- `/puzzles/737` 和 `/pinpoint/2026-05-07` 正确跳转。
+
+### Day 2：P0 发布与重新抓取
+
+任务：
+
+- 部署生产。
+- 触发 on-demand revalidate。
+- 在 GSC URL Inspection 请求重新抓取：
+  - `/`
+  - `/sitemap.xml`
+  - `/linkedin-pinpoint-answers/pinpoint-answer-742/`
+  - `/linkedin-pinpoint-answers/pinpoint-answer-737/`
+  - 最新 puzzle detail
+
+验收：
+
+- 生产 sitemap 正确。
+- 生产 `#735/#736/#737` 返回 200。
+- `/puzzles/737` 与 `/pinpoint/2026-05-07` 正确跳转。
+- 记录 P0 发布前后 48 小时 GSC baseline。
+
+### Day 3-4：只监控，不做首页大改
+
+任务：
+
+- 固定记录 GSC 核心 query、首页 mobile impressions、最新详情页 impressions。
+- 补移动专项：
+  - PageSpeed Insights mobile / CrUX
+  - Googlebot Smartphone render
+  - mobile SERP snapshot
+- 补 SERP 竞品表：US mobile / US desktop 至少各一次。
+
+验收：
+
+- 得到可复核的移动 SERP top 10。
+- 得到 PageSpeed 或 CrUX mobile field/lab 数据。
+- 得到 Googlebot Smartphone 渲染 HTML 检查结果。
+
+### Day 5-7：P1 防回归与近期详情页内容 PR
+
+任务：
+
+- 增加 registry/JSON/sitemap 一致性 CI。
+- 重写 `#742` 到最新页。
+- 补 `turning clue`、wrong answer traps、具体 clue table。
+- 统一 verification block。
+- 补 correction history。
+
+验收：
+
+- CI 能拦截 registry 缺条。
+- 每页没有明显模板句。
+- 每页至少 2 个 wrong-answer explanations。
+- 每个 clue 都有具体解释。
+- 答案文本 SSR 可见。
+
+### Day 8-10：首页改版 PR
+
+进入条件：
+
+- P0 发布后没有技术回归。
+- 移动专项没有发现 CWV P0 问题。
+- SERP 快照确认 today intent 需要更强首屏承接。
+
+任务：
+
+- 动态 title 加入 puzzle number 和日期。
+- H1 加入 puzzle number 和日期。
+- 添加 visible `Published / Last verified / Updated`。
+- 今日答案卡上移。
+- `How we verify` 摘要上移。
+- badge wall 移出首页或下沉到 About/Press。
+
+验收：
+
+- Googlebot Smartphone 抓取 HTML 中能看到当前 puzzle number、日期、clues、answer/hint 区块。
+- title/H1/可见日期/schema 日期一致。
+- 首屏不再被 archive 或 badge 内容稀释。
+- 改版 PR 自带 before/after screenshot 和 Lighthouse mobile baseline。
+
+### Day 11-12：Trust 层补强
+
+任务：
+
+- 新增或强化 `/how-we-verify`。
+- 新增或强化 `/corrections`。
+- About 页说明编辑流程。
+- Contact 页反馈路径清晰。
+- 详情页底部链接到 verification/corrections。
+
+验收：
+
+- 用户和 Google 都能看到内容如何验证。
+- 每页都有可见的反馈/修正入口。
+- 不做虚假作者或虚假验证声明。
+
+### Day 13-14：Archive 和内链收紧
+
+任务：
+
+- Archive 强化按日期/编号/线索检索。
+- 首页到今日/昨日/最近页的锚文本具体化。
+- 详情页 previous/next/archive 锚文本具体化。
+
+验收：
+
+- 内链能明确表达页面主意图。
+- Archive 不和首页抢 `today answer`。
+
+### Day 14：复盘决策
+
+判断：
+
+- 如果首页 mobile impressions 恢复，继续内容质量优化。
+- 如果首页仍无恢复但详情页上升，考虑让今日详情页成为主承接页，首页转为 strong hub。
+- 如果整体继续下滑，进入 28 天应急路径，不继续“再等等”。
+
+---
+
+## 14. 监控方案
+
+### 14.1 GSC 维度
+
+固定查询：
+
+- `date + query + page + device + country`
+
+固定周期：
+
+- 最近 7 天 vs 前 7 天。
+- 最近 28 天 vs 前 28 天。
+- 下跌窗口 `2026-05-12` 到当前 vs `2026-05-05` 到 `2026-05-11`。
+
+核心查询：
+
+- `pinpoint answer today`
+- `linkedin pinpoint answer today`
+- `pinpoint today`
+- `pinpoint today answer`
+- `linkedin pinpoint answer`
+- `pinpoint #748 answer`
+
+核心 URL：
+
+- `/`
+- `/puzzles`
+- 最新 10 个 detail URLs
+- `#742` 到最新页
+- `#735/#736/#737`
+
+### 14.2 技术监控
+
+每天抽查：
+
+- `/sitemap.xml`
+- `/robots.txt`
+- 首页 status/header
+- 最新详情页 status/header
+- 近期 legacy aliases
+- Googlebot smartphone rendered HTML
+
+### 14.3 成功指标
+
+短期，7 天内：
+
+- `#735/#736/#737` 404 清零。
+- sitemap 首页/归档 lastmod 正确。
+- 首页重新抓取成功。
+- 最新详情页重新抓取成功。
+
+中期，14-28 天：
+
+- 首页 mobile impressions 开始恢复。
+- `pinpoint answer today` ranking 从 40+ 回到前 20。
+- 最新详情页长尾 impressions 增加。
+- Archive 漏页问题不再出现。
+
+长期，30-60 天：
+
+- 首页和详情页形成稳定分工。
+- 泛 today query 不再完全依赖首页单点。
+- 最近 30 天 detail pages 能承接更多 clue-specific 查询。
+
+### 14.4 28 天无恢复应急路径
+
+如果 P0 技术修复发布 28 天后仍满足以下任一条件：
+
+- 首页 mobile impressions 未恢复到 P0 前 7 天均值的 2 倍以上。
+- `pinpoint answer today` 仍稳定在 40 名以后。
+- 最新详情页长尾 impressions 没有增长。
+- 当前 SERP top 10 中本站仍不可见。
+
+则不再继续等待，进入应急分支：
+
+1. 重新定义主承接页：
+   - A 方案：首页继续承接 `answer today`。
+   - B 方案：最新详情页承接 `#NNN answer today`，首页改为 hub。
+   - 用 GSC query/page 数据决定，不凭直觉。
+2. 做竞品内容差距表：
+   - top 5 竞品首屏模块。
+   - 日期/作者/验证/答案呈现方式。
+   - 是否有 featured snippet 或 PAA 占位。
+3. 做内容质量抽样审计：
+   - 最新 30 页。
+   - 找重复句、薄解释、无 wrong-answer 分析、无验证说明的页面。
+4. 决定是否进行更大范围信息架构改造：
+   - 首页与 latest detail 的 canonical/内部链接分工。
+   - Archive 分层。
+   - 今日页/日期页是否需要独立稳定入口。
+5. 如 SERP 被强媒体/官方/AI overview 固定占据：
+   - 降低首页泛词恢复预期。
+   - 把增长目标转向 clue-specific、puzzle-number-specific、archive lookup 查询。
+
+---
+
+## 15. 不建议做的事
+
+不要做：
+
+- 不要提前发布未验证的未来 puzzle。
+- 不要只改 `Last updated` 制造新鲜感。
+- 不要批量生成低差异页面。
+- 不要复制竞品内容再改写同义词。
+- 不要在首页堆砌 `pinpoint answer today / linkedin pinpoint answer / hints today`。
+- 不要大规模迁移 URL。
+- 不要删除 archive。
+- 不要把 directory badge 或 AI 工具站互链当 E-E-A-T。
+- 不要承诺 `100% accurate` 或 `all valid solutions`，除非有真实验证机制。
+
+---
+
+## 16. 审查决策清单
+
+请按推荐立场审查：
+
+| 决策项 | 推荐 | 理由 |
+| --- | --- | --- |
+| 立即修复 sitemap lastmod 数据源 | 批准 | 明确错误信号，修复范围小，可独立验证 |
+| 恢复 `#735/#736/#737` registry entries | 批准 | 当前生产 404，影响 sitemap、archive、legacy alias |
+| P0 技术修复单独发布 | 批准 | 保留归因能力，避免与首页大改版混淆 |
+| 增加 registry/JSON/sitemap 一致性 CI | 推迟到 P1 | 防复发重要，但不是当前排名恢复直接手段 |
+| 首页 H1/title/首屏结构改版 | 推迟到 P0 后至少 5 天 | 大改版会触发重新评估，应单独 PR |
+| 把首页 badge wall 移到 About/Press | 推迟到首页 PR | 属于页面意图/信任结构调整，不进 P0 |
+| 重写 `#742` 到最新页 | 批准，但不与 P0 同日发布 | 内容质量必须补，但要和技术修复分离 |
+| 新增 `/how-we-verify` 和 `/corrections` | 批准为 P2 | 强化 trust，但不阻塞 P0/P1 |
+| SERP 快照和移动专项检查 | 批准 | 填补根因分析外部视角和移动端缺口 |
+
+---
+
+## 17. 参考资料
+
+Google 官方：
+
+- [Debug traffic drops in Google Search](https://developers.google.com/search/docs/monitor-debug/debugging-search-traffic-drops)
+- [Creating helpful, reliable, people-first content](https://developers.google.com/search/docs/fundamentals/creating-helpful-content)
+- [Build and submit a sitemap](https://developers.google.com/search/docs/crawling-indexing/sitemaps/build-sitemap)
+- [Influencing title links in Google Search](https://developers.google.com/search/docs/appearance/title-link)
+- [Control your snippets in search results](https://developers.google.com/search/docs/appearance/snippet)
+- [Influence your byline dates in Google Search](https://developers.google.com/search/docs/appearance/publication-dates)
+- [Google Search spam policies](https://developers.google.com/search/docs/essentials/spam-policies)
+- [Google Search Status Dashboard](https://status.search.google.com/summary)
+
+本地相关文件：
+
+- [app/sitemap.ts](/Users/elng/web/pinpoint-answer-today-new/app/sitemap.ts)
+- [data/static-page-metadata.json](/Users/elng/web/pinpoint-answer-today-new/data/static-page-metadata.json)
+- [data/puzzles/registry.json](/Users/elng/web/pinpoint-answer-today-new/data/puzzles/registry.json)
+- [app/(site)/(home)/page.tsx](/Users/elng/web/pinpoint-answer-today-new/app/(site)/(home)/page.tsx)
+- [components/home/HomeHero.tsx](/Users/elng/web/pinpoint-answer-today-new/components/home/HomeHero.tsx)
+- [components/home/HomeRevealSection.tsx](/Users/elng/web/pinpoint-answer-today-new/components/home/HomeRevealSection.tsx)
+- [lib/seo/metadata.ts](/Users/elng/web/pinpoint-answer-today-new/lib/seo/metadata.ts)
+- [app/api/revalidate/route.ts](/Users/elng/web/pinpoint-answer-today-new/app/api/revalidate/route.ts)

--- a/docs/homepage-today-answer-strategy-review-2026-05-19.md
+++ b/docs/homepage-today-answer-strategy-review-2026-05-19.md
@@ -1,0 +1,1388 @@
+# Homepage Today Answer Strategy Review
+
+> 文档状态：v1.0 批准版  
+> 生成日期：2026-05-19  
+> 批准日期：2026-05-19  
+> 目标站点：`https://pinpointanswertoday.app`  
+> 竞品站点：`https://pinpointanswer.today/`  
+> 关联方案：`docs/gsc-ranking-recovery-plan-2026-05-19.md`  
+> 审批结论：Approved with minor recommendations  
+> 审查问题：竞品把首页做成今日答案页，我们为什么不能直接照抄？如果要做，应怎么做、何时做、怎么验收？
+
+---
+
+## Approval Record
+
+审批状态：**Approved**
+
+审批结论：批准按照本文档推荐的「分阶段、保守推进、先修复再实验」策略执行。
+
+批准范围：
+
+1. 批准《Homepage Today Answer Strategy Review》作为 Phase 0-3 的执行依据。
+2. 批准“先修生产完整性，再做首页实验”的整体路线。
+3. 批准 Phase 0 独立发布，不与首页 title/H1/schema/结构改版混合。
+4. 批准 P0.5 移动端诊断作为 Phase 0 并行门槛。
+5. 批准后续用 7 天滚动窗口、`query + page + device`、`impressions >= 20` 作为判断口径。
+
+非批准范围：
+
+1. 不批准当前直接复制竞品首页。
+2. 不批准当前迁移 URL 结构。
+3. 不批准当前新增 QAPage/FAQPage 等高风险 schema 实验。
+4. 不批准当前把首页改成详情页克隆。
+5. 不批准在未明确下达实现指令前启动代码变更。
+
+执行前置条件：
+
+1. 先启动 PR 1：P0 生产完整性修复。
+2. Freeze 首页结构变更，除非 P0.5 移动轻量化补丁被指标触发。
+3. 发布前补齐移动端基线：Googlebot Smartphone HTML、URL Inspection Live Test、PSI 或 Lighthouse。
+4. 发布前记录 SERP 快照：US mobile/desktop，核心 today query。
+5. Phase 0 完成后再按数据门槛决定是否进入 Phase 1。
+
+---
+
+## Executive Summary
+
+一句话结论：**批准分阶段推进，但首要目标是修复数据一致性、移动端可见性和可观测性，不是盲目复制竞品 URL 或把首页做成详情页克隆。**
+
+关键路径：
+
+1. Phase 0 先修生产完整性：动态 sitemap lastmod、`#735/#736/#737` registry 恢复、registry/detail 反向一致性 guardrail、移动端 P0.5 诊断。
+2. Phase 1 再做首页 today intent 增强：只有 Phase 0 数据门槛通过，才调整首页首屏、title/description、强详情页链接和工具性模块。
+3. Phase 2 强化详情页长尾承接：以 clue/题号 query 增长为目标，不让首页抢走详情页的长尾空间。
+4. Phase 3 才测试更激进首页/schema：必须先证明不是移动端性能、SERP feature 或全行业算法波动导致。
+5. 28 天仍无恢复时进入 Plan B：内容信任、视频/讨论信号、SERP feature 适配和利基市场降权审计。
+
+Day 0-14 任务流：
+
+```mermaid
+flowchart TD
+  A["Day 0: Freeze homepage structure changes"] --> B["Phase 0: Fix production integrity"]
+  B --> C["Dynamic sitemap lastmod"]
+  B --> D["Restore #735-#737 registry"]
+  B --> E["Add registry/detail reverse guardrail"]
+  B --> F["P0.5 mobile diagnostics"]
+  F --> G{"Mobile PSI or render fails?"}
+  G -- "Yes" --> H["Ship lightweight mobile patch before SEO experiment"]
+  G -- "No" --> I["Observe Day 2-5"]
+  C --> I
+  D --> I
+  E --> I
+  I --> J{"Phase 1 gates pass?"}
+  J -- "No" --> K["Do not change homepage; continue diagnosis"]
+  J -- "Yes" --> L["Phase 1: Homepage Today entry enhancement"]
+  L --> M["Day 7-14: GSC + SERP + cannibalization readout"]
+  M --> N{"Improves without cannibalization?"}
+  N -- "Yes" --> O["Phase 2: Detail page long-tail strengthening"]
+  N -- "No" --> P["Rollback or narrow homepage changes"]
+  O --> Q{"28-day recovery threshold met?"}
+  Q -- "No" --> R["Plan B: defensive SEO and market-level audit"]
+  Q -- "Yes" --> S["Continue measured rollout"]
+```
+
+---
+
+## 1. 审批结论
+
+**推荐批准：采用“更强首页 Today Answer 入口 + 详情页完整承接”的混合方案。**
+
+**不推荐批准：把首页直接改成详情页克隆，或在当前 P0 技术修复窗口内一次性复制竞品首页。**
+
+这不是说“我们不可以做竞品那种首页”。更准确的判断是：
+
+1. 竞品首页打法是有效方向，值得借鉴。
+2. 我们当前已经有首页 today 入口、详情页、归档页和 `/pinpoint/today` 跳转入口，直接改成竞品 URL/内容结构会破坏已有 SEO 契约。
+3. 当前 GSC 下滑窗口里还有明确生产缺陷：sitemap 静态页 `lastmod` 过期、`#735/#736/#737` registry 缺失。它们必须先单独修复，但不能被表述为已证实的排名恢复根因。
+4. 首页可以更激进地承接 `pinpoint answer today`，但必须和详情页分工清楚：  
+   - 首页 `/`：今天是什么、线索是什么、去哪里看完整答案。  
+   - 详情页：完整答案、完整解释、题号长尾和 clue 长尾排名。
+
+本方案的核心审批口径改为：
+
+```text
+Phase 0 不是“已知根因修复”，而是“生产完整性 + 可观测性修复”。
+Phase 1 不是“等 5 天就上线”，而是“Phase 0 数据门槛通过后再上线”。
+Phase 2/3 不是“照抄竞品”，而是“基于 SERP、GSC 和 cannibalization 结果做实验”。
+```
+
+最终建议：
+
+```text
+Day 0-1: 修 P0 生产完整性问题，并补诊断基线，不改首页信息架构。
+Day 2-5: 观察抓取、404、sitemap、Googlebot Smartphone HTML、SERP 快照和 GSC 初步方向。
+Day 6+: 只有通过 Phase 1 数据门槛，才独立 PR 推首页 Today Answer 增强。
+Day 14+: 只有首页/详情页分工没有恶化，才考虑更激进首页主承接实验。
+```
+
+---
+
+## 2. 输入来源与可信边界
+
+### 2.1 已使用输入
+
+1. GSC 导出数据：`/Users/elng/Downloads/cursor-469606-0a5db422b4a4.json`
+2. 当前修复总方案：`docs/gsc-ranking-recovery-plan-2026-05-19.md`
+3. 竞品首页实时抓取：`https://pinpointanswer.today/`，抓取时间 `2026-05-19`
+4. 竞品 sitemap 实时抓取：`https://pinpointanswer.today/sitemap.xml`，抓取时间 `2026-05-19`
+5. 既有竞品分析文档：`docs/competitor-analysis-pinpointanswer-today-2026-04-26.md`
+6. 两个 agent 审查输出：
+   - SEO 策略 agent：评估竞品打法、可借鉴点、风险和发布节奏。
+   - 技术映射 agent：核对当前仓库 URL、canonical、sitemap、首页模块和详情页模块。
+
+### 2.2 可信边界
+
+- 竞品首页和 sitemap 已实时验证，能确认其当前策略。
+- SERP 排名快照不是 rank-tracking，不能当作固定排名证据。
+- 本文不是代码实现 PR，不改变站点行为。
+- 本文给出的是审批建议和实施边界；具体代码变更应另开 PR。
+- PageSpeed Insights API 在本次修订中对首页和最新详情页均 90 秒超时，因此 CWV 仍是待补外部诊断；本文只记录已完成的 Googlebot Smartphone HTML 抽查。
+
+---
+
+## 3. 根因假设与验证矩阵
+
+本方案不能把 sitemap `lastmod` 和 `#735/#736/#737` registry 缺失定性为已知排名根因。它们是已确认生产缺陷，但 5 月 12 日断崖仍需要按假设验证。
+
+### 3.1 当前最合理根因表
+
+| 假设 | 支持证据 | 反证/缺口 | 验证方式 | 时间节点 | 决策影响 |
+| --- | --- | --- | --- | --- | --- |
+| H1: Google 对 `today answer` query cluster 重新排序 | 首页核心 query 从 9-10 名掉到 44-62 名；移动 impressions 几乎消失 | 缺少 5 月 11 前 SERP 对照 | 固定 US mobile/desktop SERP 快照，记录 top 10 页面类型、AI Overview、PAA、视频/论坛结果 | Day 0、Day 3、Day 7 | 若竞品/媒体/AI Overview 集体上位，Phase 1 首页增强优先级升高 |
+| H2: 首页 freshness/trust 信号弱 | 首页 sitemap `lastmod` 停在 2026-04-01；竞品首页 `lastmod` 近当天 | lastmod 早就过期，不能解释 5 月 12 单点触发 | Phase 0 后检查 sitemap、URL Inspection last crawl、Google selected canonical、首页 snippet 是否更新 | Day 1-5 | 若抓取/snippet 不更新，先修 freshness，不做首页大改 |
+| H3: registry 断层削弱近期连续性 | `#735/#736/#737` JSON 存在但 registry 缺失，造成 404、sitemap 漏页、归档断层 | 缺失发生在 5 月 7 日，5 月 8-9 仍有恢复迹象 | 恢复三题后检查 200、sitemap、归档、legacy alias、GSC page rows | Day 0-5 | 若 404 清零但排名不恢复，说明它不是主要触发器 |
+| H4: 竞品/同类站近期上位 | 当前可见 SERP 中有多个专门站、媒体站和 Reddit 结果；`pinpointanswer.today` 可见，但本次搜索快照不能证明它稳定 top 3 | 缺少竞品历史排名曲线 | 每天保存核心 query SERP top 10，标记竞品页面类型和 title/H1/content pattern | Day 0、Day 3、Day 7、Day 14 | 若竞品结构稳定占优，Phase 1/2 加速 |
+| H5: AI Overview 或 SERP feature 吃掉 impressions | puzzle answer 类 query 容易被直接答案/摘要吸收 | 本次没有完成稳定移动 SERP feature 记录 | 手动或 rank tracker 记录 AI Overview、featured snippet、PAA、视频模块 | Day 0-7 | 若 SERP feature 主导，单纯技术修复恢复有限 |
+| H6: 移动端渲染/CWV 问题 | 首页移动 impressions 从 1,442 降到 16 | Googlebot Smartphone HTML 当前能看到题号、clues、详情链接；PageSpeed API 超时未完成 | URL Inspection live test、PageSpeed/CrUX、移动截图、HTML 抽查 | Day 0-3 | 若 render/CWV fail，移动修复升为 P0.5，暂停 Phase 1 |
+| H7: 首页/详情页 cannibalization | 首页 before 周期已出现 `linkedin pinpoint 735 answer`、`pinpoint #735`、`pinpoint 735` 等题号 query | 样本小，且详情页仍有 clue query 展示 | GSC query+page 交叉表：today query 应归首页，题号/clue query 应归详情页 | Day 0、Day 7、Phase 1 后 Day 7 | 若 cannibalization 已存在，Phase 1 必须收窄首页内容 |
+| H8: 整类 puzzle answer 站点被算法降权 | 核心 query position 大幅恶化，不只是 CTR 问题 | 需要竞品同周期数据，无法从本站 GSC 直接验证 | SERP 是否由媒体/官方/UGC 替代小站；观察其他专门站是否同步波动 | Day 0-14 | 若成立，首页小改收益有限，需要内容质量/品牌 trust 升级 |
+| H9: 页面有用性不足，被识别为纯 SEO/doorway 风格页面 | 首页有 today intent，但工具性偏弱；竞品首页提供 Play on LinkedIn、reveal、recent answers 等明确任务入口 | 没有直接证据证明 Google 因有用性降权 | 对比竞品移动首屏任务完成路径；检查首页是否提供“看线索、玩游戏、看完整解释、保存/返回”的完整用户任务链 | Phase 1 设计前 | Phase 1 必须加入轻量工具性模块，而不是只堆关键词 |
+
+### 3.2 Phase 0 的真实目标
+
+Phase 0 的目标不是证明“修完就恢复排名”，而是：
+
+1. 消除已确认的生产错误。
+2. 恢复 sitemap、registry、归档、详情页之间的一致性。
+3. 让后续首页实验具备可归因基线。
+4. 如果 Phase 0 后不恢复，可以明确排除“明显生产断层”这一层干扰。
+
+Phase 0 后如果没有恢复，不代表 Phase 0 失败；它只说明排名触发器更可能在 H1/H4/H5/H6/H8。
+
+---
+
+## 4. 竞品现在到底怎么做
+
+截至 `2026-05-19` 抓取，竞品 `pinpointanswer.today` 的首页是明确的 **Today Answer 主承接页**。
+
+### 4.1 首页 metadata
+
+竞品首页：
+
+```text
+Title: LinkedIn Pinpoint Answer Today - Daily Answers & Solutions
+Canonical: https://pinpointanswer.today/
+Robots: index, follow
+```
+
+其 description 明确承诺“今日答案、每日更新、线索解释和 tips”。这说明它不是把首页当品牌页或归档页，而是直接用首页抢 `LinkedIn Pinpoint Answer Today` 和 `pinpoint answer today`。
+
+### 4.2 首页 H1 与首屏
+
+竞品首页 H1：
+
+```text
+Today's LinkedIn Pinpoint #748 Answer
+```
+
+首屏可见内容包括：
+
+- 当天题号：`#748`
+- 当天线索：`Butter chicken`、`Vindaloo`、`Palak paneer`、`Naan`、`Biryani`
+- 今日答案 reveal 按钮
+- 跳转 LinkedIn 游戏的按钮
+- 一段解题摘要
+- 详情页入口
+
+这套结构的意图很明确：搜索者落到首页后，不需要再判断“这里有没有今天的答案”。首页第一屏直接回答“有，而且是今天这一题”。
+
+### 4.3 首页结构化数据
+
+竞品首页输出了站点级和页面级 JSON-LD：
+
+- `Organization`
+- `WebSite`
+- `WebPage`
+- `FAQPage`
+- `ItemList`
+- 首页 `WebPage.mainEntity` 绑定当天问题
+- `acceptedAnswer.url` 指向当天详情页
+
+这代表它把首页和当天题的语义关系做得很强：
+
+```text
+首页 = 今天 LinkedIn Pinpoint #748 的答案入口
+详情页 = #748 的完整答案页
+```
+
+### 4.4 竞品 sitemap
+
+竞品 sitemap 当前策略：
+
+| URL 类型 | lastmod | changefreq | priority |
+| --- | --- | --- | --- |
+| `/` | `2026-05-18T07:41:13.249Z` | daily | 1 |
+| `/next-pinpoint-preview/` | `2026-05-18T07:41:13.249Z` | daily | 0.8 |
+| `/linkedin-pinpoint-answer/` | `2026-05-18T07:41:13.249Z` | daily | 0.8 |
+| `/linkedin-pinpoint-answer/pinpoint-748/` | `2026-05-18T07:04:43.000Z` | weekly | 0.7 |
+| 历史详情页 | 各自发布时间 | weekly | 0.7 |
+
+这和我们当前最大技术缺陷形成对照：竞品首页和归档页的 `lastmod` 跟随每日更新，而我们当前 `data/static-page-metadata.json` 中首页仍是 `2026-04-01T02:12:46.000Z`，`/puzzles` 是 `2026-03-31T12:59:06.000Z`。
+
+### 4.5 竞品详情页和归档页
+
+竞品详情 URL 形态：
+
+```text
+/linkedin-pinpoint-answer/pinpoint-748/
+```
+
+首页 recent list 链接最近 20 个详情页，锚文本包含题号：
+
+```text
+LinkedIn Pinpoint 748 Answer & Hints
+LinkedIn Pinpoint 747 Answer & Hints
+...
+```
+
+归档页：
+
+```text
+/linkedin-pinpoint-answer/
+```
+
+这说明竞品不是只有首页一个页面在打关键词。它是三层结构：
+
+```text
+/                                抢 today 大词
+/linkedin-pinpoint-answer/        承接归档和历史索引
+/linkedin-pinpoint-answer/{id}/   承接题号、clue、answer 长尾
+```
+
+---
+
+## 5. 竞品为什么可能有效
+
+竞品有效的核心不是“它首页像详情页”，而是它把 `today answer` 搜索意图压得非常明确。
+
+### 5.1 搜索意图对齐强
+
+搜索 `pinpoint answer today` 的用户要的不是品牌介绍，也不是完整归档。他要的是：
+
+1. 今天是哪一题？
+2. 今天的 5 个 clue 是什么？
+3. 答案能不能马上看到？
+4. 如果我想理解答案，有没有完整解释？
+
+竞品首页把这四个问题都放在首屏或首屏后第一模块，因此对 query intent 的匹配很直接。
+
+### 5.2 Freshness 信号一致
+
+竞品的 freshness 信号是多层一致的：
+
+- title 是 today intent。
+- H1 带当天题号。
+- 可见正文带当天 clues。
+- 页面 `dateModified` 接近当天。
+- sitemap 首页 `lastmod` 接近当天。
+- 首页链接当天详情页。
+- ItemList 链接最近 20 个详情页。
+
+Google 不需要猜这个首页今天有没有更新。
+
+### 5.3 首页权重集中
+
+首页通常是站内最强 URL。竞品直接让首页承接最大词：
+
+```text
+pinpoint answer today
+linkedin pinpoint answer today
+pinpoint today
+```
+
+详情页再承接：
+
+```text
+pinpoint 748 answer
+linkedin pinpoint 748 answer
+Butter chicken Vindaloo Palak paneer Naan Biryani
+```
+
+这套分工本身是合理的。
+
+### 5.4 内链结构清楚
+
+竞品首页不是孤立答案页。它把 today query 和历史详情页串起来：
+
+- 首页首屏给当天详情页强链接。
+- 首页 recent list 链最近 20 个详情页。
+- sitemap 保持详情页连续。
+- 归档页作为列表中心。
+
+这有助于 Google 理解：今天页面、历史页面和归档页面属于同一个稳定集合。
+
+---
+
+## 6. 我们为什么不能直接照抄
+
+答案不是“不能做”，而是“现在不能直接克隆，不能和 P0 修复同批发布，不能破坏现有 URL/canonical 契约”。
+
+### 6.1 当前处在排名下滑窗口，不能混合变量
+
+GSC 已确认：
+
+| 指标 | 2026-05-05 到 2026-05-11 | 2026-05-12 到 2026-05-18 |
+| --- | ---: | ---: |
+| 全站 impressions | 1,978 | 268 |
+| 全站 avg position | 10.94 | 28.28 |
+| 首页 impressions | 1,646 | 147 |
+| 首页 avg position | 11.66 | 45.02 |
+
+核心 query：
+
+| Query | Before impressions / pos | After impressions / pos |
+| --- | --- | --- |
+| `pinpoint answer today` | 1,046 / 9.51 | 15 / 48.40 |
+| `linkedin pinpoint answer today` | 145 / 10.08 | 10 / 61.70 |
+| `pinpoint today` | 115 / 10.44 | 11 / 44.55 |
+
+如果现在同一批发布：
+
+- sitemap `lastmod` 修复
+- `#735/#736/#737` registry 恢复
+- 首页 title/H1 调整
+- 首页首屏重排
+- schema 增强
+- 内链重排
+- 详情页内容增强
+
+那么 7-14 天后无论恢复还是继续掉，都无法判断是哪一个变量起作用。
+
+SEO 修复最怕“同时动太多”。当前必须先恢复可观测性。
+
+### 6.2 当前已有明确 P0 技术缺陷，必须先单独处理
+
+当前生产缺陷：
+
+1. `data/static-page-metadata.json` 中首页 lastmod 停在 `2026-04-01T02:12:46.000Z`。
+2. `data/static-page-metadata.json` 中 `/puzzles` lastmod 停在 `2026-03-31T12:59:06.000Z`。
+3. `#735/#736/#737` JSON 文件存在，但 registry 缺失，造成生产 404、归档断层和 sitemap 漏页。
+
+这三个问题不一定是 5 月 12 日断崖的单点触发器，但它们是明确负面信号。先修它们，是因为它们确定错误、可验证、可回归。
+
+### 6.3 详情页排名基线不足以无条件支撑分工假设
+
+“首页抢 today 大词、详情页抢题号和 clue 长尾”是推荐架构，不是已经完全被数据证明的事实。
+
+最新 20 个详情页 GSC 基线：
+
+| 周期 | Clicks | Impressions | 说明 |
+| --- | ---: | ---: | --- |
+| 2026-05-05 到 2026-05-11 | 1 | 266 | 主要集中在 `#741`，255 impressions / pos 6.61 |
+| 2026-05-12 到 2026-05-18 | 0 | 102 | 主要来自 `#742`、`#748`、`#743` 的 clue query |
+
+After 周期详情页样本：
+
+| Detail URL | Impressions | Avg position | Top query pattern |
+| --- | ---: | ---: | --- |
+| `/linkedin-pinpoint-answers/pinpoint-answer-742/` | 49 | 7.82 | `pinpoint scale beaker`、`scale beaker pinpoint` |
+| `/linkedin-pinpoint-answers/pinpoint-answer-748/` | 20 | 7.80 | `butter chicken vindaloo pinpoint`、完整 clue 组合 |
+| `/linkedin-pinpoint-answers/pinpoint-answer-743/` | 17 | 5.00 | `magic flute carmen pinpoint` |
+
+对 `#748` 的细分：
+
+| Query | Impressions | Avg position |
+| --- | ---: | ---: |
+| `butter chicken vindaloo pinpoint` | 7 | 9.00 |
+| `butter chicken vindaloo palak paneer naan biryani` | 6 | 7.83 |
+| `vindaloo butter chicken pinpoint` | 3 | 8.00 |
+| `butter chicken pinpoint` | 1 | 3.00 |
+
+结论：
+
+- 详情页确实能拿到 clue 组合 query 的少量展示，位置并不差。
+- 但详情页 impressions 规模很小，不能假设它已经稳固承接所有题号长尾。
+- Phase 1 首页增强时，必须监控是否让详情页这部分 clue query 消失。
+- Phase 2 详情页增强不能只是“补模块”，还要以扩大 clue/题号 query 覆盖为目标。
+
+### 6.4 我们的 URL 体系和竞品不同
+
+当前仓库路由：
+
+| 类型 | 当前 URL |
+| --- | --- |
+| 首页 | `/` |
+| 归档 | `/puzzles` |
+| 详情页 | `/linkedin-pinpoint-answers/{slug}/` |
+| 当前详情示例 | `/linkedin-pinpoint-answers/pinpoint-answer-748/` |
+| today 跳转入口 | `/pinpoint/today` |
+
+竞品路由：
+
+| 类型 | 竞品 URL |
+| --- | --- |
+| 首页 | `/` |
+| 归档 | `/linkedin-pinpoint-answer/` |
+| 详情页 | `/linkedin-pinpoint-answer/pinpoint-748/` |
+
+不建议为模仿竞品迁移 URL。原因：
+
+- 当前详情页已 self-canonical 到 `/linkedin-pinpoint-answers/{slug}/`。
+- `/puzzles` 已是归档 canonical。
+- `/pinpoint/today` 已作为动态跳转入口，正式状态下 307 到当前详情页。
+- 大规模 URL 迁移会带来 redirect、canonical、sitemap、历史索引和 GSC 数据口径重置风险。
+
+我们可以学习竞品的信息架构，不需要复制它的 URL。
+
+### 6.5 首页和详情页直接重复会制造 cannibalization
+
+如果首页也放完整答案分析、完整 hint ladder、完整 clue-by-clue explanation、完整 FAQ，首页和详情页会争同一组 query：
+
+```text
+linkedin pinpoint 748 answer
+pinpoint 748 answer
+Butter chicken Vindaloo Palak paneer Naan Biryani
+```
+
+这会导致 Google 不确定该排名的是首页还是详情页。对一个已经处于下滑窗口的站点，这会增加不稳定性。
+
+更稳的分工是：
+
+| Query 类型 | 推荐承接页 |
+| --- | --- |
+| `pinpoint answer today` | 首页 |
+| `linkedin pinpoint answer today` | 首页 |
+| `pinpoint today` | 首页 |
+| `pinpoint 748 answer` | 详情页 |
+| `linkedin pinpoint 748 answer` | 详情页 |
+| clue 组合词 | 详情页 |
+| `all linkedin pinpoint answers` | 归档页 |
+| `next pinpoint answer` | 预告页 |
+
+当前首页已经存在轻微 cannibalization 信号。Before 周期首页 top query 中出现：
+
+| 首页 query | Impressions | Avg position |
+| --- | ---: | ---: |
+| `linkedin pinpoint 735 answer` | 1 | 12.00 |
+| `pinpoint #735` | 4 | 7.25 |
+| `pinpoint 735` | 4 | 8.00 |
+| `crown case dial pinpoint` | 2 | 18.00 |
+
+这些样本很小，不足以判定严重内耗，但说明首页已经会承接一部分题号/clue 查询。Phase 1 首页增强必须避免进一步扩大这种重叠。
+
+### 6.6 竞品 schema 不能无验证照搬
+
+竞品首页把当天问题放进 `WebPage.mainEntity`，并通过 `acceptedAnswer` 指向详情页。这对它可能有效，但对我们不能直接复制，原因是：
+
+- 首页可见内容、隐藏内容和 structured data 必须严格一致。
+- 如果 answer 在 schema 中暴露，但页面上默认 spoiler-safe 隐藏，存在一致性边界问题。
+- `FAQPage` rich result 对普通站点价值有限，Google 当前对 FAQ 富结果展示非常克制。
+- 大规模 schema 调整会成为另一个不可归因变量。
+
+建议：
+
+```text
+Phase 1: 不新增 QAPage，不新增 FAQPage，不把答案塞进首页 schema。
+Phase 2: 只在可见内容和 schema 一致性验证通过后，测试 WebPage.mainEntity 指向当天详情页。
+```
+
+### 6.7 竞品当前排名未被完整验证
+
+本文已验证竞品结构，但没有竞品 GSC，因此不能验证它在 5 月 12 日前后的排名曲线。搜索快照只能说明它是当前可见强相关竞争者，不能证明“它是 5 月 12 日后才超过我们”。
+
+本次 `2026-05-19` 搜索快照观察到的强相关结果包括：
+
+| Query snapshot | 可见结果类型 | 备注 |
+| --- | --- | --- |
+| `pinpoint answer today` | `linkedin-pinpoint-answers.today`、`linkedinanswer.today`、`linkedinpinpointanswer.today`、The Word Finder、`pinpointanswertoday.online`、Try Hard Guides、Reddit | 多个专门站和媒体页都在抢 today intent |
+| `linkedin pinpoint answer today` | The Word Finder、Try Hard Guides、同类专门站、Reddit | 说明竞争不只是一个站点 |
+| `site:pinpointanswer.today pinpoint answer today` | `pinpointanswer.today` 首页和详情页可被检索 | 说明竞品可见，但不能据此判断排名稳定性 |
+
+这个快照支持“SERP 竞争格局已拥挤”的判断，不足以支持“`pinpointanswer.today` 一定是当前 top 3 且已稳定压过我们”的判断。
+
+后续必须补：
+
+1. 固定地区和设备的 SERP top 10：
+   - US mobile
+   - US desktop
+   - query: `pinpoint answer today`
+   - query: `linkedin pinpoint answer today`
+   - query: `pinpoint today answer`
+2. 记录每个结果：
+   - URL
+   - title
+   - 页面类型：首页/详情页/归档页/媒体页/UGC
+   - 是否出现 AI Overview、PAA、视频、论坛模块
+3. 连续观察：
+   - Day 0
+   - Day 3
+   - Day 7
+   - Day 14
+
+如果竞品也在波动，说明当前问题更像 SERP/算法重排；如果竞品稳定 top 3，则首页 today intent 对齐更可能是差距来源。
+
+### 6.8 竞品自身也不是完美范式
+
+竞品首页存在一些不能直接照抄的点：
+
+- 广告和交互模块较重，可能影响移动体验。
+- 首页也有 FAQ、recent list、benefits 等大量模板内容，存在模板化风险。
+- 部分内容表达偏激进，可能牺牲品牌可信度。
+- 答案 reveal 默认隐藏，对“答案词是否可被 HTML/渲染内容稳定识别”仍有风险。
+
+竞品能排名，不代表每个实现细节都该复制。
+
+---
+
+## 7. 我们当前其实已经做了哪些
+
+技术 agent 对当前仓库检查后确认：我们不是完全没有 today 首页承接。
+
+### 7.1 当前首页已具备 today 入口
+
+当前首页模块位于：
+
+- `app/(site)/(home)/page.tsx`
+- `components/home/HomeHero.tsx`
+- `components/home/HomeRevealSection.tsx`
+- `components/home/HomeRecentAnswers.tsx`
+- `components/home/HomeCtaFooter.tsx`
+
+当前首页已经有：
+
+- H1：`Today's LinkedIn Pinpoint #${puzzle.number} Answer`
+- Hero CTA：链接当前详情页
+- Reveal 区：显示 today clues、hints、answer reveal
+- Today 卡片：链接当前详情页
+- Recent answers
+- Archive 入口
+- Pro Tips / next puzzle 入口
+
+所以问题不是“首页完全没打 today”。问题是：
+
+1. 首页 metadata title 仍较通用：`LinkedIn Pinpoint Answer Today | Hints & Solution`。
+2. sitemap 静态 lastmod 没跟每日 puzzle 更新。
+3. 首页首屏还承载了品牌、bookmark、badge 等非 today 权重元素。
+4. 可见 trust/freshness 信号不如竞品强。
+5. schema 没把首页与当天 puzzle 建立足够清晰的关系。
+
+### 7.2 当前详情页已具备完整承接框架
+
+详情页位于：
+
+- `app/(detail)/linkedin-pinpoint-answers/[slug]/page.tsx`
+- `components/detail/PuzzleDetail.tsx`
+- `components/detail/PuzzleFullAnalysis.tsx`
+
+当前详情页已有：
+
+- 自指 canonical
+- article metadata
+- H1
+- 发布/更新日期
+- answer reveal
+- full analysis
+- adjacent prev/next
+- recent answer links
+- latest answer CTA
+
+因此不应把首页改成详情页克隆。更好的方向是增强详情页内容质量，同时让首页给详情页更强的内部链接和今日入口信号。
+
+---
+
+## 8. 推荐架构
+
+### 8.1 首页 `/`
+
+定位：**今日答案入口 + 站点权重 Hub**。
+
+首页应该负责：
+
+- 直接承接 `pinpoint answer today`
+- 显示当天题号
+- 显示当天日期
+- 显示 5 个 clues
+- 显示 spoiler-safe hint / reveal answer 卡
+- 提供当前详情页强链接
+- 提供最近 7-20 个答案入口
+- 提供归档页入口
+- 提供简短 trust / verification 说明
+- 提供简短 FAQ，但避免和详情页重复
+
+首页不应该负责：
+
+- 完整答案长文
+- 完整 clue-by-clue explanation
+- 完整 hint ladder
+- 与详情页完全相同的 FAQ
+- 与详情页完全相同的 title/H1
+- 题号长尾的主要排名
+
+首页必须补一个“工具性”模块，避免页面只像 SEO 文案堆叠。这个模块不追求复杂，目标是让用户在首页完成真实任务。
+
+推荐工具性模块：
+
+| 模块 | 内容 | SEO/UX 目的 |
+| --- | --- | --- |
+| Today Quick Actions | `View full answer`、`Play on LinkedIn`、`Browse archive` 三个明确入口 | 让用户快速完成“查答案/去玩/看历史”任务 |
+| Difficulty signal | 今日题难度、可能误导方向、推荐先看第几条 clue | 提升页面独特价值，不只是复述答案 |
+| Spoiler-safe progress | `Show hint 1`、`Show stronger hint`、`Reveal answer` 渐进式层级 | 满足不想被直接剧透的用户 |
+| Verification note | `Last checked`、数据来源和更正入口 | 强化可信度和 freshness |
+
+Phase 1 的首页增强必须至少包含 `Today Quick Actions` 和 `Verification note`。如果只改 title/H1/关键词，不批准上线。
+
+推荐 title：
+
+```text
+LinkedIn Pinpoint Answer Today - Daily Hints & Archive
+```
+
+更激进的测试 title：
+
+```text
+LinkedIn Pinpoint #748 Answer Today - Daily Hints
+```
+
+推荐 H1：
+
+```text
+Today's LinkedIn Pinpoint #748 Answer
+```
+
+推荐首屏 CTA：
+
+```text
+View Full Answer & Hints
+```
+
+推荐强链接 anchor：
+
+```text
+Today's LinkedIn Pinpoint #748 Answer and Hints
+```
+
+### 8.2 详情页 `/linkedin-pinpoint-answers/pinpoint-answer-748/`
+
+定位：**具体题号 SEO 主战场**。
+
+详情页必须负责：
+
+- 题号
+- 日期
+- 5 个 clues
+- 最终答案
+- hint ladder
+- clue-by-clue explanation
+- 解题思路
+- FAQ
+- 上一题/下一题
+- 返回归档页
+- 返回今日答案入口
+
+详情页内容质量标准：
+
+| 模块 | 最低标准 |
+| --- | --- |
+| Overview | 80-120 words，先说明这题为什么容易误判，再给解决方向 |
+| Clue-by-clue explanation | 5 条 clue 全覆盖，每条解释必须说明“为什么它指向答案”，不能只复述 clue |
+| Hint ladder | 至少 3 层，按 spoiler 程度递进，第一层不泄露答案 |
+| Wrong paths / disambiguation | 至少 2 个可能误读方向，说明为什么排除 |
+| FAQ | 2-4 条，优先围绕本题主题或用户搜索意图，不复用首页泛 FAQ |
+| Internal links | previous、next、archive、today answer 四类链接齐全 |
+| SEO title/description | 题号 + 主要 clues 可见，避免与首页 title 完全重合 |
+
+推荐 title：
+
+```text
+LinkedIn Pinpoint #748 Answer Today - May 18, 2026
+```
+
+或 clue 长尾 title：
+
+```text
+LinkedIn Pinpoint 748 Answer: Butter Chicken, Vindaloo, Palak Paneer, Naan, Biryani
+```
+
+推荐 H1：
+
+```text
+LinkedIn Pinpoint #748 Answer and Hints
+```
+
+### 8.3 归档页 `/puzzles`
+
+定位：**索引页 + 内链中心**。
+
+归档页应该负责：
+
+- 所有题号列表
+- 按月份分组
+- 最新题目置顶
+- 每题显示题号、日期、clue 摘要
+- 链接到详情页
+
+推荐 title：
+
+```text
+All LinkedIn Pinpoint Answers - Daily Archive
+```
+
+注意：竞品归档是 `/linkedin-pinpoint-answer/`，我们不建议迁移。当前 `/puzzles` 继续作为 canonical。
+
+### 8.4 预告页 `/next-pinpoint-preview`
+
+定位：**next / tomorrow / preview 查询**。
+
+可以继续保留：
+
+- 下一题倒计时
+- 常见解题模式
+- 最近答案入口
+- 订阅/提醒入口
+
+---
+
+## 9. 分阶段执行方案
+
+### Phase 0：P0 生产完整性修复，单独发布
+
+推荐：**批准，立即做。**
+
+范围：
+
+1. 修复首页和归档页 sitemap `lastmod`：
+   - 首页 lastmod 应跟随当前 live puzzle 更新时间或每日生成时间。
+   - `/puzzles` lastmod 应跟随最新 archive entry 更新时间。
+   - 修复方式必须是持续机制，不接受只手动改 `data/static-page-metadata.json` 一次。
+2. 恢复 `#735/#736/#737` registry entries：
+   - 确保详情页 200。
+   - 确保进入 sitemap。
+   - 确保归档页可见。
+   - 确保 date/number alias 不再 404。
+3. 补 registry/detail 反向一致性 guardrail：
+   - 当前 `validate:data` 只检查 registry 条目都有详情 JSON。
+   - 它没有检查“所有公开 detail JSON 都必须在 registry 中存在”。
+   - Phase 0 必须补这个反向检查，否则 749/750 仍可能复发。
+4. 发布后用 URL Inspection 抽查：
+   - `/`
+   - `/puzzles`
+   - `/linkedin-pinpoint-answers/pinpoint-answer-735/`
+   - `/linkedin-pinpoint-answers/pinpoint-answer-736/`
+   - `/linkedin-pinpoint-answers/pinpoint-answer-737/`
+   - 最新详情页
+
+#### Phase 0-A：sitemap lastmod 机制
+
+当前 `app/sitemap.ts` 对静态入口调用 `getStaticRouteLastModified()`，而 `data/static-page-metadata.json` 只基于静态源文件 git commit 时间生成。因此首页和归档页即使每天内容变了，lastmod 也不会跟随当前 puzzle 更新。
+
+推荐实现机制：
+
+| URL | lastmod 来源 | 理由 |
+| --- | --- | --- |
+| `/` | `currentPuzzle.updatedAt`，fallback 到 `currentPuzzle.publishDate` | 首页内容每天由 live puzzle 驱动 |
+| `/puzzles` | 最新 archive/live entry 的 `updatedAt`，fallback 到最新 `publishDate` | 归档页内容每天新增/变更 |
+| `/next-pinpoint-preview` | preview 更新时间或当前 live puzzle 更新时间 | 倒计时/预告会随每日题变化 |
+| 非动态静态页 | 继续使用 `data/static-page-metadata.json` | About/legal 不需要每日更新 |
+
+不推荐：
+
+```text
+手动把 data/static-page-metadata.json 里的 / 和 /puzzles 改成今天。
+```
+
+原因：明天新题发布后会再次过期，P0 没有真正修复。
+
+#### Phase 0-B：#735/#736/#737 缺失原因
+
+已确认：
+
+- `f5a67b8 fix: deprecate fullAnalysis field, migrate all data to articleBlocks` 修改了大量详情 JSON。
+- 同一 commit 中 `data/puzzles/registry.json` 从 `#737/#736/#735/#734` 变成只剩 `#734`，该文件 diff 显示 61 行变更，删除了三条 registry entry。
+- `#735/#736/#737` 的详情 JSON 仍存在，且 `detailState=published`、`bodyMode=standard`。
+- 后续 `46429a0 Refresh Pinpoint content and legacy routing` 之后 registry 包含 `#742/#741/#740/#739/#738/#734`，仍缺 `#735/#736/#737`。
+
+当前最可能原因：一次内容迁移/合并时 registry 被旧快照覆盖或手动裁剪，而不是每日发布 pipeline 对所有新题持续失效。理由是 `#738` 之后的 `#739-#748` 都能继续进入 registry。
+
+但这仍暴露 pipeline/CI 缺口：
+
+```text
+允许 data/puzzles/pinpoint-answer-735.json 存在且公开，但 registry.json 缺条。
+```
+
+Phase 0 必须补：
+
+1. 恢复三条 registry entry。
+2. 增加反向一致性校验。
+3. 校验最近 30 天 puzzle number 是否连续，除非明确有 allowlist。
+
+不做：
+
+- 不改首页 H1/title。
+- 不改首页布局。
+- 不改 schema。
+- 不改详情 URL。
+
+验收：
+
+| 项目 | 标准 |
+| --- | --- |
+| sitemap 首页 lastmod | 不早于最新 live puzzle 更新时间 |
+| sitemap 归档 lastmod | 不早于最新 archive 更新时间 |
+| #735/#736/#737 | 详情页全部 200 |
+| registry | 三题全部出现 |
+| sitemap | 三题全部出现 |
+| 归档页 | 三题全部可见 |
+| canonical | 自指或既定 canonical 正常 |
+| validate:data | 能拦截“公开 JSON 存在但 registry 缺条” |
+| 最近 30 天编号 | 连续或有显式 allowlist |
+
+Phase 0 发布后的判断：
+
+| 观察结果 | 解释 | 下一步 |
+| --- | --- | --- |
+| 404/sitemap 修复，首页 query 仍不恢复 | P0 不是主要排名触发器 | 按 H1/H4/H5/H6 继续诊断，准备 Phase 1 |
+| 404/sitemap 修复，首页 query 有明显恢复 | 生产完整性/freshness 是重要放大因素 | 继续观察，不急于 Phase 1 大改 |
+| 404 未清零或 sitemap 仍缺页 | Phase 0 未完成 | 不进入 Phase 1 |
+| Googlebot Smartphone 看不到核心内容 | 移动渲染升为 P0.5 | 暂停首页策略实验 |
+| PSI mobile performance < 50 或 LCP > 2.5s | 移动性能升为 P0.5 | 先发轻量化补丁，再讨论首页 SEO 改版 |
+| 竞品移动首屏明显更轻，且我们 JS/交互阻塞首屏 | 移动 UX/性能可能是放大因素 | Phase 0 加入首页首屏轻量化补丁 |
+
+#### Phase 0-C：移动端 P0.5 硬指标与轻量化分支
+
+移动端 impressions 从 1,442 降到 16，不能只作为“Phase 1 前检查项”。它必须成为 Phase 0 的并行诊断。
+
+Phase 0 必须完成以下对比：
+
+| 检查项 | 我们 | 竞品 | 判定 |
+| --- | --- | --- | --- |
+| Mobile HTML 首屏是否含题号/clues/详情链接 | 已完成初查：有 | 待补截图/HTML 摘要 | 若我们缺核心内容，直接 P0.5 |
+| 首屏 JS 依赖 | 检查 `HomeRevealSection`、answer reveal、analytics、badge wall 是否阻塞首屏 | 抓竞品首页 HTML/JS bundle 数量和首屏 DOM | 若我们首屏依赖显著更重，先轻量化 |
+| PSI mobile performance | 本次 API 90 秒超时，待补 | 待补 | < 50 触发强制轻量化 |
+| LCP | 待补 PSI/CrUX | 待补 | > 2.5s 触发强制轻量化 |
+| CLS | 待补 PSI/CrUX | 待补 | > 0.1 触发布局稳定性修复 |
+| INP/TBT | 待补 PSI/CrUX 或 Lighthouse | 待补 | INP > 200ms 或 TBT > 300ms 触发交互瘦身 |
+
+强制轻量化补丁范围：
+
+1. 首页首屏只保留 SSR 可见的题号、日期、5 clues、详情页链接和 Play on LinkedIn 链接。
+2. `HomeRevealSection` 的交互逻辑延后到首屏之后或保持 progressive enhancement。
+3. 首屏不加载非必要的 badge wall、重型 analytics、广告、动画和非关键组件。
+4. 详情页强链接必须是普通 `<a>`/`Link`，不能依赖点击 reveal 后才生成。
+5. 保留现有 title/H1/schema，不把轻量化补丁和 SEO 文案改版混在一起。
+
+轻量化验收：
+
+| 指标 | 目标 |
+| --- | --- |
+| PSI mobile performance | >= 50 才允许进入 Phase 1；>= 70 为推荐进入 |
+| LCP | <= 2.5s |
+| CLS | <= 0.1 |
+| INP 或 TBT 替代指标 | INP <= 200ms；没有 INP 时 TBT <= 300ms |
+| Googlebot Smartphone HTML | 题号、日期/更新信息、5 clues、详情链接可见 |
+
+### Phase 1：轻量首页 Today Answer 增强
+
+推荐：**有条件批准。必须同时满足时间门槛和数据门槛，不能只等 5 天。**
+
+Phase 1 触发条件：
+
+| 条件 | 必须达到的标准 |
+| --- | --- |
+| 时间 | Phase 0 发布后至少 5 个完整自然日 |
+| 生产完整性 | `#735/#736/#737` 详情页 200，sitemap/归档/legacy alias 均可见 |
+| sitemap | `/` 和 `/puzzles` lastmod 不早于最新 live puzzle 更新时间 |
+| Googlebot Smartphone HTML | 首页能看到题号、日期或更新信息、5 clues、详情页链接 |
+| GSC 方向 | 首页核心 query 没有继续恶化超过 20 名；或 impressions 未继续下跌超过 50% |
+| 详情页保护 | 最新 10 个详情页合计 impressions 未在 Phase 0 后继续下跌超过 50% |
+| SERP | 已记录至少 2 次固定 query SERP 快照 |
+| 移动性能 | PSI mobile >= 50 且 LCP <= 2.5s；若 PSI 继续超时，必须有 Lighthouse mobile 替代结果 |
+| 统计样本 | 核心判断只使用 impressions >= 20 的 query/page 组合；低于该值只做观察 |
+
+目标：让首页更像竞品一样明确承接 today intent，但不复制详情页完整内容。
+
+建议变更：
+
+1. 首页 title 从通用表达改为更明确 today 表达：
+
+   ```text
+   LinkedIn Pinpoint Answer Today - Daily Hints & Archive
+   ```
+
+2. 首页 description 保持动态题号：
+
+   ```text
+   Today's LinkedIn Pinpoint answer is Puzzle #748. View the clues, spoiler-safe hints, and full answer breakdown.
+   ```
+
+3. 首页首屏保留动态 H1：
+
+   ```text
+   Today's LinkedIn Pinpoint #748 Answer
+   ```
+
+4. 首屏直接显示：
+   - 日期
+   - 题号
+   - 5 个 clues
+   - hint/reveal card
+   - full answer CTA
+   - last verified / updated
+
+5. 将非 today 目标模块下沉：
+   - badge wall 下沉或移出首页
+   - general benefits 下沉
+   - archive/pro tips 不抢首屏
+
+6. 首页到详情页的 anchor 改为强语义：
+
+   ```text
+   Today's LinkedIn Pinpoint #748 Answer and Hints
+   ```
+
+7. 新增轻量工具性模块：
+   - `Play on LinkedIn`
+   - `View full answer`
+   - `Browse archive`
+   - `Last checked`
+   - 今日难度或 spoiler-safe hint progression
+
+不做：
+
+- 不迁移 URL。
+- 不让首页 canonical 到详情页。
+- 不让详情页 canonical 到首页。
+- 不把完整分析复制到首页。
+- 不新增 QAPage。
+- 不新增 FAQPage，除非可见内容和 structured data 已逐项匹配。
+
+验收：
+
+| 项目 | 标准 |
+| --- | --- |
+| Mobile HTML | 题号、日期、5 clues、详情页强链接可见 |
+| Googlebot Smartphone render | 核心内容可见 |
+| 首页 canonical | 仍指向 `/` |
+| 详情页 canonical | 仍指向自身 |
+| 首页到详情页链接 | SSR 可见，不依赖点击后生成 |
+| 首屏意图 | 不再被品牌/徽章/泛介绍稀释 |
+
+### Phase 2：详情页完整承接增强
+
+推荐：**批准，和 Phase 1 可并行设计，但分 PR 发布。**
+
+目标：确保详情页能赢题号和 clue 长尾，而不是被首页抢掉。
+
+建议变更：
+
+1. 详情页 H1 保持题号聚焦：
+
+   ```text
+   LinkedIn Pinpoint #748 Answer and Hints
+   ```
+
+2. 详情页上方明确显示：
+   - `Published`
+   - `Updated`
+   - `Verified`
+   - answer reveal
+   - all clues
+
+3. 增强完整解释：
+   - why each clue fits
+   - wrong paths / disambiguation
+   - hint ladder
+   - answer category
+   - previous/next
+
+4. 详情页底部强化内链：
+   - 返回 today answer
+   - 返回 archive
+   - previous/next
+   - recent 10 answers
+
+验收：
+
+| Query 类型 | 目标 URL |
+| --- | --- |
+| `pinpoint 748 answer` | 详情页 |
+| `linkedin pinpoint 748 answer` | 详情页 |
+| clue 组合词 | 详情页 |
+| `pinpoint answer today` | 首页 |
+
+数据验收：
+
+| 指标 | 目标 |
+| --- | --- |
+| 最新 10 个详情页 clue query impressions | Phase 2 后 14 天不低于 Phase 1 前基线 |
+| 最新详情页题号/clue query avg position | 有展示 query 的平均位置维持在前 10-15，或 impressions 增长 |
+| 首页承接题号 query 占比 | 不超过首页总 impressions 的 15%，否则疑似 cannibalization |
+
+### Phase 3：首页更激进主承接实验
+
+推荐：**暂不批准本轮执行，只批准准备实验设计。**
+
+触发条件：
+
+- Phase 0 后 5-7 天，抓取和 404 已恢复。
+- Phase 1 后 7-14 天，首页 query 没有继续恶化。
+- 移动端 GSC / URL Inspection / render 没有发现首页核心内容缺失。
+- 详情页仍能拿题号长尾，不被首页明显 cannibalize。
+
+可测试内容：
+
+- 首页 title 动态带当天题号。
+- 首页 `WebPage.mainEntity` 指向当天详情页。
+- 首页添加 `ItemList` recent answers。
+- 首页更强地展示 today answer module。
+
+仍不建议：
+
+- 首页复制完整详情页正文。
+- 首页复制完整详情页 FAQ。
+- URL 迁移到竞品路径。
+- 大规模 schema 一次性上线。
+
+---
+
+## 10. Cannibalization 监控
+
+首页增强后，必须监控首页和详情页是否互相抢 query。
+
+### 10.1 监控维度
+
+GSC 维度固定为：
+
+```text
+query + page + device + country + date
+```
+
+核心 URL：
+
+- `/`
+- `/puzzles`
+- `/next-pinpoint-preview`
+- 最新 10 个详情页
+- `#735/#736/#737`
+
+核心 query：
+
+- `pinpoint answer today`
+- `linkedin pinpoint answer today`
+- `pinpoint today`
+- `pinpoint today answer`
+- `pinpoint 748 answer`
+- `linkedin pinpoint 748 answer`
+- 当天 5 个 clues 的组合词
+
+### 10.2 正常状态
+
+正常状态应该是：
+
+| Query | 首页表现 | 详情页表现 | 量化标准 |
+| --- | --- | --- | --- |
+| `pinpoint answer today` | 主承接 | 辅助 | 首页拿到该 query impressions 的 70%+ |
+| `linkedin pinpoint answer today` | 主承接 | 辅助 | 首页拿到该 query impressions 的 70%+ |
+| `pinpoint 748 answer` | 辅助或无 | 主承接 | 详情页拿到该 query impressions 的 70%+ |
+| clue 组合词 | 辅助或无 | 主承接 | 详情页拿到 clue query impressions 的 70%+ |
+
+如果样本低于 20 impressions，不做强判定，只记录趋势。
+
+### 10.3 统计口径与噪声控制
+
+GSC 小样本噪声很大，不能把 1-10 impressions 的波动当成方向性结论。
+
+统一统计口径：
+
+| 规则 | 标准 |
+| --- | --- |
+| 观察窗口 | 发布后至少 7 个完整自然日；主要决策使用 7 天滚动窗口 |
+| 周期对比 | 优先同星期结构对比，例如 Mon-Sun vs Mon-Sun，避免周末/工作日错配 |
+| query/page 最小样本 | impressions >= 20 才做方向性判断；< 20 只记录，不触发回滚或加速 |
+| 核心 query 汇总 | `pinpoint answer today`、`linkedin pinpoint answer today`、`pinpoint today`、`pinpoint answers today` 合并观察 |
+| 设备维度 | 移动端单独看；desktop 恢复不能替代 mobile 恢复 |
+| 国家维度 | US 为主；样本不足时看 US + UK + CA + AU，但需单独标注 |
+| 异常日处理 | 若遇到 Google 状态事故、站点 downtime、部署失败或抓取异常，当天不作为趋势判断 |
+| bot/异常流量 | GSC 本身不提供 bot 过滤；用 server log/GA4 只做辅助，不把异常访问当 SEO 恢复 |
+
+Phase 1 后读数：
+
+| 时间点 | 看什么 | 不看什么 |
+| --- | --- | --- |
+| Day 1-3 | 抓取、server log、URL Inspection、HTML、404、sitemap | 不用 GSC 判断排名成败 |
+| Day 4-7 | GSC 初步方向，只看核心 query 聚合和 page/device 趋势 | 不解读单个低样本 query |
+| Day 8-14 | 是否继续 Phase 2 或回滚 | 不因单日波动改策略 |
+
+### 10.4 异常状态
+
+需要警惕：
+
+1. 首页和详情页同时排名同一题号 query，且位置都低。
+2. 首页拿走 `pinpoint 748 answer`，但详情页 impressions 消失。
+3. 详情页拿 today 大词，但首页 impressions 没恢复。
+4. 首页增强后 mobile impressions 继续下降，详情页没有补偿增长。
+
+### 10.5 回滚条件
+
+满足任一条件，应回滚 Phase 1 首页增强或暂停 Phase 2/3：
+
+| 条件 | 动作 |
+| --- | --- |
+| 首页改版后 7 天内 mobile impressions 继续下降超过 50%，详情页无对应增长 | 回滚首页首屏/metadata 改动 |
+| 首页核心 query avg position 再恶化 20 名以上 | 回滚首页 title/H1/schema 变更 |
+| URL Inspection 显示 Googlebot Smartphone 看不到题号、日期、clues、详情链接 | 修移动渲染，暂停 SEO 文案实验 |
+| 首页和详情页同 query cannibalization 明显 | 收窄首页内容，强化详情页主承接 |
+| title/H1/可见日期/schema 日期不一致 | 立即修 schema/metadata，不继续发布 |
+
+---
+
+## 11. 移动端专项要求
+
+这次下滑最大缺口来自移动端。首页策略调整前，必须把移动端作为单独审批项。
+
+已知数据：
+
+| Device | 2026-05-05 到 2026-05-11 | 2026-05-12 到 2026-05-18 |
+| --- | --- | --- |
+| Mobile homepage | 1,442 impressions / pos 9.34 | 16 impressions / pos 14.31 |
+| Desktop homepage | 133 impressions / pos 34.76 | 105 impressions / pos 55.49 |
+
+解释：移动端不是简单排名小幅下降，而是首页几乎不再进入可产生 impression 的移动结果集。
+
+### 11.1 已完成的移动端 HTML 抽查
+
+抓取方式：Googlebot Smartphone UA 直接请求生产 URL。
+
+| URL | 结果 |
+| --- | --- |
+| `/` | HTML 中能看到 `#748`、`Butter chicken`、详情页链接、H1 |
+| `/linkedin-pinpoint-answers/pinpoint-answer-748/` | HTML 中能看到 `#748`、`Butter chicken`、`Indian foods`、自指 canonical |
+
+初步判断：
+
+- 当前没有证据表明 Googlebot Smartphone 完全看不到首页核心内容。
+- 这不能替代 URL Inspection live test，因为 Search Console 的渲染、截图和 indexed HTML 更接近 Google 实际处理。
+
+### 11.2 仍未完成的移动诊断
+
+PageSpeed Insights mobile API 本次对首页和最新详情页均 90 秒超时，未拿到 PSI 分数。不能把“移动性能没问题”写成结论。
+
+Phase 0 同优先级必须补：
+
+1. PageSpeed Insights mobile：
+   - `/`
+   - 最新详情页
+   - `/puzzles`
+2. URL Inspection mobile render：
+   - 首页题号是否可见
+   - 日期是否可见
+   - 5 clues 是否可见
+   - 详情页链接是否 SSR 可见
+   - answer/hint 区块是否可见
+3. 移动 SERP 快照：
+   - US mobile
+   - `pinpoint answer today`
+   - `linkedin pinpoint answer today`
+   - `pinpoint today`
+4. 首页 mobile 截图留档：
+   - before Phase 1
+   - after Phase 1
+
+如果移动端 CWV 或渲染失败，首页信息架构改版暂停，先修移动问题。
+
+---
+
+## 12. 具体审批清单
+
+| 审批项 | 推荐 | 理由 |
+| --- | --- | --- |
+| P0 sitemap `lastmod` 修复 | 批准 | 明确生产缺陷，且竞品每天更新首页/归档 lastmod |
+| P0 恢复 `#735/#736/#737` registry | 批准 | 明确 404/漏页/归档断层 |
+| P0 增加 registry/detail 反向一致性校验 | 批准 | 不补 guardrail，749/750 仍可能复发 |
+| P0 移动端 HTML/URL Inspection 抽查 | 批准 | 移动端是最大损失来源，不能推迟到 Phase 1 |
+| P0.5 移动轻量化补丁 | 条件批准 | PSI mobile < 50、LCP > 2.5s、或首屏 JS 阻塞明显时强制执行 |
+| Day 0 直接复制竞品首页 | 不批准 | 混合变量，无法归因，且 cannibalization 风险高 |
+| 首页 stronger today entry | 批准，但延后 | 方向正确，但应在 P0 修复后至少 5 天独立发布 |
+| 首页动态 H1 带题号 | 批准 | 当前已有，保留并强化日期/线索支撑 |
+| 首页 title 改成 today intent | 批准，但放 Phase 1 | 需要独立观察，避免和 P0 混批 |
+| 首页展示 5 clues | 批准 | 对 today query intent 有帮助 |
+| 首页工具性模块 | 批准，Phase 1 必做 | 避免纯 SEO 页面风险，补用户任务完成路径 |
+| 首页展示完整分析长文 | 不批准本轮 | 会和详情页争题号/线索长尾 |
+| 首页新增 QAPage | 不批准本轮 | 结构化数据一致性和富结果价值不确定 |
+| 首页新增 ItemList recent answers | Phase 2 可批准 | 低风险，但仍建议独立发布 |
+| 保留详情页 self-canonical | 批准 | 这是现有 SEO 契约 |
+| 保留 `/puzzles` 作为归档 canonical | 批准 | 避免 URL 迁移风险 |
+| 迁移到竞品 URL 形态 | 不批准 | 代价高，收益不确定 |
+| 每次发布保留 SERP/HTML/mobile 截图 | 批准 | 为归因和回滚提供证据 |
+| 7 天滚动窗口统计口径 | 批准 | 避免用低样本单日波动做错误决策 |
+| 28 天无恢复后的升级路径 | 批准 | 避免“再等等看” |
+| Plan B 防御性 SEO | 批准准备，不本轮执行 | 28 天无恢复或回滚无效后使用 |
+
+---
+
+## 13. 如果 28 天仍不恢复
+
+如果 Phase 0 和 Phase 1 后 28 天仍没有恢复，不继续盲目等。
+
+### 13.1 判定标准
+
+满足以下任一项，即视为未恢复：
+
+- 首页 `pinpoint answer today` impressions 仍低于 5 月 5-11 基线的 30%。
+- 首页 mobile impressions 仍低于 5 月 5-11 基线的 30%。
+- 首页核心 query avg position 仍差于 30。
+- 详情页没有拿到题号 query 的补偿增长。
+
+### 13.2 升级路径
+
+1. 重做 SERP 对照：
+   - 记录 top 10 页面类型。
+   - 标记是否由专门站、媒体站、LinkedIn 官方、AI Overview 或 UGC 结果占据。
+2. 做内容差距审计：
+   - 首页 vs top 3 竞品。
+   - 最新 10 个详情页 vs top 3 竞品。
+3. 测试更激进首页：
+   - 首页 title 动态带题号。
+   - 首页 WebPage mainEntity 指向当天详情页。
+   - 首页 recent ItemList。
+4. 若仍失败，考虑站点层级策略：
+   - 新增 `/linkedin-pinpoint-answer/` 作为非 canonical redirect 或专题页？仅在有明确证据时评估。
+   - 拆出更强 archive hub。
+   - 重写详情页内容模板，降低模板化。
+5. 最后再考虑 URL 迁移：
+   - 只有在 GSC 显示现有 URL 体系长期无法承接，且 redirect/canonical 方案完整时才评估。
+
+### 13.3 Plan B：防御性 SEO 预案
+
+如果 28 天后没有恢复，或者 Phase 1 回滚后仍未恢复，说明根因可能不在首页信息架构，而在 SERP 形态、算法偏好或整类站点信任度。
+
+Plan B 不再优先调首页布局，而是转向防御性 SEO：
+
+| 方向 | 动作 | 目的 |
+| --- | --- | --- |
+| Video 信号 | 为当天题生成短视频/嵌入 YouTube 或自托管视频摘要，详情页加 `VideoObject` 前置验证 | 适配 SERP 视频模块，增加多媒体信任 |
+| 讨论信号 | 汇总或链接到相关公开讨论入口，如 Reddit 讨论、LinkedIn 游戏入口、用户反馈更正 | 增加实时性和真实用户语境 |
+| 作者/验证信任 | 增加清晰作者/编辑/last verified/correction policy，不虚构身份 | 降低模板站/低信任风险 |
+| 内容差异化 | 最新 10 个详情页做人工 gap analysis，不只复用模板段落 | 对抗同质化 puzzle answer 页面 |
+| SERP feature 适配 | 若 PAA/featured snippet/AI Overview 主导，重写答案摘要和 FAQ 结构，但不滥用 schema | 提高被引用或点击的概率 |
+| 市场级审计 | 跟踪 5-10 个同类专门站 14 天，判断是否集体下跌 | 区分自身问题与利基市场降权 |
+
+Plan B 触发条件：
+
+- Phase 0 完成且无恢复。
+- Phase 1 完成或回滚后无恢复。
+- SERP 快照显示 top 10 被媒体、UGC、AI Overview 或视频结果持续占据。
+- 首页与详情页均未获得补偿性增长。
+
+Plan B 不建议：
+
+- 立即迁移 URL。
+- 大量生成低质量视频或伪讨论内容。
+- 复制 Reddit 内容。
+- 为了 rich result 输出与可见内容不一致的 schema。
+
+---
+
+## 14. 推荐 PR 拆分
+
+### PR 1：P0 技术修复
+
+只包含：
+
+- sitemap static lastmod 修复
+- `#735/#736/#737` registry 恢复
+- registry/detail 反向一致性 guardrail
+- 最近 30 天编号连续性或 allowlist guardrail
+- 404/sitemap/归档/legacy alias 回归测试
+- Googlebot Smartphone HTML 抽查记录
+- PSI/Lighthouse mobile 基线记录
+- 条件触发的 P0.5 首页轻量化补丁
+
+不包含：
+
+- 首页改版
+- schema 改版
+- 详情页内容重写
+
+### PR 2：首页 Today Answer 增强
+
+只包含：
+
+- 首页 title/description 微调
+- 首页首屏 today module 调整
+- 日期、题号、clues、verification 更清楚
+- 详情页强链接 anchor
+- Today Quick Actions / Play on LinkedIn / Last checked 工具性模块
+- 非 today 模块下沉
+
+不包含：
+
+- QAPage
+- FAQPage
+- URL 迁移
+- 完整分析复制
+
+### PR 3：详情页完整承接增强
+
+只包含：
+
+- 详情页 H1/上方信息层级
+- clue-by-clue explanation 增强
+- hint ladder 增强
+- previous/next/archive/today 内链增强
+
+### PR 4：结构化数据实验
+
+前置条件：
+
+- Phase 1 后数据没有恶化。
+- 移动渲染和可见内容一致。
+- schema 测试通过。
+
+可能包含：
+
+- 首页 ItemList
+- 首页 WebPage significantLink
+- 谨慎的 mainEntity 指向详情页
+
+---
+
+## 15. 最终建议
+
+可以承认：**竞品首页打法方向是对的。**
+
+但我们不应把这个判断简化成“竞品这么做，所以我们也把首页做成详情页克隆”。竞品真正值得学的是：
+
+- 首页强承接 today intent。
+- 首页和当天详情页强连接。
+- sitemap freshness 和每日更新一致。
+- 最近答案列表形成内链。
+- 题号详情页继续承接长尾。
+
+我们本轮应该批准的是：
+
+```text
+先修 P0 生产完整性和可观测性缺陷；
+补根因验证基线；
+在数据门槛通过后，再独立上线首页 today 入口增强；
+同时保留详情页作为完整答案主承接；
+用 GSC query/page/device 数据判断是否需要进一步激进。
+```
+
+不应批准的是：
+
+```text
+在排名下滑窗口里，一次性复制竞品首页、迁移 URL、改 schema、重排首页、复制详情页长文。
+```
+
+这条路线既承认竞品打法的有效性，也保留了我们恢复窗口内最重要的东西：可归因、可回滚、可继续判断。

--- a/docs/phase0-seo-integrity-day0-check-2026-05-19.md
+++ b/docs/phase0-seo-integrity-day0-check-2026-05-19.md
@@ -1,0 +1,221 @@
+# Phase 0 SEO Integrity Day 0 Check - 2026-05-19
+
+## Summary
+
+Phase 0 production integrity fixes were merged and deployed on 2026-05-19.
+
+Result: production integrity checks passed. The site now exposes fresh sitemap `lastmod` values for the main public routes and restores public access/sitemap coverage for Pinpoint #735, #736, and #737.
+
+Do not use same-day GSC data to judge ranking recovery. The next decision checkpoint is after Google has recrawled the affected URLs and at least 5 full natural days have elapsed.
+
+## Release
+
+| Item | Result |
+|---|---|
+| PR | https://github.com/elng12/pinpoint-answer-today-new/pull/40 |
+| Merge commit | `94ff8c56b2acd905738471109f689afc921cee99` |
+| Merge time | 2026-05-19 11:16 UTC |
+| Production deploy | Vercel success at 2026-05-19 11:17:58 UTC |
+| Main CI | Passed: Validate Data, Lint, Typecheck, Pinpoint Guardrails |
+
+## Non-SEO Release Marker
+
+A follow-up security-only release was merged after the Phase 0 SEO integrity deployment.
+Record it as a non-SEO variable when reviewing logs, GSC movement, or production metrics.
+
+| Item | Result |
+|---|---|
+| PR | https://github.com/elng12/pinpoint-answer-today-new/pull/41 |
+| Merge commit | `04f00595366cb73442b8fe90d28ea1010adbb917` |
+| Merge time | 2026-05-20 03:03:45 UTC |
+| Production deploy | Vercel success at 2026-05-20 03:05:06 UTC |
+| Main CI | Passed: Lint, Typecheck, Guardrails |
+| Scope | Admin auth hardening, timing-safe secret comparison, outbound URL allowlists, proxy error redaction, API rate limiting |
+| SEO surface | No homepage, title, schema, sitemap, canonical, URL, or content changes |
+
+Production spot checks after deploy:
+
+| URL | Status | Notes |
+|---|---:|---|
+| `https://pinpointanswertoday.app/` | 200 | Homepage served successfully; no SEO surface change intended |
+| `https://pinpointanswertoday.app/api/health` | 200 | API noindex header present; platform HSTS still single header |
+
+## Production URL Checks
+
+Checked after production deploy completed.
+
+| URL | Status | Canonical | Robots | Notes |
+|---|---:|---|---|---|
+| `https://pinpointanswertoday.app/` | 200 | `https://pinpointanswertoday.app` | `index, follow` | Latest detail link present |
+| `https://pinpointanswertoday.app/puzzles` | 200 | `https://pinpointanswertoday.app/puzzles` | `index, follow` | #735, #736, #737 present |
+| `https://pinpointanswertoday.app/next-pinpoint-preview` | 200 | `https://pinpointanswertoday.app/next-pinpoint-preview` | `index, follow` | Latest detail link present |
+| `https://pinpointanswertoday.app/linkedin-pinpoint-answers/pinpoint-answer-735/` | 200 | self | `index, follow` | Core content present |
+| `https://pinpointanswertoday.app/linkedin-pinpoint-answers/pinpoint-answer-736/` | 200 | self | `index, follow` | Core content present |
+| `https://pinpointanswertoday.app/linkedin-pinpoint-answers/pinpoint-answer-737/` | 200 | self | `index, follow` | Core content present |
+
+## Sitemap Checks
+
+`https://pinpointanswertoday.app/sitemap.xml` returned `200` with `content-type: application/xml`.
+
+| URL | Found | lastmod | changefreq | priority |
+|---|---|---|---|---:|
+| `/` | yes | `2026-05-19T07:07:49.377Z` | daily | 1.0 |
+| `/puzzles` | yes | `2026-05-19T07:07:49.377Z` | daily | 0.9 |
+| `/next-pinpoint-preview` | yes | `2026-05-19T07:07:49.377Z` | daily | 0.8 |
+| `/linkedin-pinpoint-answers/pinpoint-answer-735/` | yes | `2026-05-06T07:01:42.573Z` | daily | 0.8 |
+| `/linkedin-pinpoint-answers/pinpoint-answer-736/` | yes | `2026-05-07T07:01:43.931Z` | daily | 0.8 |
+| `/linkedin-pinpoint-answers/pinpoint-answer-737/` | yes | `2026-05-07T07:01:58.344Z` | daily | 0.8 |
+
+## Googlebot Smartphone HTML Check
+
+Fetched with a Googlebot Smartphone user agent. HTML contained indexable content and links.
+
+| URL | Status | Visible markers |
+|---|---:|---|
+| `/` | 200 | today detail link, #749, #737 content |
+| `/linkedin-pinpoint-answers/pinpoint-answer-749/` | 200 | today detail link, #749, #737 content |
+| `/linkedin-pinpoint-answers/pinpoint-answer-735/` | 200 | today detail link, #749, #735 content, #737 content |
+| `/linkedin-pinpoint-answers/pinpoint-answer-736/` | 200 | today detail link, #749, #736 content, #737 content |
+| `/linkedin-pinpoint-answers/pinpoint-answer-737/` | 200 | today detail link, #749, #737 content |
+
+Note: some cross-markers come from adjacent/recent-answer links and are expected.
+
+## GSC Baseline
+
+Source: Search Console API, `sc-domain:pinpointanswertoday.app`.
+
+Window: 2026-05-12 to 2026-05-18. Same-day data excluded.
+
+### Homepage
+
+`https://pinpointanswertoday.app/`
+
+| Metric | Value |
+|---|---:|
+| clicks | 2 |
+| impressions | 155 |
+| CTR | 1.3% |
+| avg position | 45.54 |
+| desktop impressions | 113 |
+| mobile impressions | 16 |
+
+Core query examples:
+
+| Query | Impressions | Position |
+|---|---:|---:|
+| `linkedin pinpoint answer today` | 10 | 61.70 |
+| `pinpoint answer today` | 15 | 48.40 |
+| `pinpoint answers today` | 10 | 48.10 |
+| `linkedin pinpoint today` | 4 | 58.75 |
+
+### Archive
+
+`https://pinpointanswertoday.app/puzzles`
+
+| Metric | Value |
+|---|---:|
+| clicks | 0 |
+| impressions | 23 |
+| avg position | 11.74 |
+
+### Recent Detail Pages
+
+Latest 20 detail pages aggregate:
+
+| Metric | Value |
+|---|---:|
+| clicks | 0 |
+| impressions | 108 |
+| pages with clicks | 0 / 20 |
+
+Top recent detail rows:
+
+| Puzzle | Impressions | Position |
+|---|---:|---:|
+| #742 | 49 | 7.82 |
+| #748 | 26 | 8.00 |
+| #743 | 17 | 5.00 |
+| #741 | 7 | 8.00 |
+| #746 | 4 | 7.25 |
+
+#748 page detail:
+
+| Metric | Value |
+|---|---:|
+| clicks | 0 |
+| impressions | 26 |
+| avg position | 8.00 |
+| desktop impressions | 12 |
+| mobile impressions | 11 |
+
+Top #748 query examples:
+
+| Query | Impressions | Position |
+|---|---:|---:|
+| `butter chicken vindaloo pinpoint` | 8 | 9.00 |
+| `butter chicken vindaloo palak paneer naan biryani` | 7 | 7.86 |
+| `vindaloo butter chicken pinpoint` | 7 | 8.43 |
+| `butter chicken pinpoint` | 1 | 3.00 |
+
+### #735-#737 Pre-Fix GSC Visibility
+
+Search Console `find` rows for 2026-05-12 to 2026-05-18:
+
+| Slug | Matching rows | Impressions |
+|---|---:|---:|
+| `pinpoint-answer-735` | 0 | 0 |
+| `pinpoint-answer-736` | 0 | 0 |
+| `pinpoint-answer-737` | 0 | 0 |
+
+This supports the production-integrity issue: the files existed locally, but the pages had no GSC page visibility in the pre-fix window.
+
+## SERP Snapshot
+
+Captured on 2026-05-19.
+
+Observed from web search snapshots:
+
+- Queries for `linkedin pinpoint answer today` and `pinpoint answer today #749` surface multiple direct competitors with current-day answer pages.
+- Competitor patterns visible in snippets include direct `#749` targeting, current-day dates, clues, and answer/reveal language.
+- `site:pinpointanswertoday.app` style results still showed stale older snippets in at least one snapshot, including old #734-oriented language. Treat this as recrawl/snippet lag until proven otherwise.
+
+Do not infer recovery or failure from these SERP checks alone. Use them as Day 0 external context.
+
+## GSC URL Inspection
+
+Attempted URL Inspection API calls for homepage, archive, #749, #735, #736, and #737. The Search Console API token endpoint timed out twice from the local network during this step, while Search Analytics API calls succeeded.
+
+Manual GSC UI action still required:
+
+1. Run URL Inspection Live Test for:
+   - `https://pinpointanswertoday.app/`
+   - `https://pinpointanswertoday.app/puzzles`
+   - `https://pinpointanswertoday.app/linkedin-pinpoint-answers/pinpoint-answer-749/`
+   - `https://pinpointanswertoday.app/linkedin-pinpoint-answers/pinpoint-answer-735/`
+   - `https://pinpointanswertoday.app/linkedin-pinpoint-answers/pinpoint-answer-736/`
+   - `https://pinpointanswertoday.app/linkedin-pinpoint-answers/pinpoint-answer-737/`
+2. Save screenshots for Mobile render, user-declared canonical, Google-selected canonical, indexing allowed, and page fetch status.
+3. Request indexing for homepage, latest detail page, and #735-#737 if GSC allows it.
+4. Resubmit `https://pinpointanswertoday.app/sitemap.xml`.
+
+## Next Checkpoints
+
+Day 1-3:
+
+- Confirm Googlebot fetches in server/Vercel logs if available.
+- Re-run production URL checks.
+- Re-run sitemap checks.
+- Complete GSC UI Live Test screenshots if not already done.
+
+Day 5:
+
+- Re-run Search Analytics for 2026-05-19 onward, but avoid over-reading low sample query rows.
+- Check whether #735-#737 get any page rows after sitemap restoration.
+- Check whether homepage core today-query position stops worsening.
+
+Do not start Phase 1 homepage changes before:
+
+- Phase 0 has at least 5 full natural days in production.
+- GSC UI mobile live tests pass.
+- Sitemap and affected detail URLs remain stable.
+- No new 404/canonical/indexing regressions are found.


### PR DESCRIPTION
## Summary
- add the May 19 full audit remediation plan
- add the GSC ranking recovery plan
- add the homepage today-answer strategy review
- add the Phase 0 SEO integrity day-0 check

## Notes
- docs-only PR
- intentionally separate from the Pinpoint content gate rollout

## Validation
- pre-push hook ran `npm run validate:data` successfully