### PR TITLE
Add PR6B full-analysis structure validation

### DIFF
--- a/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
+++ b/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
@@ -699,6 +699,7 @@ Not all issue codes are implemented in PR6. Implementation ownership is defined 
 | `CANDIDATE_L1_MISMATCH` | P0 | `block_publish` |
 | `MISSING_CLUE_ROW` | P0 | `downgrade_to_answer_first` or `block_publish` |
 | `DUPLICATE_CLUE_ROW` | P0 | `block_publish` |
+| `MISSING_EVIDENCE_REF` | P0 | `downgrade_to_answer_first` or `requires_review` |
 | `FULL_ANALYSIS_STRUCTURE_NOT_VALIDATED` | P1 | `requires_review` |
 | `UNSUPPORTED_CLUE_FIT` | P0 | `requires_review` or `downgrade_to_answer_first` |
 | `WEAK_FIT_EVIDENCE` | P1 | `requires_review` or `downgrade_to_answer_first` |
@@ -724,6 +725,7 @@ Not all issue codes are implemented in PR6. Implementation ownership is defined 
 | `DATE_MODIFIED_MISMATCH` | P1 | repair or `requires_review` |
 | `SCHEMA_MODE_MISMATCH` | P1 | repair or `requires_review` |
 | `FAQ_SCHEMA_WITHOUT_VISIBLE_FAQ` | P0 | `block_publish` |
+| `INVALID_FAQ_STRUCTURE` | P1 | repair or `downgrade_to_answer_first` |
 | `DUPLICATE_TITLE_META` | P1 | repair or `requires_review` |
 | `ARCHIVE_LINK_MISSING` | P1 | repair or `requires_review` |
 | `RECENT_LINK_POINTS_TO_NOINDEX` | P1 | repair or `requires_review` |
@@ -1530,10 +1532,13 @@ PR6B issue-code mapping:
 | clue row missing | `MISSING_CLUE_ROW` |
 | duplicate clue row | `DUPLICATE_CLUE_ROW` |
 | clue row points to unknown clue id | `MISSING_CLUE_ROW` |
+| clue row is missing evidence refs | `MISSING_EVIDENCE_REF` |
 | reasoning missing | `MISSING_REASONING_PATTERN` |
 | reasoning pattern unsupported | `UNSUPPORTED_REASONING_PATTERN` |
 | reasoning text generic | `GENERIC_REASONING_PATTERN` |
 | FAQ schema present but visible FAQ missing | `FAQ_SCHEMA_WITHOUT_VISIBLE_FAQ` |
+| FAQ item count invalid | `INVALID_FAQ_STRUCTURE` |
+| internal link is not route-shaped | `INTERNAL_LINK_BROKEN` |
 | internal link target missing from provided route index | `INTERNAL_LINK_BROKEN` |
 
 PR6B fixture plan:
@@ -1850,9 +1855,9 @@ Defer:
 
 | Phase | Issue codes |
 | --- | --- |
-| PR6A/PR6B P0 | `MISSING_L1_INPUT`, `INVALID_L1_INPUT`, `INVALID_CANDIDATE_METADATA`, `CANDIDATE_L1_MISMATCH`, `MISSING_CLUE_ROW`, `DUPLICATE_CLUE_ROW`, `ANSWER_HIDDEN_FROM_RENDERED_HTML`, `MISSING_REASONING_PATTERN`, `CANONICAL_URL_MISMATCH`, `FAQ_SCHEMA_WITHOUT_VISIBLE_FAQ`, `NOINDEX_REQUIRED_BUT_MISSING` |
-| PR6A/PR6B P1 | `FULL_ANALYSIS_STRUCTURE_NOT_VALIDATED` |
-| PR7/PR8 | `UNSUPPORTED_CLUE_FIT`, `WEAK_FIT_EVIDENCE`, `L4_ONLY_EVIDENCE`, `INVENTED_FALSE_START`, `UNSUPPORTED_REASONING_PATTERN`, `GENERIC_REASONING_PATTERN`, `FULL_ANALYSIS_WITH_LOW_CONFIDENCE` |
+| PR6A/PR6B P0 | `MISSING_L1_INPUT`, `INVALID_L1_INPUT`, `INVALID_CANDIDATE_METADATA`, `CANDIDATE_L1_MISMATCH`, `MISSING_CLUE_ROW`, `DUPLICATE_CLUE_ROW`, `MISSING_EVIDENCE_REF`, `ANSWER_HIDDEN_FROM_RENDERED_HTML`, `MISSING_REASONING_PATTERN`, `UNSUPPORTED_REASONING_PATTERN`, `CANONICAL_URL_MISMATCH`, `FAQ_SCHEMA_WITHOUT_VISIBLE_FAQ`, `NOINDEX_REQUIRED_BUT_MISSING` |
+| PR6A/PR6B P1 | `FULL_ANALYSIS_STRUCTURE_NOT_VALIDATED`, `GENERIC_REASONING_PATTERN`, `INVALID_FAQ_STRUCTURE`, `INTERNAL_LINK_BROKEN` |
+| PR7/PR8 | `UNSUPPORTED_CLUE_FIT`, `WEAK_FIT_EVIDENCE`, `L4_ONLY_EVIDENCE`, `INVENTED_FALSE_START`, `FULL_ANALYSIS_WITH_LOW_CONFIDENCE` |
 | PR10 | review artifact completeness and reviewer decision consistency issues |
 | PR11 | `PUBLIC_HTML_FETCH_FAILED`, `PUBLIC_HTML_RENDER_FAILED`, `SITEMAP_LASTMOD_MISSING`, `SCHEMA_DATE_MODIFIED_MISSING`, `INTERNAL_LINK_BROKEN`, `SITEMAP_POLICY_MISMATCH`, `ROBOTS_POLICY_MISMATCH`, `DATE_MODIFIED_MISMATCH`, `SCHEMA_MODE_MISMATCH` |
 

--- a/lib/puzzles/content-kitchen/fixtures/full-analysis-clue-row-text-mismatch.invalid.json
+++ b/lib/puzzles/content-kitchen/fixtures/full-analysis-clue-row-text-mismatch.invalid.json
@@ -1,5 +1,5 @@
 {
-  "name": "full-analysis-basic-identity.downgrade",
+  "name": "full-analysis-clue-row-text-mismatch.invalid",
   "input": {
     "canonicalConfig": {
       "siteBaseUrl": "https://example.com",
@@ -25,9 +25,9 @@
       "slug": "pinpoint-answer-900",
       "canonicalUrl": "https://example.com/linkedin-pinpoint-answers/pinpoint-answer-900/",
       "contentMode": "full-analysis",
-      "revisionId": "rev-full-analysis-001",
+      "revisionId": "rev-row-text-mismatch",
       "inputSnapshotHash": "__HASH_L1__",
-      "contentHash": "sha256:content-full-analysis-001",
+      "contentHash": "sha256:content-row-text-mismatch",
       "answer": "Types of guitar",
       "clues": [
         { "clueId": "clue-1", "text": "Bass", "position": 1 },
@@ -35,18 +35,18 @@
         { "clueId": "clue-3", "text": "Electric", "position": 3 },
         { "clueId": "clue-4", "text": "Acoustic", "position": 4 },
         { "clueId": "clue-5", "text": "Steel", "position": 5 }
+      ],
+      "clueRows": [
+        { "clueId": "clue-1", "clueText": "Brass", "fit": "Bass guitar", "whyItSupportsAnswer": "Bass is a guitar type.", "evidenceRefs": ["ev-bass"] },
+        { "clueId": "clue-2", "clueText": "Classical", "fit": "Classical guitar", "whyItSupportsAnswer": "Classical is a guitar type.", "evidenceRefs": ["ev-classical"] },
+        { "clueId": "clue-3", "clueText": "Electric", "fit": "Electric guitar", "whyItSupportsAnswer": "Electric is a guitar type.", "evidenceRefs": ["ev-electric"] },
+        { "clueId": "clue-4", "clueText": "Acoustic", "fit": "Acoustic guitar", "whyItSupportsAnswer": "Acoustic is a guitar type.", "evidenceRefs": ["ev-acoustic"] },
+        { "clueId": "clue-5", "clueText": "Steel", "fit": "Steel guitar", "whyItSupportsAnswer": "Steel is a guitar type.", "evidenceRefs": ["ev-steel"] }
       ]
     }
   },
   "expected": {
     "outcome": "downgrade_to_answer_first",
-    "policies": {
-      "indexPolicy": "noindex",
-      "sitemapPolicy": "exclude",
-      "schemaPolicy": "none",
-      "internalLinkPolicy": "hidden_from_recent",
-      "requiredAction": "enrich"
-    },
-    "issueCodes": ["MISSING_CLUE_ROW"]
+    "issueCodes": ["CANDIDATE_L1_MISMATCH"]
   }
 }

