### PR TITLE
[codex] Add release queue dry-run ops script

### DIFF
--- a/docs/content-quality-release-gate-pr5c-queue-integration-2026-05-22.md
+++ b/docs/content-quality-release-gate-pr5c-queue-integration-2026-05-22.md
@@ -63,6 +63,15 @@ Use the admin-only, read-only simulation endpoint instead:
 curl -X POST "https://pinpoint-worker-staging.<account>.workers.dev/admin/release-queue-dry-run?secret=<admin-secret>&simulatePrimary=1&releaseQueueEnabled=1&date=2026-05-22&puzzleNumber=752&deploymentState=queued"
 ```
 
+For the full repeatable matrix, prefer the repo script:
+
+```bash
+ADMIN_SECRET=<staging-worker-admin-secret> \
+  npm run worker:release-queue-dry-run -- --date 2026-05-22 --puzzle-number 752
+```
+
+The script intentionally reads the secret only from environment variables or local ignored env files; it never writes the secret to the repository.
+
 Expected behavior:
 
 - `readOnly=true`

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "validate:data": "tsx scripts/validate-data.ts",
     "worker:preflight": "node scripts/worker-ops.mjs preflight --env prod",
     "worker:health": "node scripts/worker-ops.mjs health --env prod",
+    "worker:release-queue-dry-run": "node scripts/worker-ops.mjs release-queue-dry-run --env staging",
     "worker:refresh-cookie": "node scripts/worker-ops.mjs refresh-cookie --targets all",
     "visual:detail": "node scripts/capture-detail-screenshots.mjs",
     "visual:pinpoint-smoke": "node scripts/check-pinpoint-visibility-smoke.mjs",

--- a/scripts/check-pinpoint-guardrails.ts
+++ b/scripts/check-pinpoint-guardrails.ts
@@ -2573,6 +2573,44 @@ async function checkReleaseQueueDryRunRouteSafety() {
   console.log("ok: release queue dry-run route is admin-gated and read-only");
 }
 
+async function checkReleaseQueueDryRunOpsScript() {
+  const opsSource = await readFile(resolve(ROOT, "scripts/worker-ops.mjs"), "utf8");
+  const packageJson = JSON.parse(await readFile(resolve(ROOT, "package.json"), "utf8")) as {
+    scripts?: Record<string, string>;
+  };
+
+  assert.ok(
+    packageJson.scripts?.["worker:release-queue-dry-run"]?.includes("release-queue-dry-run"),
+    "package.json must expose the release queue dry-run matrix script",
+  );
+  assert.ok(
+    opsSource.includes('cmd === "release-queue-dry-run"') &&
+      opsSource.includes("/admin/release-queue-dry-run"),
+    "worker ops script must call the release queue dry-run endpoint",
+  );
+  assert.ok(
+    opsSource.includes("simulatePrimary") &&
+      opsSource.includes("releaseQueueEnabled") &&
+      opsSource.includes("queueEligible"),
+    "worker ops script must simulate the primary queue path without changing Worker config",
+  );
+  for (const expectedReason of [
+    "production-deployment-queued",
+    "production-deployment-building",
+    "production-deployment-unknown",
+    "production-deployment-failed",
+    "production-push-budget-exhausted",
+    "production-push-allowed",
+  ]) {
+    assert.ok(
+      opsSource.includes(expectedReason),
+      `worker ops release queue matrix must cover ${expectedReason}`,
+    );
+  }
+
+  console.log("ok: worker ops exposes release queue dry-run matrix");
+}
+
 async function checkReleaseQueueWorkerIntegration() {
   const workerModulePath = "../worker/src/index.ts";
   const workerModule = (await import(workerModulePath)) as {
@@ -2655,6 +2693,7 @@ async function main() {
   checkReleaseQueuePolicy();
   await checkCandidateBranchDryRunRouteSafety();
   await checkReleaseQueueDryRunRouteSafety();
+  await checkReleaseQueueDryRunOpsScript();
   await checkReleaseQueueWorkerIntegration();
   console.log("Pinpoint guardrail regression passed.");
 }

--- a/scripts/worker-ops.mjs
+++ b/scripts/worker-ops.mjs
@@ -66,6 +66,7 @@ function printUsage() {
   console.log(`Usage:
   node scripts/worker-ops.mjs preflight [--env prod|staging|shadow] [--date YYYY-MM-DD]
   node scripts/worker-ops.mjs health    [--env prod|staging|shadow]
