### PR TITLE
Publish Pinpoint #753

### DIFF
--- a/data/puzzles/pinpoint-answer-753.json
+++ b/data/puzzles/pinpoint-answer-753.json
@@ -3,7 +3,7 @@
   "slug": "pinpoint-answer-753",
   "publishDate": "2026-05-23",
   "isoDate": "2026-05-23",
-  "detailState": "validated",
+  "detailState": "published",
   "bodyMode": "standard",
   "pageExperienceMode": "full-analysis",
   "questionType": "category",

--- a/data/puzzles/registry.json
+++ b/data/puzzles/registry.json
@@ -4,7 +4,7 @@
     "slug": "pinpoint-answer-753",
     "publishDate": "2026-05-23",
     "status": "live",
-    "detailState": "validated",
+    "detailState": "published",
     "clues": [
       "Titan",
       "Triton",
@@ -16,7 +16,7 @@
     "category": "Moons in our solar system",
     "difficultyLevel": "Moderate",
     "shortSummary": "At first glance, Titan, Triton, Phobos do not look like one clean set. The solve only tightens once a later clue makes the shared category much harder to miss.",
-    "updatedAt": "2026-05-23T07:26:17.869Z"
+    "updatedAt": "2026-05-23T07:32:30.000Z"
   },
   {
     "puzzleNumber": 752,


### PR DESCRIPTION
## Summary
- switch `pinpoint-answer-753` detailState from `validated` to `published`
- switch the registry entry to `published` and refresh `updatedAt`

## Validation
- npm run validate:data
- npm run test:pinpoint-guardrails

## Why
The Worker produced complete full-analysis content for #753, but the final public switch was blocked by Worker subrequest limits before the Worker fixes landed. This PR makes today’s page visible while the Worker code fix prevents the same half-published state going forward.