--- a/lib/puzzles/content-kitchen/fixtures/full-analysis-cumulative-confirmation.valid.json
+++ b/lib/puzzles/content-kitchen/fixtures/full-analysis-cumulative-confirmation.valid.json
@@ -1,0 +1,74 @@
+{
+  "name": "full-analysis-cumulative-confirmation.valid",
+  "input": {
+    "canonicalConfig": {
+      "siteBaseUrl": "https://example.com",
+      "detailRoutePrefix": "/linkedin-pinpoint-answers",
+      "trailingSlash": true
+    },
+    "existingRoutes": ["/linkedin-pinpoint-answers/pinpoint-answer-899/"],
+    "renderedHtml": "<main><h1>Types of guitar</h1><p>Bass Classical Electric Acoustic Steel</p><section><h2>FAQ</h2><h3>Why does Bass fit?</h3><p>Bass is a guitar type in this board.</p><h3>Why does Electric matter?</h3><p>Electric confirms the guitar-type answer.</p></section></main>",
+    "l1Input": {
+      "puzzleId": "pinpoint-900-2026-05-23",
+      "puzzleNumber": 900,
+      "logicalGameDate": "2026-05-23",
+      "source": "official_capture",
+      "answer": "Types of guitar",
+      "clues": [
+        { "clueId": "clue-1", "text": "Bass", "position": 1 },
+        { "clueId": "clue-2", "text": "Classical", "position": 2 },
+        { "clueId": "clue-3", "text": "Electric", "position": 3 },
+        { "clueId": "clue-4", "text": "Acoustic", "position": 4 },
+        { "clueId": "clue-5", "text": "Steel", "position": 5 }
+      ]
+    },
+    "candidate": {
+      "puzzleId": "pinpoint-900-2026-05-23",
+      "slug": "pinpoint-answer-900",
+      "canonicalUrl": "https://example.com/linkedin-pinpoint-answers/pinpoint-answer-900/",
+      "contentMode": "full-analysis",
+      "revisionId": "rev-full-analysis-cumulative",
+      "inputSnapshotHash": "__HASH_L1__",
+      "contentHash": "sha256:content-full-analysis-cumulative",
+      "answer": "Types of guitar",
+      "clues": [
+        { "clueId": "clue-1", "text": "Bass", "position": 1 },
+        { "clueId": "clue-2", "text": "Classical", "position": 2 },
+        { "clueId": "clue-3", "text": "Electric", "position": 3 },
+        { "clueId": "clue-4", "text": "Acoustic", "position": 4 },
+        { "clueId": "clue-5", "text": "Steel", "position": 5 }
+      ],
+      "clueRows": [
+        { "clueId": "clue-1", "clueText": "Bass", "fit": "Bass guitar", "whyItSupportsAnswer": "Bass is a standard guitar type.", "evidenceRefs": ["ev-bass"] },
+        { "clueId": "clue-2", "clueText": "Classical", "fit": "Classical guitar", "whyItSupportsAnswer": "Classical is a recognized guitar type.", "evidenceRefs": ["ev-classical"] },
+        { "clueId": "clue-3", "clueText": "Electric", "fit": "Electric guitar", "whyItSupportsAnswer": "Electric gives the strongest guitar-specific clue.", "evidenceRefs": ["ev-electric"] },
+        { "clueId": "clue-4", "clueText": "Acoustic", "fit": "Acoustic guitar", "whyItSupportsAnswer": "Acoustic supports the same answer set.", "evidenceRefs": ["ev-acoustic"] },
+        { "clueId": "clue-5", "clueText": "Steel", "fit": "Steel guitar", "whyItSupportsAnswer": "Steel confirms the board is about guitar types.", "evidenceRefs": ["ev-steel"] }
+      ],
+      "reasoning": {
+        "pattern": "cumulative_confirmation",
+        "clueIds": ["clue-1", "clue-2", "clue-3"],
+        "text": "Bass and Classical establish two members of the guitar family, while Electric, Acoustic, and Steel confirm the same answer through separate examples."
+      },
+      "faqItems": [
+        { "question": "Why does Bass fit?", "answer": "Bass is a guitar type in this board." },
+        { "question": "Why does Electric matter?", "answer": "Electric confirms the guitar-type answer." }
+      ],
+      "schemaTypes": ["Article", "FAQPage"],
+      "internalLinks": [
+        { "href": "/linkedin-pinpoint-answers/pinpoint-answer-899/", "label": "Previous Pinpoint answer" }
+      ]
+    }
+  },
+  "expected": {
+    "outcome": "pass_full_analysis",
+    "policies": {
+      "indexPolicy": "index",
+      "sitemapPolicy": "include",
+      "schemaPolicy": "article_only",
+      "internalLinkPolicy": "normal",
+      "requiredAction": "none"
+    },
+    "issueCodes": []
+  }
+}

--- a/lib/puzzles/content-kitchen/fixtures/full-analysis-duplicate-clue-row.invalid.json
+++ b/lib/puzzles/content-kitchen/fixtures/full-analysis-duplicate-clue-row.invalid.json
@@ -1,5 +1,5 @@
 {
-  "name": "full-analysis-basic-identity.downgrade",
+  "name": "full-analysis-duplicate-clue-row.invalid",
   "input": {
     "canonicalConfig": {
       "siteBaseUrl": "https://example.com",
@@ -25,9 +25,9 @@
       "slug": "pinpoint-answer-900",
       "canonicalUrl": "https://example.com/linkedin-pinpoint-answers/pinpoint-answer-900/",
       "contentMode": "full-analysis",
-      "revisionId": "rev-full-analysis-001",
+      "revisionId": "rev-duplicate-row",
       "inputSnapshotHash": "__HASH_L1__",
-      "contentHash": "sha256:content-full-analysis-001",
+      "contentHash": "sha256:content-duplicate-row",
       "answer": "Types of guitar",
       "clues": [
         { "clueId": "clue-1", "text": "Bass", "position": 1 },
@@ -35,18 +35,19 @@
         { "clueId": "clue-3", "text": "Electric", "position": 3 },
         { "clueId": "clue-4", "text": "Acoustic", "position": 4 },
         { "clueId": "clue-5", "text": "Steel", "position": 5 }
+      ],
+      "clueRows": [
+        { "clueId": "clue-1", "fit": "Bass guitar", "whyItSupportsAnswer": "Bass is a guitar type.", "evidenceRefs": ["ev-bass"] },
+        { "clueId": "clue-1", "fit": "Bass guitar again", "whyItSupportsAnswer": "Duplicate row should fail.", "evidenceRefs": ["ev-bass-2"] },
+        { "clueId": "clue-3", "fit": "Electric guitar", "whyItSupportsAnswer": "Electric is a guitar type.", "evidenceRefs": ["ev-electric"] },
+        { "clueId": "clue-4", "fit": "Acoustic guitar", "whyItSupportsAnswer": "Acoustic is a guitar type.", "evidenceRefs": ["ev-acoustic"] },
+        { "clueId": "clue-5", "fit": "Steel guitar", "whyItSupportsAnswer": "Steel is a guitar type.", "evidenceRefs": ["ev-steel"] },
+        { "clueId": "clue-2", "fit": "Classical guitar", "whyItSupportsAnswer": "Classical is a guitar type.", "evidenceRefs": ["ev-classical"] }
       ]
     }
   },
   "expected": {
     "outcome": "downgrade_to_answer_first",
-    "policies": {
-      "indexPolicy": "noindex",
-      "sitemapPolicy": "exclude",
-      "schemaPolicy": "none",
-      "internalLinkPolicy": "hidden_from_recent",
-      "requiredAction": "enrich"
-    },
-    "issueCodes": ["MISSING_CLUE_ROW"]
+    "issueCodes": ["DUPLICATE_CLUE_ROW"]
   }
 }

