### PR TITLE
[codex] Add release queue production observation

### DIFF
--- a/docs/content-quality-release-gate-pr5d-production-enable-2026-05-22.md
+++ b/docs/content-quality-release-gate-pr5d-production-enable-2026-05-22.md
@@ -38,6 +38,23 @@ With the flag enabled:
 - a second same-slug production push inside the 60-minute window writes candidate unless `PINPOINT_RELEASE_QUEUE_OVERRIDE_SECOND_PUSH=true`
 - candidate branches are not auto-promoted
 
+## First-Run Observation
+
+Use the production observation command after each cron window until the first real publish has been reviewed:
+
+```bash
+npm run worker:release-queue-observe -- --date 2026-05-23
+```
+
+The command checks:
+
+- production Worker `/health`
+- latest GitHub `main` commit
+- combined commit status and Vercel status
+- candidate branches matching the observation date or slug
+
+If a same-day candidate branch appears, inspect it before merging or promoting it. If no candidate branch appears and the Worker produced a single healthy production commit, the first-run observation can be marked complete.
+
 ## Rollback
 
 If production publishing is unexpectedly held or routed to candidate:

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "worker:preflight": "node scripts/worker-ops.mjs preflight --env prod",
     "worker:health": "node scripts/worker-ops.mjs health --env prod",
     "worker:release-queue-dry-run": "node scripts/worker-ops.mjs release-queue-dry-run --env staging",
+    "worker:release-queue-observe": "node scripts/worker-ops.mjs release-queue-observe --env prod",
     "worker:refresh-cookie": "node scripts/worker-ops.mjs refresh-cookie --targets all",
     "visual:detail": "node scripts/capture-detail-screenshots.mjs",
     "visual:pinpoint-smoke": "node scripts/check-pinpoint-visibility-smoke.mjs",

--- a/scripts/check-pinpoint-guardrails.ts
+++ b/scripts/check-pinpoint-guardrails.ts
@@ -22,6 +22,7 @@ import { decidePinpointReleaseQueueAction } from "../lib/puzzles/release-queue-p
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(SCRIPT_DIR, "..");
+const CANDIDATE_BRANCH_PREFIX = "pinpoint/candidate/";
 const GUARDRAIL_ADMIN_TOKEN = process.env.DEV_ADMIN_TOKEN || "guardrail-local-admin-token";
 process.env.DEV_ADMIN_TOKEN = GUARDRAIL_ADMIN_TOKEN;
 
@@ -2611,6 +2612,35 @@ async function checkReleaseQueueDryRunOpsScript() {
   console.log("ok: worker ops exposes release queue dry-run matrix");
 }
 
