### PR TITLE
Add PR6C review artifact contract

### DIFF
--- a/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
+++ b/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
@@ -1602,6 +1602,20 @@ PR6C should add:
 4. Snapshot-like JSON examples that stay stable.
 5. A fixture test that proves every PR6 P0 issue code has at least one negative fixture.
 
+PR6C implementation files:
+
+- `lib/puzzles/content-kitchen/issue-registry.ts`
+- `lib/puzzles/content-kitchen/review-artifact.ts`
+- `lib/puzzles/content-kitchen/examples/*.json`
+- `scripts/check-content-kitchen-contract.ts`
+
+The contract fixture runner owns the first coverage check:
+
+- every emitted issue code must exist in the registry
+- every PR6 P0 issue code must appear in at least one negative fixture
+- every failed validation outcome must be able to build a review artifact v0
+- review artifacts must not include raw rendered HTML content
+
 Issue registry shape:
 
 ```ts
@@ -1855,8 +1869,8 @@ Defer:
 
 | Phase | Issue codes |
 | --- | --- |
-| PR6A/PR6B P0 | `MISSING_L1_INPUT`, `INVALID_L1_INPUT`, `INVALID_CANDIDATE_METADATA`, `CANDIDATE_L1_MISMATCH`, `MISSING_CLUE_ROW`, `DUPLICATE_CLUE_ROW`, `MISSING_EVIDENCE_REF`, `ANSWER_HIDDEN_FROM_RENDERED_HTML`, `MISSING_REASONING_PATTERN`, `UNSUPPORTED_REASONING_PATTERN`, `CANONICAL_URL_MISMATCH`, `FAQ_SCHEMA_WITHOUT_VISIBLE_FAQ`, `NOINDEX_REQUIRED_BUT_MISSING` |
-| PR6A/PR6B P1 | `FULL_ANALYSIS_STRUCTURE_NOT_VALIDATED`, `GENERIC_REASONING_PATTERN`, `INVALID_FAQ_STRUCTURE`, `INTERNAL_LINK_BROKEN` |
+| PR6A/PR6B/PR6C P0 | `MISSING_L1_INPUT`, `INVALID_L1_INPUT`, `INVALID_CANDIDATE_METADATA`, `CANDIDATE_L1_MISMATCH`, `MISSING_CLUE_ROW`, `DUPLICATE_CLUE_ROW`, `MISSING_EVIDENCE_REF`, `ANSWER_HIDDEN_FROM_RENDERED_HTML`, `MISSING_REASONING_PATTERN`, `UNSUPPORTED_REASONING_PATTERN`, `CANONICAL_URL_MISMATCH`, `FAQ_SCHEMA_WITHOUT_VISIBLE_FAQ`, `NOINDEX_REQUIRED_BUT_MISSING` |
+| PR6A/PR6B/PR6C P1 | `FULL_ANALYSIS_STRUCTURE_NOT_VALIDATED`, `GENERIC_REASONING_PATTERN`, `INVALID_FAQ_STRUCTURE`, `INTERNAL_LINK_BROKEN` |
 | PR7/PR8 | `UNSUPPORTED_CLUE_FIT`, `WEAK_FIT_EVIDENCE`, `L4_ONLY_EVIDENCE`, `INVENTED_FALSE_START`, `FULL_ANALYSIS_WITH_LOW_CONFIDENCE` |
 | PR10 | review artifact completeness and reviewer decision consistency issues |
 | PR11 | `PUBLIC_HTML_FETCH_FAILED`, `PUBLIC_HTML_RENDER_FAILED`, `SITEMAP_LASTMOD_MISSING`, `SCHEMA_DATE_MODIFIED_MISSING`, `INTERNAL_LINK_BROKEN`, `SITEMAP_POLICY_MISMATCH`, `ROBOTS_POLICY_MISMATCH`, `DATE_MODIFIED_MISMATCH`, `SCHEMA_MODE_MISMATCH` |

--- a/lib/puzzles/content-kitchen/examples/review-artifact-downgrade.example.json
+++ b/lib/puzzles/content-kitchen/examples/review-artifact-downgrade.example.json
@@ -1,0 +1,22 @@
+{
+  "artifactVersion": "content-kitchen-review-artifact-v0",
+  "artifactType": "review",
+  "examplePurpose": "Shows the stable review artifact shape for a full-analysis downgrade.",
+  "requiredFields": [
+    "artifactId",
+    "createdAt",
+    "candidateRevisionId",
+    "validation.outcome",
+    "validation.policies",
+    "validation.issueCodes",
+    "issueCodesRequiringDecision",
+    "recommendedAction",
+    "allowedReviewerActions"
+  ],
+  "mustNotContain": [
+    "raw model prompt",
+    "cookies",
+    "API keys",
+    "renderedHtml"
+  ]
+}

--- a/lib/puzzles/content-kitchen/examples/validation-result-block-publish.example.json
+++ b/lib/puzzles/content-kitchen/examples/validation-result-block-publish.example.json
@@ -1,0 +1,22 @@
+{
+  "examplePurpose": "Shows the stable validation result shape for a blocked candidate.",
+  "outcome": "block_publish",
+  "policies": {
+    "indexPolicy": "block_publish",
+    "sitemapPolicy": "exclude",
+    "schemaPolicy": "none",
+    "internalLinkPolicy": "hidden_from_recent",
+    "requiredAction": "block_publish"
+  },
+  "issues": [
+    {
+      "issueCode": "CANONICAL_URL_MISMATCH",
+      "severity": "P0",
+      "fieldPath": "candidate.canonicalUrl",
+      "message": "Candidate canonical URL does not match the L1-derived canonical URL.",
+      "suggestedAction": "Use buildCanonicalUrl(canonicalConfig, expectedSlug).",
+      "blocking": true,
+      "candidateRevisionId": "rev_example"
+    }
+  ]
+}

--- a/lib/puzzles/content-kitchen/fixtures/answer-first-noindex-marker-missing.invalid.json
+++ b/lib/puzzles/content-kitchen/fixtures/answer-first-noindex-marker-missing.invalid.json
@@ -1,0 +1,47 @@
+{
+  "name": "answer-first-noindex-marker-missing.invalid",
+  "input": {
+    "renderedHtml": "<main><h1>Types of guitar</h1><p>Bass Classical Electric Acoustic Steel</p></main>",
+    "canonicalConfig": {
+      "siteBaseUrl": "https://example.com",
+      "detailRoutePrefix": "/linkedin-pinpoint-answers",
+      "trailingSlash": true
+    },
+    "l1Input": {
+      "puzzleId": "pinpoint-900-2026-05-23",
+      "puzzleNumber": 900,
+      "logicalGameDate": "2026-05-23",
+      "source": "official_capture",
+      "answer": "Types of guitar",
+      "clues": [
+        { "clueId": "clue-1", "text": "Bass", "position": 1 },
+        { "clueId": "clue-2", "text": "Classical", "position": 2 },
+        { "clueId": "clue-3", "text": "Electric", "position": 3 },
+        { "clueId": "clue-4", "text": "Acoustic", "position": 4 },
+        { "clueId": "clue-5", "text": "Steel", "position": 5 }
+      ]
+    },
+    "candidate": {
+      "puzzleId": "pinpoint-900-2026-05-23",
+      "slug": "pinpoint-answer-900",
+      "canonicalUrl": "https://example.com/linkedin-pinpoint-answers/pinpoint-answer-900/",
+      "contentMode": "answer-first",
+      "revisionId": "rev-noindex-marker-missing",
+      "inputSnapshotHash": "__HASH_L1__",
+      "contentHash": "sha256:content-noindex-marker-missing",
+      "answer": "Types of guitar",
+      "clues": [
+        { "clueId": "clue-1", "text": "Bass", "position": 1 },
+        { "clueId": "clue-2", "text": "Classical", "position": 2 },
+        { "clueId": "clue-3", "text": "Electric", "position": 3 },
+        { "clueId": "clue-4", "text": "Acoustic", "position": 4 },
+        { "clueId": "clue-5", "text": "Steel", "position": 5 }
+      ]
+    }
+  },
+  "expected": {
+    "outcome": "block_publish",
+    "issueCodes": ["NOINDEX_REQUIRED_BUT_MISSING"],
+    "mustCreateArtifact": true
+  }
+}

--- a/lib/puzzles/content-kitchen/fixtures/full-analysis-unsupported-reasoning.invalid.json
+++ b/lib/puzzles/content-kitchen/fixtures/full-analysis-unsupported-reasoning.invalid.json
@@ -1,0 +1,57 @@
+{
+  "name": "full-analysis-unsupported-reasoning.invalid",
+  "input": {
+    "canonicalConfig": {
+      "siteBaseUrl": "https://example.com",
+      "detailRoutePrefix": "/linkedin-pinpoint-answers",
+      "trailingSlash": true
+    },
+    "l1Input": {
+      "puzzleId": "pinpoint-900-2026-05-23",
+      "puzzleNumber": 900,
+      "logicalGameDate": "2026-05-23",
+      "source": "official_capture",
+      "answer": "Types of guitar",
+      "clues": [
+        { "clueId": "clue-1", "text": "Bass", "position": 1 },
+        { "clueId": "clue-2", "text": "Classical", "position": 2 },
+        { "clueId": "clue-3", "text": "Electric", "position": 3 },
+        { "clueId": "clue-4", "text": "Acoustic", "position": 4 },
+        { "clueId": "clue-5", "text": "Steel", "position": 5 }
+      ]
+    },
+    "candidate": {
+      "puzzleId": "pinpoint-900-2026-05-23",
+      "slug": "pinpoint-answer-900",
+      "canonicalUrl": "https://example.com/linkedin-pinpoint-answers/pinpoint-answer-900/",
+      "contentMode": "full-analysis",
+      "revisionId": "rev-unsupported-reasoning",
+      "inputSnapshotHash": "__HASH_L1__",
+      "contentHash": "sha256:content-unsupported-reasoning",
+      "answer": "Types of guitar",
+      "clues": [
+        { "clueId": "clue-1", "text": "Bass", "position": 1 },
+        { "clueId": "clue-2", "text": "Classical", "position": 2 },
+        { "clueId": "clue-3", "text": "Electric", "position": 3 },
+        { "clueId": "clue-4", "text": "Acoustic", "position": 4 },
+        { "clueId": "clue-5", "text": "Steel", "position": 5 }
+      ],
+      "clueRows": [
+        { "clueId": "clue-1", "fit": "Bass guitar", "whyItSupportsAnswer": "Bass is a guitar type.", "evidenceRefs": ["ev-bass"] },
+        { "clueId": "clue-2", "fit": "Classical guitar", "whyItSupportsAnswer": "Classical is a guitar type.", "evidenceRefs": ["ev-classical"] },
+        { "clueId": "clue-3", "fit": "Electric guitar", "whyItSupportsAnswer": "Electric is a guitar type.", "evidenceRefs": ["ev-electric"] },
+        { "clueId": "clue-4", "fit": "Acoustic guitar", "whyItSupportsAnswer": "Acoustic is a guitar type.", "evidenceRefs": ["ev-acoustic"] },
+        { "clueId": "clue-5", "fit": "Steel guitar", "whyItSupportsAnswer": "Steel is a guitar type.", "evidenceRefs": ["ev-steel"] }
+      ],
+      "reasoning": {
+        "pattern": "unsupported_story",
+        "text": "Bass and Electric establish the guitar-type answer from two different directions, and the remaining clues confirm that reading."
+      }
+    }
+  },
+  "expected": {
+    "outcome": "downgrade_to_answer_first",
+    "issueCodes": ["UNSUPPORTED_REASONING_PATTERN"],
+    "mustCreateArtifact": true
+  }
+}

--- a/lib/puzzles/content-kitchen/full-analysis.ts
+++ b/lib/puzzles/content-kitchen/full-analysis.ts
@@ -210,7 +210,7 @@ function validateReasoning(input: FullAnalysisStructureInput): ValidationIssue |
       "candidate.reasoning.text",
       "Reasoning text is too generic for full-analysis.",
       "Explain the actual clue path with specific clue ids.",
-      { candidateRevisionId },
+      { severity: "P1", candidateRevisionId },
     );
   }
 
@@ -276,7 +276,7 @@ function validateFaq(input: FullAnalysisStructureInput): ValidationIssue | null 
         "candidate.faqItems",
         "Full-analysis FAQ items must be 2 to 4 when present.",
         "Keep 2 to 4 specific FAQ items or omit FAQ items.",
-        { candidateRevisionId },
+        { severity: "P1", candidateRevisionId },
       );
     }
   }
@@ -335,7 +335,7 @@ function validateInternalLinks(input: FullAnalysisStructureInput): ValidationIss
         fieldPath,
         "Internal link must be a route-shaped path.",
         "Use a local route path that starts with one slash.",
-        { candidateRevisionId },
+        { severity: "P1", candidateRevisionId },
       );
     }
 
@@ -345,7 +345,7 @@ function validateInternalLinks(input: FullAnalysisStructureInput): ValidationIss
         fieldPath,
         "Internal link target is not in the provided route index.",
         "Use an existing public route or update the route index.",
-        { candidateRevisionId },
+        { severity: "P1", candidateRevisionId },
       );
     }
   }

--- a/lib/puzzles/content-kitchen/issue-registry.ts
+++ b/lib/puzzles/content-kitchen/issue-registry.ts
@@ -1,0 +1,160 @@
+import type { ContentKitchenIssueCode, IssueCodeDefinition } from "./types";
+
+export const CONTENT_KITCHEN_ISSUE_REGISTRY: IssueCodeDefinition[] = [
+  {
+    code: "MISSING_L1_INPUT",
+    phaseOwner: "PR6A",
+    defaultSeverity: "P0",
+    defaultOutcome: "block_publish",
+    defaultRequiredAction: "block_publish",
+    description: "L1 input object is absent or cannot be loaded.",
+  },
+  {
+    code: "INVALID_L1_INPUT",
+    phaseOwner: "PR6A",
+    defaultSeverity: "P0",
+    defaultOutcome: "block_publish",
+    defaultRequiredAction: "block_publish",
+    description: "L1 exists but required answer, clue, or identity fields are invalid.",
+  },
+  {
+    code: "INVALID_CANDIDATE_METADATA",
+    phaseOwner: "PR6A",
+    defaultSeverity: "P0",
+    defaultOutcome: "block_publish",
+    defaultRequiredAction: "block_publish",
+    description: "Candidate metadata is missing or unsupported.",
+  },
+  {
+    code: "CANDIDATE_L1_MISMATCH",
+    phaseOwner: "PR6A",
+    defaultSeverity: "P0",
+    defaultOutcome: "block_publish",
+    defaultRequiredAction: "block_publish",
+    description: "Candidate identity or clue data does not match L1.",
+  },
+  {
+    code: "CANONICAL_URL_MISMATCH",
+    phaseOwner: "PR6A",
+    defaultSeverity: "P0",
+    defaultOutcome: "block_publish",
+    defaultRequiredAction: "block_publish",
+    description: "Candidate slug or canonical URL does not match the L1-derived canonical identity.",
+  },
+  {
+    code: "ANSWER_HIDDEN_FROM_RENDERED_HTML",
+    phaseOwner: "PR6A",
+    defaultSeverity: "P0",
+    defaultOutcome: "requires_review",
+    defaultRequiredAction: "review",
+    description: "Indexable candidate lacks rendered proof that answer and L1 clues are visible.",
+  },
+  {
+    code: "NOINDEX_REQUIRED_BUT_MISSING",
+    phaseOwner: "PR6C",
+    defaultSeverity: "P0",
+    defaultOutcome: "block_publish",
+    defaultRequiredAction: "block_publish",
+    description: "A noindex policy is required, but rendered HTML proof does not contain a noindex marker.",
+  },
+  {
+    code: "FULL_ANALYSIS_STRUCTURE_NOT_VALIDATED",
+    phaseOwner: "PR6A",
+    defaultSeverity: "P1",
+    defaultOutcome: "requires_review",
+    defaultRequiredAction: "review",
+    description: "Full-analysis identity passed before PR6B structural validation exists.",
+  },
+  {
+    code: "MISSING_CLUE_ROW",
+    phaseOwner: "PR6B",
+    defaultSeverity: "P0",
+    defaultOutcome: "downgrade_to_answer_first",
+    defaultRequiredAction: "enrich",
+    description: "Full-analysis clue rows are missing, unknown, or structurally incomplete.",
+  },
+  {
+    code: "DUPLICATE_CLUE_ROW",
+    phaseOwner: "PR6B",
+    defaultSeverity: "P0",
+    defaultOutcome: "downgrade_to_answer_first",
+    defaultRequiredAction: "enrich",
+    description: "Full-analysis contains duplicate clue-row coverage.",
+  },
+  {
+    code: "MISSING_EVIDENCE_REF",
+    phaseOwner: "PR6B",
+    defaultSeverity: "P0",
+    defaultOutcome: "downgrade_to_answer_first",
+    defaultRequiredAction: "enrich",
+    description: "A full-analysis clue row lacks an evidence ref string.",
+  },
+  {
+    code: "MISSING_REASONING_PATTERN",
+    phaseOwner: "PR6B",
+    defaultSeverity: "P0",
+    defaultOutcome: "downgrade_to_answer_first",
+    defaultRequiredAction: "enrich",
+    description: "Full-analysis reasoning is missing.",
+  },
+  {
+    code: "UNSUPPORTED_REASONING_PATTERN",
+    phaseOwner: "PR6B",
+    defaultSeverity: "P0",
+    defaultOutcome: "downgrade_to_answer_first",
+    defaultRequiredAction: "enrich",
+    description: "Full-analysis reasoning pattern or required reasoning fields are unsupported.",
+  },
+  {
+    code: "GENERIC_REASONING_PATTERN",
+    phaseOwner: "PR6B",
+    defaultSeverity: "P1",
+    defaultOutcome: "downgrade_to_answer_first",
+    defaultRequiredAction: "enrich",
+    description: "Full-analysis reasoning is too generic to trust as a solve path.",
+  },
+  {
+    code: "FAQ_SCHEMA_WITHOUT_VISIBLE_FAQ",
+    phaseOwner: "PR6B",
+    defaultSeverity: "P0",
+    defaultOutcome: "downgrade_to_answer_first",
+    defaultRequiredAction: "enrich",
+    description: "FAQPage schema exists without matching visible FAQ content.",
+  },
+  {
+    code: "INVALID_FAQ_STRUCTURE",
+    phaseOwner: "PR6B",
+    defaultSeverity: "P1",
+    defaultOutcome: "downgrade_to_answer_first",
+    defaultRequiredAction: "enrich",
+    description: "Full-analysis FAQ item count or shape is invalid.",
+  },
+  {
+    code: "INTERNAL_LINK_BROKEN",
+    phaseOwner: "PR6B",
+    defaultSeverity: "P1",
+    defaultOutcome: "downgrade_to_answer_first",
+    defaultRequiredAction: "enrich",
+    description: "Internal link is not route-shaped or is absent from the provided route index.",
+  },
+];
+
+export const CONTENT_KITCHEN_ISSUE_DEFINITIONS = new Map<ContentKitchenIssueCode, IssueCodeDefinition>(
+  CONTENT_KITCHEN_ISSUE_REGISTRY.map((definition) => [definition.code, definition]),
+);
+
+export function getIssueDefinition(code: ContentKitchenIssueCode): IssueCodeDefinition {
+  const definition = CONTENT_KITCHEN_ISSUE_DEFINITIONS.get(code);
+  if (!definition) {
+    throw new Error(`Unknown content kitchen issue code: ${code}`);
+  }
+  return definition;
+}
+
+export function getPr6P0IssueCodes(): ContentKitchenIssueCode[] {
+  return CONTENT_KITCHEN_ISSUE_REGISTRY
+    .filter((definition) => {
+      return definition.defaultSeverity === "P0" && definition.phaseOwner.startsWith("PR6");
+    })
+    .map((definition) => definition.code);
+}

--- a/lib/puzzles/content-kitchen/review-artifact.ts
+++ b/lib/puzzles/content-kitchen/review-artifact.ts
@@ -1,0 +1,104 @@
+import { createHash } from "node:crypto";
+import { getIssueDefinition } from "./issue-registry";
+import { normalizeIdentityText } from "./identity";
+import type {
+  ContentKitchenIssueCode,
+  ReviewArtifactEvidenceSummary,
+  ReviewArtifactReviewerAction,
+  ReviewArtifactV0,
+  ValidateCandidateInput,
+  ValidateCandidateOutput,
+} from "./types";
+
+export type BuildReviewArtifactInput = {
+  validationInput: ValidateCandidateInput;
+  validationOutput: ValidateCandidateOutput;
+  artifactId?: string;
+  createdAt?: string;
+  publishedRevisionId?: string;
+  renderedPreviewUrl?: string;
+  evidenceSummary?: ReviewArtifactEvidenceSummary;
+};
+
+function stableArtifactId(input: BuildReviewArtifactInput): string {
+  const candidateRevisionId = normalizeIdentityText(input.validationInput.candidate?.revisionId) || "unknown-revision";
+  const issueCodes = input.validationOutput.issues.map((issue) => issue.issueCode).join(".");
+  const hash = createHash("sha256")
+    .update(`${candidateRevisionId}:${input.validationOutput.outcome}:${issueCodes}`, "utf8")
+    .digest("hex")
+    .slice(0, 12);
+  return `art_review_${hash}`;
+}
+
+export function shouldCreateReviewArtifact(output: ValidateCandidateOutput): boolean {
+  return (
+    output.outcome === "requires_review" ||
+    output.outcome === "downgrade_to_answer_first" ||
+    output.outcome === "block_publish"
+  );
+}
+
+function allowedReviewerActions(output: ValidateCandidateOutput): ReviewArtifactReviewerAction[] {
+  if (output.outcome === "block_publish") {
+    return ["reject_candidate", "create_fix_task"];
+  }
+
+  if (output.outcome === "downgrade_to_answer_first") {
+    return ["approve_downgrade", "request_full_analysis_fix", "create_fix_task"];
+  }
+
+  if (output.outcome === "requires_review") {
+    return ["approve_candidate", "reject_candidate", "create_fix_task"];
+  }
+
+  return [];
+}
+
+function issueCodesRequiringDecision(output: ValidateCandidateOutput): ContentKitchenIssueCode[] {
+  return output.issues
+    .filter((issue) => issue.blocking || output.outcome !== "pass_answer_first" && output.outcome !== "pass_full_analysis")
+    .map((issue) => issue.issueCode);
+}
+
+export function buildReviewArtifactV0(input: BuildReviewArtifactInput): ReviewArtifactV0 | null {
+  const output = input.validationOutput;
+  if (!shouldCreateReviewArtifact(output)) {
+    return null;
+  }
+
+  for (const issue of output.issues) {
+    getIssueDefinition(issue.issueCode);
+  }
+
+  const candidate = input.validationInput.candidate;
+  const l1Input = input.validationInput.l1Input;
+
+  return {
+    artifactVersion: "content-kitchen-review-artifact-v0",
+    artifactId: input.artifactId ?? stableArtifactId(input),
+    artifactType: "review",
+    createdAt: input.createdAt ?? new Date(0).toISOString(),
+    ...(normalizeIdentityText(candidate?.puzzleId ?? l1Input?.puzzleId)
+      ? { puzzleId: normalizeIdentityText(candidate?.puzzleId ?? l1Input?.puzzleId) }
+      : {}),
+    ...(normalizeIdentityText(candidate?.canonicalUrl)
+      ? { canonicalUrl: normalizeIdentityText(candidate?.canonicalUrl) }
+      : {}),
+    ...(candidate?.contentMode ? { contentMode: candidate.contentMode } : {}),
+    ...(normalizeIdentityText(candidate?.revisionId)
+      ? { candidateRevisionId: normalizeIdentityText(candidate?.revisionId) }
+      : {}),
+    ...(input.publishedRevisionId ? { publishedRevisionId: input.publishedRevisionId } : {}),
+    validation: {
+      outcome: output.outcome,
+      policies: output.policies,
+      issueCodes: output.issues.map((issue) => issue.issueCode),
+      issues: output.issues,
+    },
+    issueCodesRequiringDecision: issueCodesRequiringDecision(output),
+    recommendedAction: output.policies.requiredAction,
+    allowedReviewerActions: allowedReviewerActions(output),
+    ...(input.evidenceSummary ? { evidenceSummary: input.evidenceSummary } : {}),
+    ...(input.renderedPreviewUrl ? { renderedPreviewUrl: input.renderedPreviewUrl } : {}),
+  };
+}

--- a/lib/puzzles/content-kitchen/types.ts
+++ b/lib/puzzles/content-kitchen/types.ts
@@ -170,3 +170,67 @@ export type ValidateCandidateOutput = {
   policies: ValidationPolicies;
   issues: ValidationIssue[];
 };
+
+export type IssuePhaseOwner =
+  | "PR6A"
+  | "PR6B"
+  | "PR6C"
+  | "PR7"
+  | "PR8"
+  | "PR10"
+  | "PR11";
+
+export type IssueCodeDefinition = {
+  code: ContentKitchenIssueCode;
+  phaseOwner: IssuePhaseOwner;
+  defaultSeverity: ContentKitchenIssueSeverity;
+  defaultOutcome: ValidationOutcome;
+  defaultRequiredAction: RequiredAction;
+  description: string;
+};
+
+export type FixtureExpectation = {
+  name: string;
+  expectedOutcome: ValidationOutcome;
+  expectedPolicies?: Partial<ValidationPolicies>;
+  expectedIssueCodes: ContentKitchenIssueCode[];
+  mustCreateArtifact?: boolean;
+};
+
+export type ReviewArtifactType = "review";
+
+export type ReviewArtifactReviewerAction =
+  | "approve_candidate"
+  | "approve_downgrade"
+  | "reject_candidate"
+  | "request_full_analysis_fix"
+  | "create_fix_task";
+
+export type ReviewArtifactEvidenceSummary = {
+  evidenceRefCount?: number;
+  sourceLevels?: string[];
+  notes?: string[];
+};
+
+export type ReviewArtifactV0 = {
+  artifactVersion: "content-kitchen-review-artifact-v0";
+  artifactId: string;
+  artifactType: ReviewArtifactType;
+  createdAt: string;
+  puzzleId?: string;
+  canonicalUrl?: string;
+  contentMode?: ContentMode;
+  candidateRevisionId?: string;
+  publishedRevisionId?: string;
+  validation: {
+    outcome: ValidationOutcome;
+    policies: ValidationPolicies;
+    issueCodes: ContentKitchenIssueCode[];
+    issues: ValidationIssue[];
+  };
+  issueCodesRequiringDecision: ContentKitchenIssueCode[];
+  recommendedAction: RequiredAction;
+  allowedReviewerActions: ReviewArtifactReviewerAction[];
+  evidenceSummary?: ReviewArtifactEvidenceSummary;
+  renderedPreviewUrl?: string;
+};

--- a/lib/puzzles/content-kitchen/validate-candidate.ts
+++ b/lib/puzzles/content-kitchen/validate-candidate.ts
@@ -124,6 +124,11 @@ function renderedHtmlShowsAnswerAndClues(renderedHtml: string | undefined, l1Inp
   });
 }
 
+function renderedHtmlHasNoindex(renderedHtml: string | undefined): boolean {
+  const normalizedHtml = normalizeIdentityMatch(renderedHtml);
+  return Boolean(normalizedHtml && normalizedHtml.includes("noindex"));
+}
+
 function isContentMode(value: unknown): value is ContentCandidate["contentMode"] {
   return value === "answer-first" || value === "full-analysis";
 }
@@ -286,6 +291,22 @@ export function validateCandidate(input: ValidateCandidateInput): ValidateCandid
   }
 
   const preliminaryPolicies = derivePolicies(input);
+  if (
+    preliminaryPolicies.indexPolicy === "noindex" &&
+    normalizeIdentityText(input.renderedHtml) &&
+    !renderedHtmlHasNoindex(input.renderedHtml)
+  ) {
+    return block(
+      makeIssue(
+        "NOINDEX_REQUIRED_BUT_MISSING",
+        "renderedHtml",
+        "Candidate requires noindex, but rendered HTML proof does not contain a noindex marker.",
+        "Add a noindex marker or do not provide rendered HTML proof for this candidate yet.",
+        { candidateRevisionId },
+      ),
+    );
+  }
+
   if (preliminaryPolicies.indexPolicy === "index" && !renderedHtmlShowsAnswerAndClues(input.renderedHtml, validatedL1)) {
     return output("requires_review", REVIEW_POLICIES, [
       makeIssue(

--- a/scripts/check-content-kitchen-contract.ts
+++ b/scripts/check-content-kitchen-contract.ts
@@ -3,6 +3,12 @@ import { readdir, readFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { hashInputSnapshot } from "../lib/puzzles/content-kitchen/identity";
+import {
+  CONTENT_KITCHEN_ISSUE_REGISTRY,
+  getIssueDefinition,
+  getPr6P0IssueCodes,
+} from "../lib/puzzles/content-kitchen/issue-registry";
+import { buildReviewArtifactV0, shouldCreateReviewArtifact } from "../lib/puzzles/content-kitchen/review-artifact";
 import { validateCandidate } from "../lib/puzzles/content-kitchen/validate-candidate";
 import type {
   ContentKitchenIssueCode,
@@ -14,6 +20,7 @@ import type {
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(SCRIPT_DIR, "..");
 const FIXTURE_DIR = resolve(ROOT, "lib", "puzzles", "content-kitchen", "fixtures");
+const EXAMPLE_DIR = resolve(ROOT, "lib", "puzzles", "content-kitchen", "examples");
 
 type Fixture = {
   name: string;
@@ -22,6 +29,7 @@ type Fixture = {
     outcome: ValidationOutcome;
     policies?: Partial<ValidationPolicies>;
     issueCodes?: ContentKitchenIssueCode[];
+    mustCreateArtifact?: boolean;
   };
 };
 
@@ -76,6 +84,86 @@ function assertIssueCodes(
   );
 }
 
+function assertIssuesAreRegistered(fileName: string, issueCodes: ContentKitchenIssueCode[]) {
+  for (const issueCode of issueCodes) {
+    assert.doesNotThrow(() => getIssueDefinition(issueCode), `${fileName}: ${issueCode} should be registered`);
+  }
+}
+
+function assertReviewArtifactBehavior(fileName: string, fixture: Fixture, actual: ReturnType<typeof validateCandidate>) {
+  const hydratedInput = hydrateFixtureInput(fixture.input);
+  const artifact = buildReviewArtifactV0({
+    validationInput: hydratedInput,
+    validationOutput: actual,
+    createdAt: "2026-05-23T00:00:00.000Z",
+  });
+
+  const shouldCreate = shouldCreateReviewArtifact(actual);
+  assert.equal(Boolean(artifact), shouldCreate, `${fileName}: artifact creation should follow validation outcome`);
+
+  if (fixture.expected.mustCreateArtifact != null) {
+    assert.equal(Boolean(artifact), fixture.expected.mustCreateArtifact, `${fileName}: mustCreateArtifact should match`);
+  }
+
+  if (!artifact) return;
+
+  assert.equal(artifact.artifactVersion, "content-kitchen-review-artifact-v0", `${fileName}: artifact version should be stable`);
+  assert.equal(artifact.validation.outcome, actual.outcome, `${fileName}: artifact outcome should match validation`);
+  assert.deepEqual(
+    artifact.validation.issueCodes,
+    actual.issues.map((issue) => issue.issueCode),
+    `${fileName}: artifact issue codes should match validation`,
+  );
+  assert.ok(artifact.allowedReviewerActions.length > 0, `${fileName}: artifact should include reviewer actions`);
+
+  const serialized = JSON.stringify(artifact);
+  if (typeof hydratedInput.renderedHtml === "string" && hydratedInput.renderedHtml.trim()) {
+    assert.ok(
+      !serialized.includes(hydratedInput.renderedHtml),
+      `${fileName}: artifact must not include raw rendered HTML content`,
+    );
+  }
+  assert.ok(!serialized.includes("secret"), `${fileName}: artifact must not include obvious secret strings`);
+}
+
+function assertPr6P0Coverage(fixtures: Fixture[]) {
+  const negativeIssueCodes = new Set<ContentKitchenIssueCode>();
+
+  for (const fixture of fixtures) {
+    if (fixture.expected.outcome === "pass_answer_first" || fixture.expected.outcome === "pass_full_analysis") {
+      continue;
+    }
+
+    for (const issueCode of fixture.expected.issueCodes ?? []) {
+      negativeIssueCodes.add(issueCode);
+    }
+  }
+
+  const missing = getPr6P0IssueCodes().filter((issueCode) => !negativeIssueCodes.has(issueCode));
+  assert.deepEqual(missing, [], "every PR6 P0 issue code should have at least one negative fixture");
+}
+
+function assertIssueRegistryIsStable() {
+  const seen = new Set<ContentKitchenIssueCode>();
+  for (const definition of CONTENT_KITCHEN_ISSUE_REGISTRY) {
+    assert.ok(!seen.has(definition.code), `duplicate issue code in registry: ${definition.code}`);
+    seen.add(definition.code);
+    assert.ok(definition.description.trim(), `${definition.code}: description is required`);
+  }
+}
+
+async function assertExamplesAreValidJson() {
+  const fileNames = (await readdir(EXAMPLE_DIR)).filter((fileName) => fileName.endsWith(".json")).sort();
+  assert.ok(fileNames.length >= 2, "content kitchen should include stable PR6C JSON examples");
+
+  for (const fileName of fileNames) {
+    const raw = await readFile(resolve(EXAMPLE_DIR, fileName), "utf8");
+    const parsed = JSON.parse(raw) as unknown;
+    assert.ok(parsed && typeof parsed === "object", `${fileName}: example should parse as a JSON object`);
+    assert.ok(!raw.includes("<main"), `${fileName}: examples should not include raw rendered HTML`);
+  }
+}
+
 function checkHashExcludesVolatileFields() {
   const base = {
     puzzleId: "pinpoint-900-2026-05-23",
@@ -120,9 +208,11 @@ function checkHashExcludesVolatileFields() {
 async function main() {
   const fileNames = (await readdir(FIXTURE_DIR)).filter((fileName) => fileName.endsWith(".json")).sort();
   assert.ok(fileNames.length >= 6, "content kitchen should have at least 6 fixtures");
+  const fixtures: Fixture[] = [];
 
   for (const fileName of fileNames) {
     const fixture = await readFixture(fileName);
+    fixtures.push(fixture);
     const actual = validateCandidate(hydrateFixtureInput(fixture.input));
     assert.equal(actual.outcome, fixture.expected.outcome, `${fileName}: outcome should match`);
     assertPolicySubset(fileName, actual.policies, fixture.expected.policies);
@@ -131,9 +221,14 @@ async function main() {
       actual.issues.map((issue) => issue.issueCode),
       fixture.expected.issueCodes,
     );
+    assertIssuesAreRegistered(fileName, actual.issues.map((issue) => issue.issueCode));
+    assertReviewArtifactBehavior(fileName, fixture, actual);
   }
 
   checkHashExcludesVolatileFields();
+  assertIssueRegistryIsStable();
+  assertPr6P0Coverage(fixtures);
+  await assertExamplesAreValidJson();
   console.log(`content-kitchen contract fixtures passed (${fileNames.length} fixtures)`);
 }
 


### PR DESCRIPTION
## Summary
- add content-kitchen issue registry with phase, severity, outcome, and action defaults
- add review artifact v0 builder for requires-review, downgrade, and blocked validation results
- add stable JSON examples for validation output and review artifact shape
- extend fixture runner to check issue registry coverage, PR6 P0 negative fixture coverage, and artifact creation
- add fixtures for noindex marker mismatch and unsupported reasoning pattern; fixture count is now 26

## Validation
- `npm run test:content-kitchen`
- `npm run typecheck`
- `npm run lint`
- pre-push `npm run validate:data`

## Scope Guard
- does not change production rendering
- does not change sitemap behavior
- does not change Worker publish behavior
- does not add persistence or review UI
- artifacts intentionally exclude raw rendered HTML content and raw prompts
