### PR TITLE
[codex] Add release queue dry-run simulation

### DIFF
--- a/docs/content-quality-release-gate-pr5c-queue-integration-2026-05-22.md
+++ b/docs/content-quality-release-gate-pr5c-queue-integration-2026-05-22.md
@@ -53,6 +53,36 @@ Actions:
 
 If a candidate branch already exists, the Worker does not auto-promote it. Even a current candidate stays in `write-candidate` with `candidate-branch-awaiting-promotion` unless a future maintainer-controlled promotion path explicitly passes `allowCandidatePromotion`.
 
+## Read-Only Staging Simulation
+
+Staging cannot safely exercise the real release queue by pointing `GITHUB_BRANCH_NEW_SITE` at `main`: that would make an admin publish capable of touching the production branch.
+
+Use the admin-only, read-only simulation endpoint instead:
+
+```bash
+curl -X POST "https://pinpoint-worker-staging.<account>.workers.dev/admin/release-queue-dry-run?secret=<admin-secret>&simulatePrimary=1&releaseQueueEnabled=1&date=2026-05-22&puzzleNumber=752&deploymentState=queued"
+```
+
+Expected behavior:
+
+- `readOnly=true`
+- `simulatePrimary=true`
+- `queueEligible=true`
+- `decision.action=write-candidate`
+- no GitHub ref writes
+- no ISR revalidation
+- no queue notification
+
+Useful scenarios:
+
+| Scenario | Query params | Expected decision |
+| --- | --- | --- |
+| Vercel queue/build pressure | `deploymentState=queued` or `deploymentState=building` | `write-candidate` |
+| Missing Vercel status | `deploymentState=unknown` | `write-candidate` |
+| Failed production deployment | `deploymentState=failed` | `hold-review` |
+| Same-slug push budget exhausted | `deploymentState=ready&lastProductionPushAt=<ISO time within 60 min>` | `write-candidate` |
+| Explicit second-push override | `deploymentState=ready&lastProductionPushAt=<ISO time within 60 min>&overrideSecondProductionPush=1` | `push-production` |
+
 ## What This Does Not Do
 
 This PR does not add automatic promotion.

--- a/scripts/check-pinpoint-guardrails.ts
+++ b/scripts/check-pinpoint-guardrails.ts
@@ -2549,6 +2549,30 @@ async function checkCandidateBranchDryRunRouteSafety() {
   console.log("ok: candidate branch dry-run route is admin-gated and blocked on primary branch");
 }
 