--- a/lib/puzzles/content-kitchen/fixtures/full-analysis-faq-schema-hidden.invalid.json
+++ b/lib/puzzles/content-kitchen/fixtures/full-analysis-faq-schema-hidden.invalid.json
@@ -1,0 +1,63 @@
+{
+  "name": "full-analysis-faq-schema-hidden.invalid",
+  "input": {
+    "canonicalConfig": {
+      "siteBaseUrl": "https://example.com",
+      "detailRoutePrefix": "/linkedin-pinpoint-answers",
+      "trailingSlash": true
+    },
+    "renderedHtml": "<main><h1>Types of guitar</h1><p>Bass Classical Electric Acoustic Steel</p><section>The clue rows are visible, but the FAQ is not rendered here.</section></main>",
+    "l1Input": {
+      "puzzleId": "pinpoint-900-2026-05-23",
+      "puzzleNumber": 900,
+      "logicalGameDate": "2026-05-23",
+      "source": "official_capture",
+      "answer": "Types of guitar",
+      "clues": [
+        { "clueId": "clue-1", "text": "Bass", "position": 1 },
+        { "clueId": "clue-2", "text": "Classical", "position": 2 },
+        { "clueId": "clue-3", "text": "Electric", "position": 3 },
+        { "clueId": "clue-4", "text": "Acoustic", "position": 4 },
+        { "clueId": "clue-5", "text": "Steel", "position": 5 }
+      ]
+    },
+    "candidate": {
+      "puzzleId": "pinpoint-900-2026-05-23",
+      "slug": "pinpoint-answer-900",
+      "canonicalUrl": "https://example.com/linkedin-pinpoint-answers/pinpoint-answer-900/",
+      "contentMode": "full-analysis",
+      "revisionId": "rev-faq-hidden",
+      "inputSnapshotHash": "__HASH_L1__",
+      "contentHash": "sha256:content-faq-hidden",
+      "answer": "Types of guitar",
+      "clues": [
+        { "clueId": "clue-1", "text": "Bass", "position": 1 },
+        { "clueId": "clue-2", "text": "Classical", "position": 2 },
+        { "clueId": "clue-3", "text": "Electric", "position": 3 },
+        { "clueId": "clue-4", "text": "Acoustic", "position": 4 },
+        { "clueId": "clue-5", "text": "Steel", "position": 5 }
+      ],
+      "clueRows": [
+        { "clueId": "clue-1", "fit": "Bass guitar", "whyItSupportsAnswer": "Bass is a guitar type.", "evidenceRefs": ["ev-bass"] },
+        { "clueId": "clue-2", "fit": "Classical guitar", "whyItSupportsAnswer": "Classical is a guitar type.", "evidenceRefs": ["ev-classical"] },
+        { "clueId": "clue-3", "fit": "Electric guitar", "whyItSupportsAnswer": "Electric is a guitar type.", "evidenceRefs": ["ev-electric"] },
+        { "clueId": "clue-4", "fit": "Acoustic guitar", "whyItSupportsAnswer": "Acoustic is a guitar type.", "evidenceRefs": ["ev-acoustic"] },
+        { "clueId": "clue-5", "fit": "Steel guitar", "whyItSupportsAnswer": "Steel is a guitar type.", "evidenceRefs": ["ev-steel"] }
+      ],
+      "reasoning": {
+        "pattern": "cumulative_confirmation",
+        "clueIds": ["clue-1", "clue-3"],
+        "text": "Bass and Electric establish the guitar-type answer from two different directions, and the remaining clues confirm that reading."
+      },
+      "faqItems": [
+        { "question": "Why does Bass fit?", "answer": "Bass is a guitar type in this board." },
+        { "question": "Why does Electric matter?", "answer": "Electric confirms the guitar-type answer." }
+      ],
+      "schemaTypes": ["FAQPage"]
+    }
+  },
+  "expected": {
+    "outcome": "downgrade_to_answer_first",
+    "issueCodes": ["FAQ_SCHEMA_WITHOUT_VISIBLE_FAQ"]
+  }
+}

--- a/lib/puzzles/content-kitchen/fixtures/full-analysis-four-clue-rows.invalid.json
+++ b/lib/puzzles/content-kitchen/fixtures/full-analysis-four-clue-rows.invalid.json
@@ -1,5 +1,5 @@
 {
-  "name": "full-analysis-basic-identity.downgrade",
+  "name": "full-analysis-four-clue-rows.invalid",
   "input": {
     "canonicalConfig": {
       "siteBaseUrl": "https://example.com",
@@ -25,9 +25,9 @@
       "slug": "pinpoint-answer-900",
       "canonicalUrl": "https://example.com/linkedin-pinpoint-answers/pinpoint-answer-900/",
       "contentMode": "full-analysis",
-      "revisionId": "rev-full-analysis-001",
+      "revisionId": "rev-four-rows",
       "inputSnapshotHash": "__HASH_L1__",
-      "contentHash": "sha256:content-full-analysis-001",
+      "contentHash": "sha256:content-four-rows",
       "answer": "Types of guitar",
       "clues": [
         { "clueId": "clue-1", "text": "Bass", "position": 1 },
@@ -35,18 +35,17 @@
         { "clueId": "clue-3", "text": "Electric", "position": 3 },
         { "clueId": "clue-4", "text": "Acoustic", "position": 4 },
         { "clueId": "clue-5", "text": "Steel", "position": 5 }
+      ],
+      "clueRows": [
+        { "clueId": "clue-1", "fit": "Bass guitar", "whyItSupportsAnswer": "Bass is a guitar type.", "evidenceRefs": ["ev-bass"] },
+        { "clueId": "clue-2", "fit": "Classical guitar", "whyItSupportsAnswer": "Classical is a guitar type.", "evidenceRefs": ["ev-classical"] },
+        { "clueId": "clue-3", "fit": "Electric guitar", "whyItSupportsAnswer": "Electric is a guitar type.", "evidenceRefs": ["ev-electric"] },
+        { "clueId": "clue-4", "fit": "Acoustic guitar", "whyItSupportsAnswer": "Acoustic is a guitar type.", "evidenceRefs": ["ev-acoustic"] }
       ]
     }
   },
   "expected": {
     "outcome": "downgrade_to_answer_first",
-    "policies": {
-      "indexPolicy": "noindex",
-      "sitemapPolicy": "exclude",
-      "schemaPolicy": "none",
-      "internalLinkPolicy": "hidden_from_recent",
-      "requiredAction": "enrich"
-    },
     "issueCodes": ["MISSING_CLUE_ROW"]
   }
 }