+async function checkReleaseQueueObservationOpsScript() {
+  const opsSource = await readFile(resolve(ROOT, "scripts/worker-ops.mjs"), "utf8");
+  const packageJson = JSON.parse(await readFile(resolve(ROOT, "package.json"), "utf8")) as {
+    scripts?: Record<string, string>;
+  };
+
+  assert.ok(
+    packageJson.scripts?.["worker:release-queue-observe"]?.includes("release-queue-observe"),
+    "package.json must expose the production release queue observation script",
+  );
+  assert.ok(
+    opsSource.includes('cmd === "release-queue-observe"') &&
+      opsSource.includes("/health") &&
+      opsSource.includes("commits/main") &&
+      opsSource.includes(CANDIDATE_BRANCH_PREFIX),
+    "worker ops observation must check Worker health, main commit status, and candidate branches",
+  );
+  assert.ok(
+    !opsSource.includes('cmd === "release-queue-observe"') ||
+      !opsSource.slice(
+        opsSource.indexOf('cmd === "release-queue-observe"'),
+        opsSource.indexOf('cmd === "refresh-cookie"'),
+      ).includes("requireAdminSecret()"),
+    "release queue observation must not require admin secrets",
+  );
+
+  console.log("ok: worker ops exposes production release queue observation");
+}
+
 async function checkReleaseQueueWorkerIntegration() {
   const workerModulePath = "../worker/src/index.ts";
   const workerModule = (await import(workerModulePath)) as {
@@ -2694,6 +2724,7 @@ async function main() {
   await checkCandidateBranchDryRunRouteSafety();
   await checkReleaseQueueDryRunRouteSafety();
   await checkReleaseQueueDryRunOpsScript();
+  await checkReleaseQueueObservationOpsScript();
   await checkReleaseQueueWorkerIntegration();
   console.log("Pinpoint guardrail regression passed.");
 }

--- a/scripts/worker-ops.mjs
+++ b/scripts/worker-ops.mjs
@@ -19,6 +19,8 @@ const WORKER_BASE_URLS = {
   shadow: "https://pinpoint-worker-shadow.2296744453m.workers.dev",
 };
 
+const GITHUB_REPO = "elng12/pinpoint-answer-today-new";
+const CANDIDATE_BRANCH_PREFIX = "pinpoint/candidate/";
 const USER_AGENT = "curl/8.0 (pinpoint-worker-ops)";
 
 function loadEnvFile(filePath) {
@@ -67,6 +69,7 @@ function printUsage() {
   node scripts/worker-ops.mjs preflight [--env prod|staging|shadow] [--date YYYY-MM-DD]
   node scripts/worker-ops.mjs health    [--env prod|staging|shadow]
   node scripts/worker-ops.mjs release-queue-dry-run [--env staging|shadow|prod] [--date YYYY-MM-DD] [--puzzle-number N]
+  node scripts/worker-ops.mjs release-queue-observe [--env prod|staging|shadow] [--date YYYY-MM-DD] [--puzzle-number N] [--json]
   node scripts/worker-ops.mjs refresh-cookie [--targets prod,staging,shadow|all]
 `);
 }
@@ -186,6 +189,41 @@ async function fetchJson(url, options = {}) {
     json = null;
   }
   return { ok: res.ok, status: res.status, json, text };
+}
+
+function runCommand(command, args) {
+  const result = spawnSync(command, args, {
+    cwd: ROOT,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.status !== 0) {
+    const detail = String(result.stderr || result.stdout || `${command} failed`).trim();
+    throw new Error(`${command} ${args.join(" ")} failed: ${detail}`);
+  }
+  return String(result.stdout || "").trim();
+}
+
+function ghJson(pathname) {
+  const raw = runCommand("gh", ["api", pathname]);
+  return JSON.parse(raw);
+}
+
+function listGitHubBranchNames(repo) {
+  const raw = runCommand("gh", ["api", "--paginate", `repos/${repo}/branches?per_page=100`, "--jq", ".[].name"]);
+  return raw
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function formatShortSha(sha) {
+  return String(sha || "").slice(0, 7);
+}
+
+function resolveVercelCommitStatus(statusJson) {
+  const statuses = Array.isArray(statusJson?.statuses) ? statusJson.statuses : [];
+  return statuses.find((item) => String(item?.context || "").trim().toLowerCase() === "vercel") || null;
 }
 
 function getReleaseQueueDryRunScenarios(nowIso) {
@@ -413,6 +451,100 @@ async function main() {
     }
 
     console.log(`[${envName}] release queue dry-run matrix passed (${scenarios.length} scenarios)`);
+    return;
+  }
+
+  if (cmd === "release-queue-observe") {
+    const envName = normalizeEnvName(getOption(argv, "--env") || "prod");
+    const emitJson = argv.includes("--json");
+    const requestedDate = getOption(argv, "--date");
+    const requestedPuzzleNumber = getOption(argv, "--puzzle-number") || getOption(argv, "--puzzleNumber");
+    const requestedSlug = getOption(argv, "--slug");
+    const baseUrl = WORKER_BASE_URLS[envName];
+
+    const healthResult = await fetchJson(`${baseUrl}/health`);
+    if (!healthResult.ok) {
+      console.error(`[${envName}] health failed: HTTP ${healthResult.status}`);
+      console.error(String(healthResult.text || "").slice(0, 500));
+      process.exit(1);
+    }
+
+    const health = healthResult.json || {};
+    const observationDate = requestedDate || health.puzzleDate || new Date().toISOString().slice(0, 10);
+    const slug = requestedSlug || (requestedPuzzleNumber ? `pinpoint-answer-${requestedPuzzleNumber}` : "");
+    const mainCommit = ghJson(`repos/${GITHUB_REPO}/commits/main`);
+    const mainSha = String(mainCommit?.sha || "");
+    const statusJson = ghJson(`repos/${GITHUB_REPO}/commits/${mainSha}/status`);
+    const vercelStatus = resolveVercelCommitStatus(statusJson);
+    const candidateBranches = listGitHubBranchNames(GITHUB_REPO)
+      .filter((name) => name.startsWith(CANDIDATE_BRANCH_PREFIX));
+    const matchingCandidates = candidateBranches.filter((name) => {
+      if (slug) return name.includes(`${observationDate}-${slug}`);
+      return name.includes(observationDate);
+    });
+
+    const report = {
+      env: envName,
+      checkedAt: new Date().toISOString(),
+      worker: {
+        baseUrl,
+        healthOk: true,
+        puzzleDate: health.puzzleDate || null,
+        source: health.source || null,
+        fetchedAt: health.fetchedAt || null,
+        mainAnswer: health.mainAnswer || health.theme || null,
+        words: Array.isArray(health.answers)
+          ? health.answers
+              .map((item) => String(item?.word || "").trim())
+              .filter(Boolean)
+              .slice(0, 5)
+          : [],
+      },
+      github: {
+        repo: GITHUB_REPO,
+        mainSha,
+        mainShortSha: formatShortSha(mainSha),
+        mainCommitDate: mainCommit?.commit?.author?.date || null,
+        mainCommitTitle: String(mainCommit?.commit?.message || "").split(/\r?\n/)[0] || null,
+      },
+      deploymentStatus: {
+        combinedState: statusJson?.state || "unknown",
+        vercelState: vercelStatus?.state || "missing",
+        vercelDescription: vercelStatus?.description || "",
+        vercelTargetUrl: vercelStatus?.target_url || "",
+      },
+      releaseQueue: {
+        observationDate,
+        slug: slug || null,
+        candidateBranchCount: candidateBranches.length,
+        matchingCandidateBranches: matchingCandidates,
+      },
+    };
+
+    if (emitJson) {
+      console.log(JSON.stringify(report, null, 2));
+      return;
+    }
+
+    console.log(`[${envName}] release queue observation`);
+    console.log(
+      `worker health: puzzleDate=${report.worker.puzzleDate ?? ""} source=${report.worker.source ?? ""} mainAnswer=${report.worker.mainAnswer ?? ""}`,
+    );
+    console.log(
+      `main: ${report.github.mainShortSha} status=${report.deploymentStatus.combinedState} vercel=${report.deploymentStatus.vercelState} title=${report.github.mainCommitTitle ?? ""}`,
+    );
+    if (report.deploymentStatus.vercelDescription) {
+      console.log(`vercel: ${report.deploymentStatus.vercelDescription}`);
+    }
+    console.log(
+      `candidates: total=${report.releaseQueue.candidateBranchCount} matching=${report.releaseQueue.matchingCandidateBranches.length}`,
+    );
+    for (const branch of report.releaseQueue.matchingCandidateBranches.slice(0, 10)) {
+      console.log(`- ${branch}`);
+    }
+    if (report.releaseQueue.matchingCandidateBranches.length > 10) {
+      console.log(`- ... ${report.releaseQueue.matchingCandidateBranches.length - 10} more`);
+    }
     return;
   }
 


### PR DESCRIPTION
## Summary

- add `npm run worker:release-queue-observe` for production release queue observation
- report production Worker `/health`, latest GitHub `main` commit, combined/Vercel status, and matching candidate branches
- add guardrail coverage so the observation command stays wired and does not require admin secrets
- document first-run observation in the PR5D production enablement runbook

## First observation

Ran:

```bash
npm run worker:release-queue-observe -- --date 2026-05-22 --puzzle-number 752
```

Result:

- production Worker health OK: `puzzleDate=2026-05-22`, `source=playwright`
- latest main commit: `4769629`, Vercel status success
- candidate branches total: 1
- matching candidate branch for `2026-05-22` + `pinpoint-answer-752`: 0

The single existing candidate branch is from the earlier staging dry-run puzzle (`pinpoint-answer-900752`), not the production #752 slug.

## Verification

- `node --check scripts/worker-ops.mjs`
- `npm run validate:data`
- `npm run test:pinpoint-guardrails`