+async function checkReleaseQueueDryRunRouteSafety() {
+  const workerSource = await readFile(resolve(ROOT, "worker/src/index.ts"), "utf8");
+  const routeStart = workerSource.indexOf('url.pathname === "/admin/release-queue-dry-run" && req.method === "POST"');
+  const routeEnd = workerSource.indexOf('url.pathname === "/admin/run"', routeStart);
+  assert.ok(routeStart >= 0, "release queue dry-run route must exist and be POST-only");
+  assert.ok(routeEnd > routeStart, "release queue dry-run route must stay before the real admin run route");
+
+  const routeSource = workerSource.slice(routeStart, routeEnd);
+  assert.ok(routeSource.includes("getAdminSecret(env)"), "release queue dry-run route must be admin-gated");
+  assert.ok(routeSource.includes("readOnly: true"), "release queue dry-run response must identify itself as read-only");
+  assert.ok(
+    routeSource.includes("simulatePrimary") && routeSource.includes("queueEligible"),
+    "release queue dry-run route must support staging-safe primary-branch simulation",
+  );
+  assert.ok(
+    !routeSource.includes("publishToNewSiteGitHub(") &&
+      !routeSource.includes("ensureBranchRef(") &&
+      !routeSource.includes("notifyPinpointReleaseQueueDecision("),
+    "release queue dry-run route must not write GitHub refs or send queue notifications",
+  );
+
+  console.log("ok: release queue dry-run route is admin-gated and read-only");
+}
+
 async function checkReleaseQueueWorkerIntegration() {
   const workerModulePath = "../worker/src/index.ts";
   const workerModule = (await import(workerModulePath)) as {
@@ -2630,6 +2654,7 @@ async function main() {
   checkIntermediateStateCommitDetection();
   checkReleaseQueuePolicy();
   await checkCandidateBranchDryRunRouteSafety();
+  await checkReleaseQueueDryRunRouteSafety();
   await checkReleaseQueueWorkerIntegration();
   console.log("Pinpoint guardrail regression passed.");
 }

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -514,6 +514,30 @@ function parsePositiveNumber(value: string | undefined): number | undefined {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
 }
 
+function parseOptionalBooleanParam(params: URLSearchParams, name: string): boolean | undefined {
+  const raw = params.get(name);
+  if (raw == null || raw.trim().length === 0) return undefined;
+  const normalized = raw.trim().toLowerCase();
+  if (normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on") return true;
+  if (normalized === "0" || normalized === "false" || normalized === "no" || normalized === "off") return false;
+  return undefined;
+}
+
+function parseDeploymentStateParam(value: string | null): DeploymentState {
+  const normalized = String(value || "").trim().toLowerCase();
+  if (
+    normalized === "none" ||
+    normalized === "queued" ||
+    normalized === "building" ||
+    normalized === "ready" ||
+    normalized === "failed" ||
+    normalized === "unknown"
+  ) {
+    return normalized;
+  }
+  return "unknown";
+}
+
 function releaseQueueLastProductionPushKeyOf(slug: string): string {
   return `pinpoint:release-queue:last-production-push:${slug}`;
 }
@@ -5990,6 +6014,99 @@ export default {
         detailState: "fallback_full",
         productionBranchTouched: false,
         revalidateTriggered: false,
+      }), {
+        headers: { "content-type": "application/json; charset=utf-8" },
+      });
+    }
+
+    if (url.pathname === "/admin/release-queue-dry-run" && req.method === "POST") {
+      const adminSecret = getAdminSecret(env);
+      if (!adminSecret) return new Response("admin secret not configured", { status: 503 });
+      const secret = url.searchParams.get("secret");
+      if (secret !== adminSecret) return new Response("unauthorized", { status: 401 });
+
+      const params = url.searchParams;
+      const requestedDate = String(params.get("date") || "").trim();
+      const puzzleDate = /^\d{4}-\d{2}-\d{2}$/.test(requestedDate) ? requestedDate : getBeijingTodayDate();
+      const requestedPuzzleNumber = String(params.get("puzzleNumber") || "").trim();
+      const puzzleNumber = inferPuzzleNumber(requestedPuzzleNumber || undefined, puzzleDate);
+      const defaultSlug = `pinpoint-answer-${puzzleNumber}`;
+      const requestedSlug = String(params.get("slug") || "").trim();
+      const slug = /^[A-Za-z0-9][A-Za-z0-9._-]{1,126}$/.test(requestedSlug) ? requestedSlug : defaultSlug;
+      const detailState = resolvePublishDetailState(params.get("detailState"));
+      const isPublicState = isPublicPublishDetailState(detailState);
+      const baseBranch = normalizeGitHubBranchName(env.GITHUB_BRANCH_NEW_SITE, "main");
+      const actualIsPrimaryBranch = isPrimaryNewSiteBranch(baseBranch);
+      const simulatePrimary = parseOptionalBooleanParam(params, "simulatePrimary") === true;
+      const effectiveIsPrimaryBranch = simulatePrimary || actualIsPrimaryBranch;
+      const candidateBranch = buildPinpointCandidateBranchName(env, puzzleDate, slug);
+      const candidateBranchEnabled =
+        parseOptionalBooleanParam(params, "candidateBranchEnabled") ??
+        envFlag(env.PINPOINT_CANDIDATE_BRANCH_ENABLED, false);
+      const releaseQueueFlag =
+        parseOptionalBooleanParam(params, "releaseQueueEnabled") ??
+        envFlag(env.PINPOINT_RELEASE_QUEUE_ENABLED, false);
+      const forceCandidateBranch = candidateBranchEnabled && isPublicState;
+      const queueEligible = releaseQueueFlag && isPublicState && effectiveIsPrimaryBranch && !forceCandidateBranch;
+      const deploymentState = parseDeploymentStateParam(params.get("deploymentState"));
+      const localGatesPassed = parseOptionalBooleanParam(params, "localGatesPassed");
+      const overrideSecondProductionPush =
+        parseOptionalBooleanParam(params, "overrideSecondProductionPush") ??
+        envFlag(env.PINPOINT_RELEASE_QUEUE_OVERRIDE_SECOND_PUSH, false);
+      const allowCandidatePromotion = parseOptionalBooleanParam(params, "allowCandidatePromotion");
+      const candidateBranchExists = parseOptionalBooleanParam(params, "candidateBranchExists");
+      const candidateIsCurrent = parseOptionalBooleanParam(params, "candidateIsCurrent");
+      const lastProductionPushAt = String(params.get("lastProductionPushAt") || "").trim() || undefined;
+      const nowMs = String(params.get("now") || "").trim() || undefined;
+      const publishMode = String(params.get("publishMode") || "full-analysis").trim() || "full-analysis";
+
+      const decision = decidePinpointReleaseQueueAction({
+        slug,
+        logicalGameDate: puzzleDate,
+        publishMode,
+        deploymentState,
+        lastProductionPushAt,
+        slaWindowMinutes: parsePositiveNumber(env.PINPOINT_RELEASE_QUEUE_SLA_WINDOW_MINUTES),
+        candidateBranch,
+        candidateBranchExists,
+        candidateIsCurrent,
+        overrideSecondProductionPush,
+        allowCandidatePromotion,
+        localGatesPassed,
+        nowMs,
+      });
+
+      return new Response(JSON.stringify({
+        ok: true,
+        mode: "release-queue-dry-run",
+        readOnly: true,
+        baseBranch,
+        actualIsPrimaryBranch,
+        simulatePrimary,
+        effectiveIsPrimaryBranch,
+        releaseQueueFlag,
+        candidateBranchEnabled,
+        forceCandidateBranch,
+        detailState,
+        isPublicState,
+        queueEligible,
+        wouldApplyDecision: queueEligible,
+        candidateBranch,
+        input: {
+          slug,
+          puzzleDate,
+          puzzleNumber,
+          publishMode,
+          deploymentState,
+          lastProductionPushAt,
+          overrideSecondProductionPush,
+          allowCandidatePromotion,
+          candidateBranchExists,
+          candidateIsCurrent,
+          localGatesPassed,
+          nowMs,
+        },
+        decision,
       }), {
         headers: { "content-type": "application/json; charset=utf-8" },
       });


### PR DESCRIPTION
## Summary

- add an admin-only, read-only `/admin/release-queue-dry-run` Worker endpoint
- let staging simulate the primary-branch release queue path without pointing `GITHUB_BRANCH_NEW_SITE` at `main`
- document staging scenarios for queued/building/unknown/failed/same-slug-budget decisions
- add guardrails proving the endpoint is POST-only, admin-gated, read-only, and does not call GitHub write/notification paths

## Why

The staging rehearsal exposed a safety gap: the real release queue only runs on the primary branch, while staging is intentionally pinned to `worker-staging`. Changing staging to `main` would make admin publish calls capable of touching production. This endpoint closes that gap by computing the queue decision without writing GitHub refs, sending queue notifications, or triggering ISR revalidation.

## Verification

- `npm run test:pinpoint-guardrails`
- `cd worker && npm run typecheck`
- `cd worker && npx wrangler deploy --env staging --name pinpoint-worker-staging`
- staging endpoint deployed; unauthenticated/wrong-secret call returns `unauthorized` as expected

## Notes

Production defaults remain disabled:

- `PINPOINT_RELEASE_QUEUE_ENABLED=false`
- `PINPOINT_CANDIDATE_BRANCH_ENABLED=false`