--- a/lib/puzzles/content-kitchen/fixtures/full-analysis-generic-reasoning.invalid.json
+++ b/lib/puzzles/content-kitchen/fixtures/full-analysis-generic-reasoning.invalid.json
@@ -1,5 +1,5 @@
 {
-  "name": "full-analysis-basic-identity.downgrade",
+  "name": "full-analysis-generic-reasoning.invalid",
   "input": {
     "canonicalConfig": {
       "siteBaseUrl": "https://example.com",
@@ -25,9 +25,9 @@
       "slug": "pinpoint-answer-900",
       "canonicalUrl": "https://example.com/linkedin-pinpoint-answers/pinpoint-answer-900/",
       "contentMode": "full-analysis",
-      "revisionId": "rev-full-analysis-001",
+      "revisionId": "rev-generic-reasoning",
       "inputSnapshotHash": "__HASH_L1__",
-      "contentHash": "sha256:content-full-analysis-001",
+      "contentHash": "sha256:content-generic-reasoning",
       "answer": "Types of guitar",
       "clues": [
         { "clueId": "clue-1", "text": "Bass", "position": 1 },
@@ -35,18 +35,25 @@
         { "clueId": "clue-3", "text": "Electric", "position": 3 },
         { "clueId": "clue-4", "text": "Acoustic", "position": 4 },
         { "clueId": "clue-5", "text": "Steel", "position": 5 }
-      ]
+      ],
+      "clueRows": [
+        { "clueId": "clue-1", "fit": "Bass guitar", "whyItSupportsAnswer": "Bass is a guitar type.", "evidenceRefs": ["ev-bass"] },
+        { "clueId": "clue-2", "fit": "Classical guitar", "whyItSupportsAnswer": "Classical is a guitar type.", "evidenceRefs": ["ev-classical"] },
+        { "clueId": "clue-3", "fit": "Electric guitar", "whyItSupportsAnswer": "Electric is a guitar type.", "evidenceRefs": ["ev-electric"] },
+        { "clueId": "clue-4", "fit": "Acoustic guitar", "whyItSupportsAnswer": "Acoustic is a guitar type.", "evidenceRefs": ["ev-acoustic"] },
+        { "clueId": "clue-5", "fit": "Steel guitar", "whyItSupportsAnswer": "Steel is a guitar type.", "evidenceRefs": ["ev-steel"] }
+      ],
+      "reasoning": {
+        "pattern": "turning_point",
+        "clueId": "clue-3",
+        "brokenTheory": "general instruments",
+        "supportedTheory": "types of guitar",
+        "text": "All clues point to the same shared category."
+      }
     }
   },
   "expected": {
     "outcome": "downgrade_to_answer_first",
-    "policies": {
-      "indexPolicy": "noindex",
-      "sitemapPolicy": "exclude",
-      "schemaPolicy": "none",
-      "internalLinkPolicy": "hidden_from_recent",
-      "requiredAction": "enrich"
-    },
-    "issueCodes": ["MISSING_CLUE_ROW"]
+    "issueCodes": ["GENERIC_REASONING_PATTERN"]
   }
 }

--- a/lib/puzzles/content-kitchen/fixtures/full-analysis-internal-link-missing.invalid.json
+++ b/lib/puzzles/content-kitchen/fixtures/full-analysis-internal-link-missing.invalid.json
@@ -1,0 +1,62 @@
+{
+  "name": "full-analysis-internal-link-missing.invalid",
+  "input": {
+    "canonicalConfig": {
+      "siteBaseUrl": "https://example.com",
+      "detailRoutePrefix": "/linkedin-pinpoint-answers",
+      "trailingSlash": true
+    },
+    "existingRoutes": ["/linkedin-pinpoint-answers/pinpoint-answer-899/"],
+    "renderedHtml": "<main><h1>Types of guitar</h1><p>Bass Classical Electric Acoustic Steel</p></main>",
+    "l1Input": {
+      "puzzleId": "pinpoint-900-2026-05-23",
+      "puzzleNumber": 900,
+      "logicalGameDate": "2026-05-23",
+      "source": "official_capture",
+      "answer": "Types of guitar",
+      "clues": [
+        { "clueId": "clue-1", "text": "Bass", "position": 1 },
+        { "clueId": "clue-2", "text": "Classical", "position": 2 },
+        { "clueId": "clue-3", "text": "Electric", "position": 3 },
+        { "clueId": "clue-4", "text": "Acoustic", "position": 4 },
+        { "clueId": "clue-5", "text": "Steel", "position": 5 }
+      ]
+    },
+    "candidate": {
+      "puzzleId": "pinpoint-900-2026-05-23",
+      "slug": "pinpoint-answer-900",
+      "canonicalUrl": "https://example.com/linkedin-pinpoint-answers/pinpoint-answer-900/",
+      "contentMode": "full-analysis",
+      "revisionId": "rev-internal-link-missing",
+      "inputSnapshotHash": "__HASH_L1__",
+      "contentHash": "sha256:content-internal-link-missing",
+      "answer": "Types of guitar",
+      "clues": [
+        { "clueId": "clue-1", "text": "Bass", "position": 1 },
+        { "clueId": "clue-2", "text": "Classical", "position": 2 },
+        { "clueId": "clue-3", "text": "Electric", "position": 3 },
+        { "clueId": "clue-4", "text": "Acoustic", "position": 4 },
+        { "clueId": "clue-5", "text": "Steel", "position": 5 }
+      ],
+      "clueRows": [
+        { "clueId": "clue-1", "fit": "Bass guitar", "whyItSupportsAnswer": "Bass is a guitar type.", "evidenceRefs": ["ev-bass"] },
+        { "clueId": "clue-2", "fit": "Classical guitar", "whyItSupportsAnswer": "Classical is a guitar type.", "evidenceRefs": ["ev-classical"] },
+        { "clueId": "clue-3", "fit": "Electric guitar", "whyItSupportsAnswer": "Electric is a guitar type.", "evidenceRefs": ["ev-electric"] },
+        { "clueId": "clue-4", "fit": "Acoustic guitar", "whyItSupportsAnswer": "Acoustic is a guitar type.", "evidenceRefs": ["ev-acoustic"] },
+        { "clueId": "clue-5", "fit": "Steel guitar", "whyItSupportsAnswer": "Steel is a guitar type.", "evidenceRefs": ["ev-steel"] }
+      ],
+      "reasoning": {
+        "pattern": "cumulative_confirmation",
+        "clueIds": ["clue-1", "clue-3"],
+        "text": "Bass and Electric establish the guitar-type answer from two different directions, and the remaining clues confirm that reading."
+      },
+      "internalLinks": [
+        { "href": "/linkedin-pinpoint-answers/pinpoint-answer-1000/", "label": "Missing route" }
+      ]
+    }
+  },
+  "expected": {
+    "outcome": "downgrade_to_answer_first",
+    "issueCodes": ["INTERNAL_LINK_BROKEN"]
+  }
+}

--- a/lib/puzzles/content-kitchen/fixtures/full-analysis-missing-evidence-ref.invalid.json
+++ b/lib/puzzles/content-kitchen/fixtures/full-analysis-missing-evidence-ref.invalid.json
@@ -1,5 +1,5 @@
 {
-  "name": "full-analysis-basic-identity.downgrade",
+  "name": "full-analysis-missing-evidence-ref.invalid",
   "input": {
     "canonicalConfig": {
       "siteBaseUrl": "https://example.com",
@@ -25,9 +25,9 @@
       "slug": "pinpoint-answer-900",
       "canonicalUrl": "https://example.com/linkedin-pinpoint-answers/pinpoint-answer-900/",
       "contentMode": "full-analysis",
-      "revisionId": "rev-full-analysis-001",
+      "revisionId": "rev-missing-evidence-ref",
       "inputSnapshotHash": "__HASH_L1__",
-      "contentHash": "sha256:content-full-analysis-001",
+      "contentHash": "sha256:content-missing-evidence-ref",
       "answer": "Types of guitar",
       "clues": [
         { "clueId": "clue-1", "text": "Bass", "position": 1 },
@@ -35,18 +35,18 @@
         { "clueId": "clue-3", "text": "Electric", "position": 3 },
         { "clueId": "clue-4", "text": "Acoustic", "position": 4 },
         { "clueId": "clue-5", "text": "Steel", "position": 5 }
+      ],
+      "clueRows": [
+        { "clueId": "clue-1", "fit": "Bass guitar", "whyItSupportsAnswer": "Bass is a guitar type.", "evidenceRefs": [] },
+        { "clueId": "clue-2", "fit": "Classical guitar", "whyItSupportsAnswer": "Classical is a guitar type.", "evidenceRefs": ["ev-classical"] },
+        { "clueId": "clue-3", "fit": "Electric guitar", "whyItSupportsAnswer": "Electric is a guitar type.", "evidenceRefs": ["ev-electric"] },
+        { "clueId": "clue-4", "fit": "Acoustic guitar", "whyItSupportsAnswer": "Acoustic is a guitar type.", "evidenceRefs": ["ev-acoustic"] },
+        { "clueId": "clue-5", "fit": "Steel guitar", "whyItSupportsAnswer": "Steel is a guitar type.", "evidenceRefs": ["ev-steel"] }
       ]
     }
   },
   "expected": {
     "outcome": "downgrade_to_answer_first",
-    "policies": {
-      "indexPolicy": "noindex",
-      "sitemapPolicy": "exclude",
-      "schemaPolicy": "none",
-      "internalLinkPolicy": "hidden_from_recent",
-      "requiredAction": "enrich"
-    },
-    "issueCodes": ["MISSING_CLUE_ROW"]
+    "issueCodes": ["MISSING_EVIDENCE_REF"]
   }
 }