+  node scripts/worker-ops.mjs release-queue-dry-run [--env staging|shadow|prod] [--date YYYY-MM-DD] [--puzzle-number N]
   node scripts/worker-ops.mjs refresh-cookie [--targets prod,staging,shadow|all]
 `);
 }
@@ -119,7 +120,8 @@ function resolveProxyUrl() {
   return "";
 }
 
-function fetchJsonViaCurl(url, proxyUrl) {
+function fetchJsonViaCurl(url, proxyUrl, options = {}) {
+  const method = String(options.method || "GET").toUpperCase();
   const args = [
     "-sS",
     "-L",
@@ -131,6 +133,7 @@ function fetchJsonViaCurl(url, proxyUrl) {
     `user-agent: ${USER_AGENT}`,
     "-H",
     "accept: application/json",
+    ...(method !== "GET" ? ["-X", method] : []),
     "--write-out",
     "\n__STATUS__:%{http_code}",
     url,
@@ -162,13 +165,14 @@ function fetchJsonViaCurl(url, proxyUrl) {
   return { ok: status >= 200 && status < 300, status, json, text };
 }
 
-async function fetchJson(url) {
+async function fetchJson(url, options = {}) {
   const proxyUrl = resolveProxyUrl();
   if (proxyUrl) {
-    return fetchJsonViaCurl(url, proxyUrl);
+    return fetchJsonViaCurl(url, proxyUrl, options);
   }
 
   const res = await fetch(url, {
+    method: options.method || "GET",
     headers: {
       "user-agent": USER_AGENT,
       accept: "application/json",
@@ -182,6 +186,56 @@ async function fetchJson(url) {
     json = null;
   }
   return { ok: res.ok, status: res.status, json, text };
+}
+
+function getReleaseQueueDryRunScenarios(nowIso) {
+  return [
+    {
+      name: "queued",
+      params: { deploymentState: "queued" },
+      expectedAction: "write-candidate",
+      expectedReasonCode: "production-deployment-queued",
+    },
+    {
+      name: "building",
+      params: { deploymentState: "building" },
+      expectedAction: "write-candidate",
+      expectedReasonCode: "production-deployment-building",
+    },
+    {
+      name: "unknown",
+      params: { deploymentState: "unknown" },
+      expectedAction: "write-candidate",
+      expectedReasonCode: "production-deployment-unknown",
+    },
+    {
+      name: "failed",
+      params: { deploymentState: "failed" },
+      expectedAction: "hold-review",
+      expectedReasonCode: "production-deployment-failed",
+    },
+    {
+      name: "same-slug-budget",
+      params: {
+        deploymentState: "ready",
+        lastProductionPushAt: nowIso,
+        now: nowIso,
+      },
+      expectedAction: "write-candidate",
+      expectedReasonCode: "production-push-budget-exhausted",
+    },
+    {
+      name: "override-second-push",
+      params: {
+        deploymentState: "ready",
+        lastProductionPushAt: nowIso,
+        now: nowIso,
+        overrideSecondProductionPush: "1",
+      },
+      expectedAction: "push-production",
+      expectedReasonCode: "production-push-allowed",
+    },
+  ];
 }
 
 function extractEdgeCookie() {
@@ -303,6 +357,62 @@ async function main() {
     console.log(
       `[${envName}] puzzleDate=${puzzleDate} source=${source} fetchedAt=${fetchedAt ?? ""} words=${words} mainAnswer=${mainAnswer ?? ""}`,
     );
+    return;
+  }
+
+  if (cmd === "release-queue-dry-run") {
+    const envName = normalizeEnvName(getOption(argv, "--env") || "staging");
+    const date = getOption(argv, "--date") || new Date().toISOString().slice(0, 10);
+    const puzzleNumber = getOption(argv, "--puzzle-number") || getOption(argv, "--puzzleNumber");
+    const secret = requireAdminSecret();
+    const baseUrl = WORKER_BASE_URLS[envName];
+    const nowIso = new Date().toISOString();
+    const scenarios = getReleaseQueueDryRunScenarios(nowIso);
+
+    for (const scenario of scenarios) {
+      const url = new URL(`${baseUrl}/admin/release-queue-dry-run`);
+      url.searchParams.set("secret", secret);
+      url.searchParams.set("simulatePrimary", "1");
+      url.searchParams.set("releaseQueueEnabled", "1");
+      url.searchParams.set("date", date);
+      if (puzzleNumber) url.searchParams.set("puzzleNumber", puzzleNumber);
+      for (const [key, value] of Object.entries(scenario.params)) {
+        url.searchParams.set(key, String(value));
+      }
+
+      const { ok, status, json, text } = await fetchJson(url.toString(), { method: "POST" });
+      if (!ok) {
+        console.error(`[${envName}] release queue dry-run ${scenario.name} failed: HTTP ${status}`);
+        console.error(String(text || "").slice(0, 500));
+        process.exit(1);
+      }
+
+      const action = json?.decision?.action;
+      const reasonCode = json?.decision?.reasonCode;
+      if (
+        json?.ok !== true ||
+        json?.readOnly !== true ||
+        json?.queueEligible !== true ||
+        action !== scenario.expectedAction ||
+        reasonCode !== scenario.expectedReasonCode
+      ) {
+        console.error(`[${envName}] release queue dry-run ${scenario.name} returned unexpected decision`);
+        console.error(JSON.stringify({
+          ok: json?.ok,
+          readOnly: json?.readOnly,
+          queueEligible: json?.queueEligible,
+          action,
+          reasonCode,
+          expectedAction: scenario.expectedAction,
+          expectedReasonCode: scenario.expectedReasonCode,
+        }, null, 2));
+        process.exit(1);
+      }
+
+      console.log(`[${envName}] ${scenario.name} ok action=${action} reason=${reasonCode}`);
+    }
+
+    console.log(`[${envName}] release queue dry-run matrix passed (${scenarios.length} scenarios)`);
     return;
   }
 


### PR DESCRIPTION
## Summary

- add `npm run worker:release-queue-dry-run` for repeatable staging release queue simulation
- extend `scripts/worker-ops.mjs` to POST to `/admin/release-queue-dry-run` with `simulatePrimary=1` and `releaseQueueEnabled=1`
- validate six decisions: queued, building, unknown, failed, same-slug production-push budget, and explicit second-push override
- add guardrail coverage so the ops script stays wired to the read-only endpoint and scenario matrix
- update the PR5C runbook with the preferred command

## Verification

- `node --check scripts/worker-ops.mjs`
- `npm run validate:data`
- `npm run test:pinpoint-guardrails`

## Notes

The script intentionally requires `ADMIN_SECRET` or `ADMIN_PASSPHRASE` from the operator environment/local ignored env files. Cloudflare secrets cannot be read back, so the live staging matrix still needs the actual staging Worker `ADMIN_SECRET` supplied at runtime.
