### PR TITLE
Avoid duplicate Pinpoint GitHub publishes

### DIFF
--- a/scripts/check-pinpoint-guardrails.ts
+++ b/scripts/check-pinpoint-guardrails.ts
@@ -2455,6 +2455,10 @@ async function checkWorkerEnrichCommitsOnlyFinalPublicPayload() {
       !enrichSource.includes("failedPayload"),
     "worker enrich path must not build GitHub payloads for non-public intermediate states",
   );
+  assert.ok(
+    !workerSource.includes("publishToNewSiteGitHub(env, date, doc, enrichResult.payload"),
+    "manual and scheduled callers must not duplicate the final GitHub publish already handled by enrichPublishToSite",
+  );
 
   console.log("ok: worker enrich writes only final public payloads to GitHub");
 }

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -6218,15 +6218,6 @@ export default {
             );
             await persistCronHeartbeat(env, manualHeartbeat);
 
-            // Publish to new site (non-blocking, failures don't affect old site)
-            if (isSuccessfulEnrichResult(enrichResult)) {
-              try {
-                await publishToNewSiteGitHub(env, date, doc, enrichResult.payload, puzzleNumber);
-              } catch (newSiteErr) {
-                console.warn("[new-site] publish failed (non-fatal):", newSiteErr);
-              }
-            }
-
             let payloadForI18n = enrichResult.payload ?? null;
             if (
               !payloadForI18n &&
@@ -6745,19 +6736,6 @@ export default {
                 if (isSuccessfulEnrichResult(enrichResult)) {
                   heartbeat.enrich = stampHeartbeatStage(heartbeat.enrich, "published");
                   await persistCronHeartbeat(env, heartbeat);
-                  try {
-                    await publishToNewSiteGitHub(env, date, doc, enrichResult.payload, puzzleNumber);
-                  } catch (newSiteErr) {
-                    const newSiteMsg = newSiteErr instanceof Error ? newSiteErr.message : String(newSiteErr);
-                    console.warn("[new-site] publish failed (non-fatal):", newSiteMsg);
-                    await notifyCron(env, "⚠️ 新站结构化发布异常", [
-                      `日期: ${date}`,
-                      `谜题: #${puzzleNumber}`,
-                      `详情: ${detailUrl}`,
-                      `原因: ${toZhWebhookReason(newSiteMsg)}`,
-                      "说明: 英文站增强已成功，但新站结构化落库阶段没有正常完成。",
-                    ]);
-                  }
                 } else {
                   heartbeat.enrich = stampHeartbeatStage(
                     heartbeat.enrich,


### PR DESCRIPTION
## Summary
- remove the extra outer GitHub publish from manual `/admin/run`
- remove the extra outer GitHub publish from scheduled cron
- keep `enrichPublishToSite()` as the single owner of the final public write
- extend the guardrail so callers cannot duplicate the final publish again

## Validation
- npm run test:pinpoint-guardrails
- npm run typecheck

## Why
PR #54 stopped non-public intermediate commits, but the outer manual/scheduled flow still made a second final GitHub publish attempt after enrich. That still wastes Cloudflare subrequests. This removes that duplicate call.