--- a/lib/puzzles/content-kitchen/fixtures/full-analysis-missing-reasoning.invalid.json
+++ b/lib/puzzles/content-kitchen/fixtures/full-analysis-missing-reasoning.invalid.json
@@ -1,5 +1,5 @@
 {
-  "name": "full-analysis-basic-identity.downgrade",
+  "name": "full-analysis-missing-reasoning.invalid",
   "input": {
     "canonicalConfig": {
       "siteBaseUrl": "https://example.com",
@@ -25,9 +25,9 @@
       "slug": "pinpoint-answer-900",
       "canonicalUrl": "https://example.com/linkedin-pinpoint-answers/pinpoint-answer-900/",
       "contentMode": "full-analysis",
-      "revisionId": "rev-full-analysis-001",
+      "revisionId": "rev-missing-reasoning",
       "inputSnapshotHash": "__HASH_L1__",
-      "contentHash": "sha256:content-full-analysis-001",
+      "contentHash": "sha256:content-missing-reasoning",
       "answer": "Types of guitar",
       "clues": [
         { "clueId": "clue-1", "text": "Bass", "position": 1 },
@@ -35,18 +35,18 @@
         { "clueId": "clue-3", "text": "Electric", "position": 3 },
         { "clueId": "clue-4", "text": "Acoustic", "position": 4 },
         { "clueId": "clue-5", "text": "Steel", "position": 5 }
+      ],
+      "clueRows": [
+        { "clueId": "clue-1", "fit": "Bass guitar", "whyItSupportsAnswer": "Bass is a guitar type.", "evidenceRefs": ["ev-bass"] },
+        { "clueId": "clue-2", "fit": "Classical guitar", "whyItSupportsAnswer": "Classical is a guitar type.", "evidenceRefs": ["ev-classical"] },
+        { "clueId": "clue-3", "fit": "Electric guitar", "whyItSupportsAnswer": "Electric is a guitar type.", "evidenceRefs": ["ev-electric"] },
+        { "clueId": "clue-4", "fit": "Acoustic guitar", "whyItSupportsAnswer": "Acoustic is a guitar type.", "evidenceRefs": ["ev-acoustic"] },
+        { "clueId": "clue-5", "fit": "Steel guitar", "whyItSupportsAnswer": "Steel is a guitar type.", "evidenceRefs": ["ev-steel"] }
       ]
     }
   },
   "expected": {
     "outcome": "downgrade_to_answer_first",
-    "policies": {
-      "indexPolicy": "noindex",
-      "sitemapPolicy": "exclude",
-      "schemaPolicy": "none",
-      "internalLinkPolicy": "hidden_from_recent",
-      "requiredAction": "enrich"
-    },
-    "issueCodes": ["MISSING_CLUE_ROW"]
+    "issueCodes": ["MISSING_REASONING_PATTERN"]
   }
 }

--- a/lib/puzzles/content-kitchen/fixtures/full-analysis-turning-point.valid.json
+++ b/lib/puzzles/content-kitchen/fixtures/full-analysis-turning-point.valid.json
@@ -1,0 +1,67 @@
+{
+  "name": "full-analysis-turning-point.valid",
+  "input": {
+    "canonicalConfig": {
+      "siteBaseUrl": "https://example.com",
+      "detailRoutePrefix": "/linkedin-pinpoint-answers",
+      "trailingSlash": true
+    },
+    "renderedHtml": "<main><h1>Types of guitar</h1><p>Bass Classical Electric Acoustic Steel</p><section>Electric changes the solve because it narrows the board from instruments generally to guitar types.</section></main>",
+    "l1Input": {
+      "puzzleId": "pinpoint-900-2026-05-23",
+      "puzzleNumber": 900,
+      "logicalGameDate": "2026-05-23",
+      "source": "official_capture",
+      "answer": "Types of guitar",
+      "clues": [
+        { "clueId": "clue-1", "text": "Bass", "position": 1 },
+        { "clueId": "clue-2", "text": "Classical", "position": 2 },
+        { "clueId": "clue-3", "text": "Electric", "position": 3 },
+        { "clueId": "clue-4", "text": "Acoustic", "position": 4 },
+        { "clueId": "clue-5", "text": "Steel", "position": 5 }
+      ]
+    },
+    "candidate": {
+      "puzzleId": "pinpoint-900-2026-05-23",
+      "slug": "pinpoint-answer-900",
+      "canonicalUrl": "https://example.com/linkedin-pinpoint-answers/pinpoint-answer-900/",
+      "contentMode": "full-analysis",
+      "revisionId": "rev-full-analysis-turning-point",
+      "inputSnapshotHash": "__HASH_L1__",
+      "contentHash": "sha256:content-full-analysis-turning-point",
+      "answer": "Types of guitar",
+      "clues": [
+        { "clueId": "clue-1", "text": "Bass", "position": 1 },
+        { "clueId": "clue-2", "text": "Classical", "position": 2 },
+        { "clueId": "clue-3", "text": "Electric", "position": 3 },
+        { "clueId": "clue-4", "text": "Acoustic", "position": 4 },
+        { "clueId": "clue-5", "text": "Steel", "position": 5 }
+      ],
+      "clueRows": [
+        { "clueId": "clue-1", "clueText": "Bass", "fit": "Bass guitar", "whyItSupportsAnswer": "Bass is a standard guitar type.", "evidenceRefs": ["ev-bass"] },
+        { "clueId": "clue-2", "clueText": "Classical", "fit": "Classical guitar", "whyItSupportsAnswer": "Classical is a recognized guitar type.", "evidenceRefs": ["ev-classical"] },
+        { "clueId": "clue-3", "clueText": "Electric", "fit": "Electric guitar", "whyItSupportsAnswer": "Electric gives the strongest guitar-specific clue.", "evidenceRefs": ["ev-electric"] },
+        { "clueId": "clue-4", "clueText": "Acoustic", "fit": "Acoustic guitar", "whyItSupportsAnswer": "Acoustic supports the same answer set.", "evidenceRefs": ["ev-acoustic"] },
+        { "clueId": "clue-5", "clueText": "Steel", "fit": "Steel guitar", "whyItSupportsAnswer": "Steel confirms the board is about guitar types.", "evidenceRefs": ["ev-steel"] }
+      ],
+      "reasoning": {
+        "pattern": "turning_point",
+        "clueId": "clue-3",
+        "brokenTheory": "general instruments",
+        "supportedTheory": "types of guitar",
+        "text": "Electric changes the solve because it narrows the board from instruments generally to guitar types, then Bass and Classical confirm that reading."
+      }
+    }
+  },
+  "expected": {
+    "outcome": "pass_full_analysis",
+    "policies": {
+      "indexPolicy": "index",
+      "sitemapPolicy": "include",
+      "schemaPolicy": "article_only",
+      "internalLinkPolicy": "normal",
+      "requiredAction": "none"
+    },
+    "issueCodes": []
+  }
+}

