### PR TITLE
Fix Pinpoint Worker final publish commits

### DIFF
--- a/scripts/check-pinpoint-guardrails.ts
+++ b/scripts/check-pinpoint-guardrails.ts
@@ -31,6 +31,7 @@ type RegistryEntry = {
   slug: string;
   publishDate: string;
   status: string;
+  detailState?: string;
 };
 
 function addUtcDays(isoDate: string, days: number): string {
@@ -42,8 +43,12 @@ function addUtcDays(isoDate: string, days: number): string {
 async function readLiveRegistryEntry(): Promise<RegistryEntry> {
   const raw = await readFile(resolve(ROOT, "data", "puzzles", "registry.json"), "utf8");
   const registry = JSON.parse(raw) as RegistryEntry[];
-  const liveEntry = registry.find((entry) => entry.status === "live");
-  assert.ok(liveEntry, "registry.json must contain one live puzzle");
+  const liveEntry = registry.find((entry) => {
+    if (entry.status !== "live" && entry.status !== "archived") return false;
+    const detailState = entry.detailState || "published";
+    return detailState === "published" || detailState === "fallback_full";
+  });
+  assert.ok(liveEntry, "registry.json must contain one public puzzle");
   return liveEntry;
 }
 
@@ -225,8 +230,8 @@ async function checkPublishedSummaryRoute() {
       );
       assert.equal(
         payload.latest?.status,
-        "live",
-        "summary route should keep the published live status",
+        liveEntry.status,
+        "summary route should expose the published registry status",
       );
     },
   );
@@ -2426,6 +2431,34 @@ function checkIntermediateStateCommitDetection() {
   console.log("ok: intermediate-state commit detector skips only non-public state-only updates");
 }
 
+async function checkWorkerEnrichCommitsOnlyFinalPublicPayload() {
+  const workerSource = await readFile(resolve(ROOT, "worker/src/index.ts"), "utf8");
+  const start = workerSource.indexOf("async function enrichPublishToSite(");
+  const end = workerSource.indexOf("async function localizePublishOne(");
+  assert.ok(start >= 0 && end > start, "worker enrich publish function should be present");
+
+  const enrichSource = workerSource.slice(start, end);
+  const githubPublishCalls = Array.from(enrichSource.matchAll(/publishToNewSiteGitHub\(/g));
+  assert.equal(
+    githubPublishCalls.length,
+    1,
+    "worker enrich path should write GitHub only once, after the final public payload is ready",
+  );
+  assert.ok(
+    enrichSource.includes('await options.onDetailStateChange?.("generating")') &&
+      enrichSource.includes('await options.onDetailStateChange?.("validated")'),
+    "worker enrich path should keep generating and validated progress in heartbeat state",
+  );
+  assert.ok(
+    !enrichSource.includes("generatingPayload") &&
+      !enrichSource.includes("validatedPayload") &&
+      !enrichSource.includes("failedPayload"),
+    "worker enrich path must not build GitHub payloads for non-public intermediate states",
+  );
+
+  console.log("ok: worker enrich writes only final public payloads to GitHub");
+}
+
 function checkReleaseQueuePolicy() {
   const baseInput = {
     slug: "pinpoint-answer-752",
@@ -2720,6 +2753,7 @@ async function main() {
   await checkPinpointEvidenceV1Guards724Mapping();
   checkReleaseOverrideDryRunSchema();
   checkIntermediateStateCommitDetection();
+  await checkWorkerEnrichCommitsOnlyFinalPublicPayload();
   checkReleaseQueuePolicy();
   await checkCandidateBranchDryRunRouteSafety();
   await checkReleaseQueueDryRunRouteSafety();

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -3201,20 +3201,6 @@ function isPrimaryNewSiteBranch(branch: string): boolean {
   return branch.trim() === "main";
 }
 
-function buildNewSiteStatusPayload(
-  siteBaseUrl: string,
-  puzzleDate: string,
-  doc: Doc,
-  puzzleNumber: number,
-  words: string[],
-  detailState: PublishDetailState,
-): JsonRecord {
-  return {
-    ...createQuickPayload(siteBaseUrl, puzzleDate, doc, puzzleNumber, words),
-    detailState,
-  };
-}
-
 function isSuccessfulEnrichResult(
   result: EnrichPublishResult,
 ): result is EnrichPublishResult & {
@@ -4100,30 +4086,9 @@ async function enrichPublishToSite(
   const enrichModel = selectModel(env.AUTO_ENRICH_MODEL, "google/gemini-2.0-flash-001");
   const retryModel = selectModel(env.AUTO_ENRICH_RETRY_MODEL, enrichModel);
   const draftAttempts = parseAttemptCount(env.AUTO_ENRICH_DRAFT_ATTEMPTS, 2, 3);
-  const generatingPayload = buildNewSiteStatusPayload(
-    siteBaseUrl,
-    puzzleDate,
-    doc,
-    puzzleNumber,
-    words,
-    "generating",
-  );
-  const failedPayload = buildNewSiteStatusPayload(
-    siteBaseUrl,
-    puzzleDate,
-    doc,
-    puzzleNumber,
-    words,
-    "failed",
-  );
 
   try {
-    try {
-      await publishToNewSiteGitHub(env, puzzleDate, doc, generatingPayload, puzzleNumber);
-      await options.onDetailStateChange?.("generating");
-    } catch (statusError) {
-      console.warn("[new-site] generating state publish failed (non-fatal):", statusError);
-    }
+    await options.onDetailStateChange?.("generating");
 
     const llmApiKey = String(env.LLM_API_KEY || "").trim();
     const llmBaseUrl = String(env.LLM_BASE_URL || "").trim();
@@ -4347,16 +4312,7 @@ async function enrichPublishToSite(
     };
 
     if (publishDetailState === "published") {
-      const validatedPayload: JsonRecord = {
-        ...enrichedPayload,
-        detailState: "validated",
-      };
-      try {
-        await publishToNewSiteGitHub(env, puzzleDate, doc, validatedPayload, puzzleNumber);
-        await options.onDetailStateChange?.("validated");
-      } catch (statusError) {
-        console.warn("[new-site] validated state publish failed (non-fatal):", statusError);
-      }
+      await options.onDetailStateChange?.("validated");
     }
 
     await publishToNewSiteGitHub(env, puzzleDate, doc, enrichedPayload, puzzleNumber);
@@ -4377,15 +4333,10 @@ async function enrichPublishToSite(
       await options.onDetailStateChange?.("failed", error.message);
       throw error;
     }
-    try {
-      await publishToNewSiteGitHub(env, puzzleDate, doc, failedPayload, puzzleNumber);
-      await options.onDetailStateChange?.(
-        "failed",
-        error instanceof Error ? error.message : String(error),
-      );
-    } catch (statusError) {
-      console.warn("[new-site] failed state publish failed (non-fatal):", statusError);
-    }
+    await options.onDetailStateChange?.(
+      "failed",
+      error instanceof Error ? error.message : String(error),
+    );
     throw error;
   } finally {
     await env.PP_DATA.delete(runningKey);


### PR DESCRIPTION
## Summary
- stop committing `generating`, `validated`, and `failed` intermediate detail states from the Worker enrich path
- keep intermediate progress in heartbeat/KV via `onDetailStateChange`
- add a guardrail that the enrich path only calls GitHub once for the final public payload
- make the summary guardrail pick the latest public registry entry when a newer live entry is still non-public

## Validation
- npm run test:pinpoint-guardrails
- npm run typecheck

## Production issue addressed
Today #753 reached `validated` but stayed invisible because the Worker ran out of subrequests before the final public publish. This prevents that half-published state from being committed to main again.