--- a/lib/puzzles/content-kitchen/full-analysis.ts
+++ b/lib/puzzles/content-kitchen/full-analysis.ts
@@ -1,0 +1,366 @@
+import { normalizeIdentityMatch, normalizeIdentityText } from "./identity";
+import {
+  CONTENT_KITCHEN_CLUE_COUNT,
+  type ContentCandidate,
+  type ContentKitchenIssueCode,
+  type FullAnalysisClueRowCandidate,
+  type FullAnalysisReasoning,
+  type L1PuzzleInput,
+  type ValidationIssue,
+} from "./types";
+
+type FullAnalysisStructureInput = {
+  candidate: Partial<ContentCandidate>;
+  l1Input: L1PuzzleInput;
+  renderedHtml?: string;
+  existingRoutes?: string[];
+};
+
+type IssueOptions = {
+  severity?: "P0" | "P1" | "P2";
+  blocking?: boolean;
+  candidateRevisionId?: string;
+};
+
+const GENERIC_REASONING_PATTERNS = [
+  /\ball clues point to the same\b/i,
+  /\blook at all (the )?clues\b/i,
+  /\bthe answer becomes clear\b/i,
+  /\bshared category\b/i,
+  /\bcommon theme\b/i,
+  /\bthey all fit\b/i,
+];
+
+function makeIssue(
+  issueCode: ContentKitchenIssueCode,
+  fieldPath: string,
+  message: string,
+  suggestedAction: string,
+  options: IssueOptions = {},
+): ValidationIssue {
+  return {
+    issueCode,
+    severity: options.severity ?? "P0",
+    fieldPath,
+    message,
+    suggestedAction,
+    blocking: options.blocking ?? true,
+    ...(options.candidateRevisionId ? { candidateRevisionId: options.candidateRevisionId } : {}),
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function countWords(text: string): number {
+  return text.trim().split(/\s+/).filter(Boolean).length;
+}
+
+function hasStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.length > 0 && value.every((item) => normalizeIdentityText(item));
+}
+
+function l1ClueIds(l1Input: L1PuzzleInput): Set<string> {
+  return new Set(l1Input.clues.map((clue) => normalizeIdentityMatch(clue.clueId)));
+}
+
+function getL1ClueText(l1Input: L1PuzzleInput, clueId: string): string {
+  const normalizedId = normalizeIdentityMatch(clueId);
+  return normalizeIdentityText(
+    l1Input.clues.find((clue) => normalizeIdentityMatch(clue.clueId) === normalizedId)?.text,
+  );
+}
+
+function visibleInRenderedHtml(renderedHtml: string | undefined, value: string): boolean {
+  const normalizedHtml = normalizeIdentityMatch(renderedHtml);
+  return Boolean(normalizedHtml && normalizedHtml.includes(normalizeIdentityMatch(value)));
+}
+
+function validateClueRows(input: FullAnalysisStructureInput): ValidationIssue | null {
+  const rows = input.candidate.clueRows;
+  const candidateRevisionId = normalizeIdentityText(input.candidate.revisionId);
+
+  if (!Array.isArray(rows) || rows.length < CONTENT_KITCHEN_CLUE_COUNT) {
+    return makeIssue(
+      "MISSING_CLUE_ROW",
+      "candidate.clueRows",
+      "Full-analysis must contain exactly five clue rows.",
+      "Add one clue row for every L1 clue.",
+      { candidateRevisionId },
+    );
+  }
+
+  const knownL1Ids = l1ClueIds(input.l1Input);
+  const seenIds = new Set<string>();
+
+  for (let index = 0; index < rows.length; index += 1) {
+    const row = rows[index] as Partial<FullAnalysisClueRowCandidate> | undefined;
+    const fieldPath = `candidate.clueRows[${index}]`;
+
+    if (!isRecord(row)) {
+      return makeIssue(
+        "MISSING_CLUE_ROW",
+        fieldPath,
+        "Clue row must be an object.",
+        "Regenerate the full-analysis clue rows.",
+        { candidateRevisionId },
+      );
+    }
+
+    const clueId = normalizeIdentityText(row.clueId);
+    const normalizedClueId = normalizeIdentityMatch(clueId);
+    if (!clueId || !knownL1Ids.has(normalizedClueId)) {
+      return makeIssue(
+        "MISSING_CLUE_ROW",
+        `${fieldPath}.clueId`,
+        "Clue row must point to one known L1 clue id.",
+        "Use the exact L1 clue id for each row.",
+        { candidateRevisionId },
+      );
+    }
+
+    if (seenIds.has(normalizedClueId)) {
+      return makeIssue(
+        "DUPLICATE_CLUE_ROW",
+        `${fieldPath}.clueId`,
+        "A clue id appears in more than one full-analysis row.",
+        "Keep exactly one row per L1 clue.",
+        { candidateRevisionId },
+      );
+    }
+    seenIds.add(normalizedClueId);
+
+    const rowClueText = normalizeIdentityText(row.clueText);
+    if (rowClueText && normalizeIdentityMatch(rowClueText) !== normalizeIdentityMatch(getL1ClueText(input.l1Input, clueId))) {
+      return makeIssue(
+        "CANDIDATE_L1_MISMATCH",
+        `${fieldPath}.clueText`,
+        "Clue row text does not match the L1 clue text.",
+        "Use the exact L1 clue text for this row.",
+        { candidateRevisionId },
+      );
+    }
+
+    if (!normalizeIdentityText(row.fit) || !normalizeIdentityText(row.whyItSupportsAnswer)) {
+      return makeIssue(
+        "MISSING_CLUE_ROW",
+        fieldPath,
+        "Every clue row needs fit and whyItSupportsAnswer.",
+        "Add non-empty fit and whyItSupportsAnswer fields.",
+        { candidateRevisionId },
+      );
+    }
+
+    if (!hasStringArray(row.evidenceRefs)) {
+      return makeIssue(
+        "MISSING_EVIDENCE_REF",
+        `${fieldPath}.evidenceRefs`,
+        "Every clue row needs at least one evidence ref string.",
+        "Add evidenceRefs as non-empty strings. PR7 will check source quality.",
+        { candidateRevisionId },
+      );
+    }
+  }
+
+  if (rows.length > CONTENT_KITCHEN_CLUE_COUNT) {
+    return makeIssue(
+      "DUPLICATE_CLUE_ROW",
+      "candidate.clueRows",
+      "Full-analysis has more than five clue rows.",
+      "Keep exactly one row per L1 clue.",
+      { candidateRevisionId },
+    );
+  }
+
+  for (const clue of input.l1Input.clues) {
+    if (!seenIds.has(normalizeIdentityMatch(clue.clueId))) {
+      return makeIssue(
+        "MISSING_CLUE_ROW",
+        "candidate.clueRows",
+        "Full-analysis is missing an L1 clue row.",
+        "Add one clue row for every L1 clue.",
+        { candidateRevisionId },
+      );
+    }
+  }
+
+  return null;
+}
+
+function validateReasoning(input: FullAnalysisStructureInput): ValidationIssue | null {
+  const reasoning = input.candidate.reasoning as Partial<FullAnalysisReasoning> | undefined;
+  const candidateRevisionId = normalizeIdentityText(input.candidate.revisionId);
+
+  if (!isRecord(reasoning)) {
+    return makeIssue(
+      "MISSING_REASONING_PATTERN",
+      "candidate.reasoning",
+      "Full-analysis reasoning is missing.",
+      "Add turning_point or cumulative_confirmation reasoning.",
+      { candidateRevisionId },
+    );
+  }
+
+  const text = normalizeIdentityText(reasoning.text);
+  const generic = !text || countWords(text) < 12 || GENERIC_REASONING_PATTERNS.some((pattern) => pattern.test(text));
+  if (generic) {
+    return makeIssue(
+      "GENERIC_REASONING_PATTERN",
+      "candidate.reasoning.text",
+      "Reasoning text is too generic for full-analysis.",
+      "Explain the actual clue path with specific clue ids.",
+      { candidateRevisionId },
+    );
+  }
+
+  const knownL1Ids = l1ClueIds(input.l1Input);
+  if (reasoning.pattern === "turning_point") {
+    const clueId = normalizeIdentityText(reasoning.clueId);
+    if (!clueId || !knownL1Ids.has(normalizeIdentityMatch(clueId))) {
+      return makeIssue(
+        "UNSUPPORTED_REASONING_PATTERN",
+        "candidate.reasoning.clueId",
+        "Turning-point reasoning must name exactly one known L1 clue id.",
+        "Use one L1 clue id as the turning point.",
+        { candidateRevisionId },
+      );
+    }
+
+    if (!normalizeIdentityText(reasoning.brokenTheory) || !normalizeIdentityText(reasoning.supportedTheory)) {
+      return makeIssue(
+        "UNSUPPORTED_REASONING_PATTERN",
+        "candidate.reasoning",
+        "Turning-point reasoning needs brokenTheory and supportedTheory.",
+        "Add both theory fields.",
+        { candidateRevisionId },
+      );
+    }
+
+    return null;
+  }
+
+  if (reasoning.pattern === "cumulative_confirmation") {
+    const clueIds = Array.isArray(reasoning.clueIds) ? reasoning.clueIds.map(normalizeIdentityText).filter(Boolean) : [];
+    const uniqueKnownIds = new Set(clueIds.map(normalizeIdentityMatch).filter((clueId) => knownL1Ids.has(clueId)));
+    if (uniqueKnownIds.size < 2) {
+      return makeIssue(
+        "UNSUPPORTED_REASONING_PATTERN",
+        "candidate.reasoning.clueIds",
+        "Cumulative-confirmation reasoning needs at least two known L1 clue ids.",
+        "Reference at least two L1 clue ids.",
+        { candidateRevisionId },
+      );
+    }
+
+    return null;
+  }
+
+  return makeIssue(
+    "UNSUPPORTED_REASONING_PATTERN",
+    "candidate.reasoning.pattern",
+    "Reasoning pattern must be turning_point or cumulative_confirmation.",
+    "Use a supported reasoning pattern.",
+    { candidateRevisionId },
+  );
+}
+
+function validateFaq(input: FullAnalysisStructureInput): ValidationIssue | null {
+  const faqItems = input.candidate.faqItems;
+  const candidateRevisionId = normalizeIdentityText(input.candidate.revisionId);
+
+  if (Array.isArray(faqItems) && faqItems.length > 0) {
+    if (faqItems.length < 2 || faqItems.length > 4) {
+      return makeIssue(
+        "INVALID_FAQ_STRUCTURE",
+        "candidate.faqItems",
+        "Full-analysis FAQ items must be 2 to 4 when present.",
+        "Keep 2 to 4 specific FAQ items or omit FAQ items.",
+        { candidateRevisionId },
+      );
+    }
+  }
+
+  const schemaTypes = Array.isArray(input.candidate.schemaTypes) ? input.candidate.schemaTypes : [];
+  const hasFaqSchema = schemaTypes.some((schemaType) => normalizeIdentityMatch(schemaType) === "faqpage");
+  if (!hasFaqSchema) {
+    return null;
+  }
+
+  if (!Array.isArray(faqItems) || faqItems.length === 0) {
+    return makeIssue(
+      "FAQ_SCHEMA_WITHOUT_VISIBLE_FAQ",
+      "candidate.schemaTypes",
+      "FAQPage schema requires visible FAQ content.",
+      "Remove FAQPage schema or render matching FAQ content.",
+      { candidateRevisionId },
+    );
+  }
+
+  const visible = faqItems.every((item) => {
+    return visibleInRenderedHtml(input.renderedHtml, item.question) && visibleInRenderedHtml(input.renderedHtml, item.answer);
+  });
+
+  if (!visible) {
+    return makeIssue(
+      "FAQ_SCHEMA_WITHOUT_VISIBLE_FAQ",
+      "renderedHtml",
+      "FAQPage schema is present but matching FAQ content is not visible.",
+      "Render the FAQ question and answer text or remove FAQPage schema.",
+      { candidateRevisionId },
+    );
+  }
+
+  return null;
+}
+
+function validateInternalLinks(input: FullAnalysisStructureInput): ValidationIssue | null {
+  const internalLinks = input.candidate.internalLinks;
+  const candidateRevisionId = normalizeIdentityText(input.candidate.revisionId);
+  const existingRoutes = Array.isArray(input.existingRoutes) ? new Set(input.existingRoutes) : null;
+
+  if (!Array.isArray(internalLinks)) {
+    return null;
+  }
+
+  for (let index = 0; index < internalLinks.length; index += 1) {
+    const link = internalLinks[index];
+    const href = normalizeIdentityText(link?.href);
+    const fieldPath = `candidate.internalLinks[${index}].href`;
+    const routeShaped = href.startsWith("/") && !href.startsWith("//") && !/^https?:\/\//i.test(href);
+
+    if (!routeShaped) {
+      return makeIssue(
+        "INTERNAL_LINK_BROKEN",
+        fieldPath,
+        "Internal link must be a route-shaped path.",
+        "Use a local route path that starts with one slash.",
+        { candidateRevisionId },
+      );
+    }
+
+    if (existingRoutes && !existingRoutes.has(href)) {
+      return makeIssue(
+        "INTERNAL_LINK_BROKEN",
+        fieldPath,
+        "Internal link target is not in the provided route index.",
+        "Use an existing public route or update the route index.",
+        { candidateRevisionId },
+      );
+    }
+  }
+
+  return null;
+}
+
+export function validateFullAnalysisStructure(input: FullAnalysisStructureInput): ValidationIssue[] {
+  const validators = [validateClueRows, validateReasoning, validateFaq, validateInternalLinks];
+  for (const validator of validators) {
+    const issue = validator(input);
+    if (issue) {
+      return [issue];
+    }
+  }
+
+  return [];
+}

--- a/lib/puzzles/content-kitchen/policies.ts
+++ b/lib/puzzles/content-kitchen/policies.ts
@@ -24,6 +24,22 @@ export const FULL_ANALYSIS_REVIEW_POLICIES: ValidationPolicies = {
   requiredAction: "review",
 };
 
+export const FULL_ANALYSIS_PASS_POLICIES: ValidationPolicies = {
+  indexPolicy: "index",
+  sitemapPolicy: "include",
+  schemaPolicy: "article_only",
+  internalLinkPolicy: "normal",
+  requiredAction: "none",
+};
+
+export const DOWNGRADE_TO_ANSWER_FIRST_POLICIES: ValidationPolicies = {
+  indexPolicy: "noindex",
+  sitemapPolicy: "exclude",
+  schemaPolicy: "none",
+  internalLinkPolicy: "hidden_from_recent",
+  requiredAction: "enrich",
+};
+
 export function derivePolicies(input: Pick<ValidateCandidateInput, "candidate" | "allowAnswerFirstIndex">): ValidationPolicies {
   const candidate = input.candidate as Partial<ContentCandidate> | null | undefined;
 

--- a/lib/puzzles/content-kitchen/types.ts
+++ b/lib/puzzles/content-kitchen/types.ts
@@ -29,7 +29,7 @@ export type DegradationAction =
   | "hide_from_recent"
   | "create_fix_task";
 
-export type Pr6aIssueCode =
+export type ContentKitchenIssueCode =
   | "MISSING_L1_INPUT"
   | "INVALID_L1_INPUT"
   | "INVALID_CANDIDATE_METADATA"
@@ -37,7 +37,18 @@ export type Pr6aIssueCode =
   | "CANONICAL_URL_MISMATCH"
   | "ANSWER_HIDDEN_FROM_RENDERED_HTML"
   | "NOINDEX_REQUIRED_BUT_MISSING"
-  | "FULL_ANALYSIS_STRUCTURE_NOT_VALIDATED";
+  | "FULL_ANALYSIS_STRUCTURE_NOT_VALIDATED"
+  | "MISSING_CLUE_ROW"
+  | "DUPLICATE_CLUE_ROW"
+  | "MISSING_EVIDENCE_REF"
+  | "MISSING_REASONING_PATTERN"
+  | "UNSUPPORTED_REASONING_PATTERN"
+  | "GENERIC_REASONING_PATTERN"
+  | "FAQ_SCHEMA_WITHOUT_VISIBLE_FAQ"
+  | "INVALID_FAQ_STRUCTURE"
+  | "INTERNAL_LINK_BROKEN";
+
+export type Pr6aIssueCode = ContentKitchenIssueCode;
 
 export type ContentKitchenIssueSeverity = "P0" | "P1" | "P2";
 
@@ -70,6 +81,44 @@ export type ContentCandidateClue = {
   position: number;
 };
 
+export type FullAnalysisClueRowCandidate = {
+  clueId: string;
+  clueText?: string;
+  fit: string;
+  whyItSupportsAnswer: string;
+  evidenceRefs: string[];
+};
+
+export type TurningPointReasoning = {
+  pattern: "turning_point";
+  clueId: string;
+  brokenTheory: string;
+  supportedTheory: string;
+  text: string;
+  evidenceRefs?: string[];
+};
+
+export type CumulativeConfirmationReasoning = {
+  pattern: "cumulative_confirmation";
+  clueIds: string[];
+  text: string;
+  evidenceRefs?: string[];
+};
+
+export type FullAnalysisReasoning =
+  | TurningPointReasoning
+  | CumulativeConfirmationReasoning;
+
+export type FaqCandidate = {
+  question: string;
+  answer: string;
+};
+
+export type InternalLinkCandidate = {
+  href: string;
+  label?: string;
+};
+
 export type ContentCandidate = {
   puzzleId: string;
   slug: string;
@@ -81,10 +130,15 @@ export type ContentCandidate = {
   answer: string;
   clues: ContentCandidateClue[];
   summary?: string;
+  clueRows?: FullAnalysisClueRowCandidate[];
+  reasoning?: FullAnalysisReasoning;
+  faqItems?: FaqCandidate[];
+  internalLinks?: InternalLinkCandidate[];
+  schemaTypes?: string[];
 };
 
 export type ValidationIssue = {
-  issueCode: Pr6aIssueCode;
+  issueCode: ContentKitchenIssueCode;
   severity: ContentKitchenIssueSeverity;
   fieldPath: string;
   message: string;
@@ -108,6 +162,7 @@ export type ValidateCandidateInput = {
   canonicalConfig: CanonicalConfig;
   renderedHtml?: string;
   allowAnswerFirstIndex?: boolean;
+  existingRoutes?: string[];
 };
 
 export type ValidateCandidateOutput = {

--- a/lib/puzzles/content-kitchen/validate-candidate.ts
+++ b/lib/puzzles/content-kitchen/validate-candidate.ts
@@ -5,19 +5,21 @@ import {
   normalizeIdentityMatch,
   normalizeIdentityText,
 } from "./identity";
+import { validateFullAnalysisStructure } from "./full-analysis";
 import {
   BLOCK_PUBLISH_POLICIES,
+  DOWNGRADE_TO_ANSWER_FIRST_POLICIES,
   derivePolicies,
-  FULL_ANALYSIS_REVIEW_POLICIES,
+  FULL_ANALYSIS_PASS_POLICIES,
   REVIEW_POLICIES,
 } from "./policies";
 import {
   CONTENT_KITCHEN_CLUE_COUNT,
   type ContentCandidate,
   type ContentCandidateClue,
+  type ContentKitchenIssueCode,
   type L1PuzzleClue,
   type L1PuzzleInput,
-  type Pr6aIssueCode,
   type ValidateCandidateInput,
   type ValidateCandidateOutput,
   type ValidationIssue,
@@ -26,7 +28,7 @@ import {
 } from "./types";
 
 function makeIssue(
-  issueCode: Pr6aIssueCode,
+  issueCode: ContentKitchenIssueCode,
   fieldPath: string,
   message: string,
   suggestedAction: string,
@@ -297,15 +299,30 @@ export function validateCandidate(input: ValidateCandidateInput): ValidateCandid
   }
 
   if (candidate.contentMode === "full-analysis") {
-    return output("requires_review", FULL_ANALYSIS_REVIEW_POLICIES, [
-      makeIssue(
-        "FULL_ANALYSIS_STRUCTURE_NOT_VALIDATED",
-        "candidate.contentMode",
-        "PR6A validates identity only; full-analysis structure waits for PR6B.",
-        "Run PR6B structural validation before publish.",
-        { severity: "P1", blocking: false, candidateRevisionId },
-      ),
-    ]);
+    const structureIssues = validateFullAnalysisStructure({
+      candidate,
+      l1Input: validatedL1,
+      renderedHtml: input.renderedHtml,
+      existingRoutes: input.existingRoutes,
+    });
+
+    if (structureIssues.length > 0) {
+      return output("downgrade_to_answer_first", DOWNGRADE_TO_ANSWER_FIRST_POLICIES, structureIssues);
+    }
+
+    if (!renderedHtmlShowsAnswerAndClues(input.renderedHtml, validatedL1)) {
+      return output("requires_review", REVIEW_POLICIES, [
+        makeIssue(
+          "ANSWER_HIDDEN_FROM_RENDERED_HTML",
+          "renderedHtml",
+          "Indexable full-analysis candidate lacks rendered HTML proof for the answer and all five clues.",
+          "Provide renderedHtml proof before indexing full-analysis.",
+          { blocking: false, candidateRevisionId },
+        ),
+      ]);
+    }
+
+    return output("pass_full_analysis", FULL_ANALYSIS_PASS_POLICIES, []);
   }
 
   return output("pass_answer_first", preliminaryPolicies, []);

--- a/scripts/check-content-kitchen-contract.ts
+++ b/scripts/check-content-kitchen-contract.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from "node:url";
 import { hashInputSnapshot } from "../lib/puzzles/content-kitchen/identity";
 import { validateCandidate } from "../lib/puzzles/content-kitchen/validate-candidate";
 import type {
-  Pr6aIssueCode,
+  ContentKitchenIssueCode,
   ValidateCandidateInput,
   ValidationOutcome,
   ValidationPolicies,
@@ -21,7 +21,7 @@ type Fixture = {
   expected: {
     outcome: ValidationOutcome;
     policies?: Partial<ValidationPolicies>;
-    issueCodes?: Pr6aIssueCode[];
+    issueCodes?: ContentKitchenIssueCode[];
   };
 };
 
@@ -64,7 +64,11 @@ function assertPolicySubset(
   }
 }
 
-function assertIssueCodes(fileName: string, actualCodes: Pr6aIssueCode[], expectedCodes: Pr6aIssueCode[] = []) {
+function assertIssueCodes(
+  fileName: string,
+  actualCodes: ContentKitchenIssueCode[],
+  expectedCodes: ContentKitchenIssueCode[] = [],
+) {
   assert.deepEqual(
     actualCodes,
     expectedCodes,


### PR DESCRIPTION
## Summary
- add PR6B full-analysis structural validator for clue rows, reasoning, FAQ schema visibility, and internal link route checks
- extend content-kitchen candidate types and full-analysis pass/downgrade policies
- add PR6B positive and negative fixtures; content-kitchen fixture coverage is now 24 cases
- update the architecture issue-code plan for PR6B structural issue codes

## Validation
- `npm run test:content-kitchen`
- `npm run typecheck`
- `npm run lint`
- pre-push `npm run validate:data`

## Scope Guard
- does not call search
- does not call a model
- does not judge evidence source quality
- does not fetch public URLs
- does not change production rendering, sitemap behavior, or Worker publish behavior
