### PR TITLE
Add PR7 evidence source validation

### DIFF
--- a/lib/puzzles/content-kitchen/evidence.ts
+++ b/lib/puzzles/content-kitchen/evidence.ts
@@ -1,0 +1,252 @@
+import { normalizeIdentityMatch, normalizeIdentityText } from "./identity";
+import type {
+  ContentCandidate,
+  ContentKitchenEvidenceRecord,
+  ContentKitchenIssueCode,
+  EvidenceConfidence,
+  EvidenceSourceLevel,
+  EvidenceSourceType,
+  FullAnalysisClueRowCandidate,
+  L1PuzzleInput,
+  ValidationIssue,
+} from "./types";
+
+type EvidenceCoverageInput = {
+  candidate: Partial<ContentCandidate>;
+  l1Input: L1PuzzleInput;
+  evidenceRecords?: Partial<ContentKitchenEvidenceRecord>[];
+};
+
+type IssueOptions = {
+  severity?: "P0" | "P1" | "P2";
+  blocking?: boolean;
+  candidateRevisionId?: string;
+};
+
+export const L2_SOURCE_ALLOWLIST: EvidenceSourceType[] = [
+  "category_membership",
+  "alias_dictionary",
+  "deterministic_lookup",
+];
+
+export const PROHIBITED_EVIDENCE_SOURCE_TYPES: EvidenceSourceType[] = [
+  "competitor_answer_page",
+  "answer_aggregator",
+  "ai_summary",
+  "search_snippet",
+  "generated_page",
+];
+
+const L2_SOURCE_ALLOWLIST_SET = new Set<EvidenceSourceType>(L2_SOURCE_ALLOWLIST);
+const PROHIBITED_EVIDENCE_SOURCE_TYPE_SET = new Set<EvidenceSourceType>(PROHIBITED_EVIDENCE_SOURCE_TYPES);
+const SOURCE_LEVELS = new Set<EvidenceSourceLevel>(["L1", "L2", "L3", "L4", "L5"]);
+const CONFIDENCE_LEVELS = new Set<EvidenceConfidence>(["high", "medium", "low"]);
+
+function makeIssue(
+  issueCode: ContentKitchenIssueCode,
+  fieldPath: string,
+  message: string,
+  suggestedAction: string,
+  options: IssueOptions = {},
+): ValidationIssue {
+  return {
+    issueCode,
+    severity: options.severity ?? "P1",
+    fieldPath,
+    message,
+    suggestedAction,
+    blocking: options.blocking ?? false,
+    ...(options.candidateRevisionId ? { candidateRevisionId: options.candidateRevisionId } : {}),
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function isIsoUtc(value: unknown): boolean {
+  return /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/.test(normalizeIdentityText(value));
+}
+
+function evidenceById(records: Partial<ContentKitchenEvidenceRecord>[]): Map<string, Partial<ContentKitchenEvidenceRecord>> {
+  const byId = new Map<string, Partial<ContentKitchenEvidenceRecord>>();
+  for (const record of records) {
+    const evidenceId = normalizeIdentityText(record.evidenceId);
+    if (evidenceId) {
+      byId.set(evidenceId, record);
+    }
+  }
+  return byId;
+}
+
+function sourceLevel(record: Partial<ContentKitchenEvidenceRecord>): EvidenceSourceLevel | "" {
+  return SOURCE_LEVELS.has(record.sourceLevel as EvidenceSourceLevel) ? record.sourceLevel as EvidenceSourceLevel : "";
+}
+
+function confidence(record: Partial<ContentKitchenEvidenceRecord>): EvidenceConfidence | "" {
+  return CONFIDENCE_LEVELS.has(record.confidence as EvidenceConfidence) ? record.confidence as EvidenceConfidence : "";
+}
+
+function sourceType(record: Partial<ContentKitchenEvidenceRecord>): EvidenceSourceType | "" {
+  return normalizeIdentityText(record.sourceType) as EvidenceSourceType | "";
+}
+
+function referencesClue(record: Partial<ContentKitchenEvidenceRecord>, row: FullAnalysisClueRowCandidate): boolean {
+  return normalizeIdentityMatch(record.clueId) === normalizeIdentityMatch(row.clueId);
+}
+
+function supportsFit(record: Partial<ContentKitchenEvidenceRecord>): boolean {
+  return record.supportKind === "fit";
+}
+
+function hasRequiredRecordShape(record: Partial<ContentKitchenEvidenceRecord>): boolean {
+  return Boolean(
+    normalizeIdentityText(record.evidenceId) &&
+      sourceLevel(record) &&
+      sourceType(record) &&
+      record.supportKind &&
+      normalizeIdentityText(record.claim) &&
+      confidence(record),
+  );
+}
+
+function hasUnresolvedConflict(record: Partial<ContentKitchenEvidenceRecord>): boolean {
+  return record.conflictStatus === "unresolved";
+}
+
+function hasProhibitedSource(record: Partial<ContentKitchenEvidenceRecord>): boolean {
+  return PROHIBITED_EVIDENCE_SOURCE_TYPE_SET.has(sourceType(record) as EvidenceSourceType);
+}
+
+function hasStrongL2Fit(record: Partial<ContentKitchenEvidenceRecord>): boolean {
+  return (
+    sourceLevel(record) === "L2" &&
+    L2_SOURCE_ALLOWLIST_SET.has(sourceType(record) as EvidenceSourceType) &&
+    normalizeIdentityText(record.lookupVersion) !== "" &&
+    confidence(record) !== "low"
+  );
+}
+
+function hasStrongL5Fit(record: Partial<ContentKitchenEvidenceRecord>): boolean {
+  return (
+    sourceLevel(record) === "L5" &&
+    sourceType(record) === "human_review" &&
+    normalizeIdentityText(record.humanVerifiedBy) !== "" &&
+    isIsoUtc(record.humanVerifiedAt) &&
+    confidence(record) !== "low"
+  );
+}
+
+function isStrongFitEvidence(record: Partial<ContentKitchenEvidenceRecord>): boolean {
+  return (
+    hasRequiredRecordShape(record) &&
+    supportsFit(record) &&
+    !hasUnresolvedConflict(record) &&
+    !hasProhibitedSource(record) &&
+    (hasStrongL2Fit(record) || hasStrongL5Fit(record))
+  );
+}
+
+function issueForWeakRow(
+  fieldPath: string,
+  rowEvidence: Partial<ContentKitchenEvidenceRecord>[],
+  candidateRevisionId: string,
+): ValidationIssue {
+  if (rowEvidence.some(hasProhibitedSource)) {
+    return makeIssue(
+      "PROHIBITED_EVIDENCE_SOURCE",
+      fieldPath,
+      "A full-analysis clue row cites a prohibited evidence source.",
+      "Remove competitor, aggregator, AI summary, search-snippet, or generated-page evidence.",
+      { severity: "P0", candidateRevisionId },
+    );
+  }
+
+  if (rowEvidence.some(hasUnresolvedConflict)) {
+    return makeIssue(
+      "EVIDENCE_SOURCE_CONFLICT",
+      fieldPath,
+      "A full-analysis clue row has an unresolved evidence conflict.",
+      "Resolve the conflict or send this candidate to human review.",
+      { candidateRevisionId },
+    );
+  }
+
+  if (rowEvidence.length > 0 && rowEvidence.every((record) => sourceLevel(record) === "L4")) {
+    return makeIssue(
+      "L4_ONLY_EVIDENCE",
+      fieldPath,
+      "A full-analysis clue row only has L4 model-consensus evidence.",
+      "Add reviewed L2 evidence or human-reviewed L5 evidence.",
+      { candidateRevisionId },
+    );
+  }
+
+  if (rowEvidence.length > 0 && rowEvidence.every((record) => confidence(record) === "low")) {
+    return makeIssue(
+      "FULL_ANALYSIS_WITH_LOW_CONFIDENCE",
+      fieldPath,
+      "A full-analysis clue row only has low-confidence evidence.",
+      "Add stronger fit evidence or send this candidate to review.",
+      { candidateRevisionId },
+    );
+  }
+
+  return makeIssue(
+    "WEAK_FIT_EVIDENCE",
+    fieldPath,
+    "A full-analysis clue row does not have strong reviewed fit evidence.",
+    "Add L2 lookup evidence with lookupVersion or L5 human-reviewed evidence.",
+    { candidateRevisionId },
+  );
+}
+
+export function validateFullAnalysisEvidence(input: EvidenceCoverageInput): ValidationIssue[] {
+  const candidateRevisionId = normalizeIdentityText(input.candidate.revisionId);
+  const rows = Array.isArray(input.candidate.clueRows)
+    ? input.candidate.clueRows as FullAnalysisClueRowCandidate[]
+    : [];
+  const records = Array.isArray(input.evidenceRecords) ? input.evidenceRecords : [];
+
+  if (records.length === 0) {
+    return [
+      makeIssue(
+        "WEAK_FIT_EVIDENCE",
+        "evidenceRecords",
+        "Full-analysis needs evidence records before it can auto-pass.",
+        "Attach L2 dictionary evidence or L5 human-reviewed evidence.",
+        { candidateRevisionId },
+      ),
+    ];
+  }
+
+  const byId = evidenceById(records);
+  for (let index = 0; index < rows.length; index += 1) {
+    const row = rows[index];
+    const fieldPath = `candidate.clueRows[${index}].evidenceRefs`;
+    const linked = row.evidenceRefs.map((evidenceRef) => byId.get(normalizeIdentityText(evidenceRef))).filter(isRecord);
+    const rowFitEvidence = linked.filter((record) => referencesClue(record, row) && supportsFit(record));
+
+    if (rowFitEvidence.length === 0) {
+      return [
+        makeIssue(
+          "UNSUPPORTED_CLUE_FIT",
+          fieldPath,
+          "A full-analysis clue row has no matching clue-fit evidence record.",
+          "Make the row evidenceRefs point to fit evidence for the same L1 clue id.",
+          { severity: "P0", candidateRevisionId },
+        ),
+      ];
+    }
+
+    if (
+      rowFitEvidence.some(hasProhibitedSource) ||
+      rowFitEvidence.some(hasUnresolvedConflict) ||
+      !rowFitEvidence.some(isStrongFitEvidence)
+    ) {
+      return [issueForWeakRow(fieldPath, rowFitEvidence, candidateRevisionId)];
+    }
+  }
+
+  return [];
+}

--- a/lib/puzzles/content-kitchen/fixtures/full-analysis-cumulative-confirmation.valid.json
+++ b/lib/puzzles/content-kitchen/fixtures/full-analysis-cumulative-confirmation.valid.json
@@ -8,6 +8,13 @@
     },
     "existingRoutes": ["/linkedin-pinpoint-answers/pinpoint-answer-899/"],
     "renderedHtml": "<main><h1>Types of guitar</h1><p>Bass Classical Electric Acoustic Steel</p><section><h2>FAQ</h2><h3>Why does Bass fit?</h3><p>Bass is a guitar type in this board.</p><h3>Why does Electric matter?</h3><p>Electric confirms the guitar-type answer.</p></section></main>",
+    "evidenceRecords": [
+      { "evidenceId": "ev-bass", "clueId": "clue-1", "sourceLevel": "L2", "sourceType": "category_membership", "supportKind": "fit", "claim": "Bass is a member of Types of guitar.", "confidence": "high", "lookupVersion": "category_membership_2026_05_23" },
+      { "evidenceId": "ev-classical", "clueId": "clue-2", "sourceLevel": "L2", "sourceType": "category_membership", "supportKind": "fit", "claim": "Classical is a member of Types of guitar.", "confidence": "high", "lookupVersion": "category_membership_2026_05_23" },
+      { "evidenceId": "ev-electric", "clueId": "clue-3", "sourceLevel": "L2", "sourceType": "category_membership", "supportKind": "fit", "claim": "Electric is a member of Types of guitar.", "confidence": "high", "lookupVersion": "category_membership_2026_05_23" },
+      { "evidenceId": "ev-acoustic", "clueId": "clue-4", "sourceLevel": "L2", "sourceType": "category_membership", "supportKind": "fit", "claim": "Acoustic is a member of Types of guitar.", "confidence": "high", "lookupVersion": "category_membership_2026_05_23" },
+      { "evidenceId": "ev-steel", "clueId": "clue-5", "sourceLevel": "L2", "sourceType": "category_membership", "supportKind": "fit", "claim": "Steel is a member of Types of guitar.", "confidence": "high", "lookupVersion": "category_membership_2026_05_23" }
+    ],
     "l1Input": {
       "puzzleId": "pinpoint-900-2026-05-23",
       "puzzleNumber": 900,

--- a/lib/puzzles/content-kitchen/fixtures/full-analysis-evidence-conflict.requires-review.json
+++ b/lib/puzzles/content-kitchen/fixtures/full-analysis-evidence-conflict.requires-review.json
@@ -1,14 +1,14 @@
 {
-  "name": "full-analysis-turning-point.valid",
+  "name": "full-analysis-evidence-conflict.requires-review",
   "input": {
     "canonicalConfig": {
       "siteBaseUrl": "https://example.com",
       "detailRoutePrefix": "/linkedin-pinpoint-answers",
       "trailingSlash": true
     },
-    "renderedHtml": "<main><h1>Types of guitar</h1><p>Bass Classical Electric Acoustic Steel</p><section>Electric changes the solve because it narrows the board from instruments generally to guitar types.</section></main>",
+    "renderedHtml": "<main><h1>Types of guitar</h1><p>Bass Classical Electric Acoustic Steel</p></main>",
     "evidenceRecords": [
-      { "evidenceId": "ev-bass", "clueId": "clue-1", "sourceLevel": "L2", "sourceType": "category_membership", "supportKind": "fit", "claim": "Bass is a member of Types of guitar.", "confidence": "high", "lookupVersion": "category_membership_2026_05_23" },
+      { "evidenceId": "ev-bass", "clueId": "clue-1", "sourceLevel": "L2", "sourceType": "category_membership", "supportKind": "fit", "claim": "Bass is a member of Types of guitar.", "confidence": "high", "lookupVersion": "category_membership_2026_05_23", "conflictStatus": "unresolved" },
       { "evidenceId": "ev-classical", "clueId": "clue-2", "sourceLevel": "L2", "sourceType": "category_membership", "supportKind": "fit", "claim": "Classical is a member of Types of guitar.", "confidence": "high", "lookupVersion": "category_membership_2026_05_23" },
       { "evidenceId": "ev-electric", "clueId": "clue-3", "sourceLevel": "L2", "sourceType": "category_membership", "supportKind": "fit", "claim": "Electric is a member of Types of guitar.", "confidence": "high", "lookupVersion": "category_membership_2026_05_23" },
       { "evidenceId": "ev-acoustic", "clueId": "clue-4", "sourceLevel": "L2", "sourceType": "category_membership", "supportKind": "fit", "claim": "Acoustic is a member of Types of guitar.", "confidence": "high", "lookupVersion": "category_membership_2026_05_23" },
@@ -33,9 +33,9 @@
       "slug": "pinpoint-answer-900",
       "canonicalUrl": "https://example.com/linkedin-pinpoint-answers/pinpoint-answer-900/",
       "contentMode": "full-analysis",
-      "revisionId": "rev-full-analysis-turning-point",
+      "revisionId": "rev-evidence-conflict",
       "inputSnapshotHash": "__HASH_L1__",
-      "contentHash": "sha256:content-full-analysis-turning-point",
+      "contentHash": "sha256:content-evidence-conflict",
       "answer": "Types of guitar",
       "clues": [
         { "clueId": "clue-1", "text": "Bass", "position": 1 },
@@ -45,30 +45,29 @@
         { "clueId": "clue-5", "text": "Steel", "position": 5 }
       ],
       "clueRows": [
-        { "clueId": "clue-1", "clueText": "Bass", "fit": "Bass guitar", "whyItSupportsAnswer": "Bass is a standard guitar type.", "evidenceRefs": ["ev-bass"] },
-        { "clueId": "clue-2", "clueText": "Classical", "fit": "Classical guitar", "whyItSupportsAnswer": "Classical is a recognized guitar type.", "evidenceRefs": ["ev-classical"] },
-        { "clueId": "clue-3", "clueText": "Electric", "fit": "Electric guitar", "whyItSupportsAnswer": "Electric gives the strongest guitar-specific clue.", "evidenceRefs": ["ev-electric"] },
-        { "clueId": "clue-4", "clueText": "Acoustic", "fit": "Acoustic guitar", "whyItSupportsAnswer": "Acoustic supports the same answer set.", "evidenceRefs": ["ev-acoustic"] },
-        { "clueId": "clue-5", "clueText": "Steel", "fit": "Steel guitar", "whyItSupportsAnswer": "Steel confirms the board is about guitar types.", "evidenceRefs": ["ev-steel"] }
+        { "clueId": "clue-1", "fit": "Bass guitar", "whyItSupportsAnswer": "Bass is a guitar type.", "evidenceRefs": ["ev-bass"] },
+        { "clueId": "clue-2", "fit": "Classical guitar", "whyItSupportsAnswer": "Classical is a guitar type.", "evidenceRefs": ["ev-classical"] },
+        { "clueId": "clue-3", "fit": "Electric guitar", "whyItSupportsAnswer": "Electric is a guitar type.", "evidenceRefs": ["ev-electric"] },
+        { "clueId": "clue-4", "fit": "Acoustic guitar", "whyItSupportsAnswer": "Acoustic is a guitar type.", "evidenceRefs": ["ev-acoustic"] },
+        { "clueId": "clue-5", "fit": "Steel guitar", "whyItSupportsAnswer": "Steel is a guitar type.", "evidenceRefs": ["ev-steel"] }
       ],
       "reasoning": {
-        "pattern": "turning_point",
-        "clueId": "clue-3",
-        "brokenTheory": "general instruments",
-        "supportedTheory": "types of guitar",
-        "text": "Electric changes the solve because it narrows the board from instruments generally to guitar types, then Bass and Classical confirm that reading."
+        "pattern": "cumulative_confirmation",
+        "clueIds": ["clue-1", "clue-2", "clue-3"],
+        "text": "Bass and Classical point toward guitar types, while Electric, Acoustic, and Steel support the same answer from separate clues."
       }
     }
   },
   "expected": {
-    "outcome": "pass_full_analysis",
+    "outcome": "requires_review",
     "policies": {
-      "indexPolicy": "index",
-      "sitemapPolicy": "include",
+      "indexPolicy": "review_required",
+      "sitemapPolicy": "include_after_audit",
       "schemaPolicy": "article_only",
-      "internalLinkPolicy": "normal",
-      "requiredAction": "none"
+      "internalLinkPolicy": "deemphasized",
+      "requiredAction": "review"
     },
-    "issueCodes": []
+    "issueCodes": ["EVIDENCE_SOURCE_CONFLICT"],
+    "mustCreateArtifact": true
   }
 }

--- a/lib/puzzles/content-kitchen/fixtures/full-analysis-evidence-ref-unknown.requires-review.json
+++ b/lib/puzzles/content-kitchen/fixtures/full-analysis-evidence-ref-unknown.requires-review.json
@@ -1,0 +1,69 @@
+{
+  "name": "full-analysis-evidence-ref-unknown.requires-review",
+  "input": {
+    "canonicalConfig": {
+      "siteBaseUrl": "https://example.com",
+      "detailRoutePrefix": "/linkedin-pinpoint-answers",
+      "trailingSlash": true
+    },
+    "renderedHtml": "<main><h1>Types of guitar</h1><p>Bass Classical Electric Acoustic Steel</p></main>",
+    "evidenceRecords": [
+      { "evidenceId": "ev-classical", "clueId": "clue-2", "sourceLevel": "L2", "sourceType": "category_membership", "supportKind": "fit", "claim": "Classical is a member of Types of guitar.", "confidence": "high", "lookupVersion": "category_membership_2026_05_23" }
+    ],
+    "l1Input": {
+      "puzzleId": "pinpoint-900-2026-05-23",
+      "puzzleNumber": 900,
+      "logicalGameDate": "2026-05-23",
+      "source": "official_capture",
+      "answer": "Types of guitar",
+      "clues": [
+        { "clueId": "clue-1", "text": "Bass", "position": 1 },
+        { "clueId": "clue-2", "text": "Classical", "position": 2 },
+        { "clueId": "clue-3", "text": "Electric", "position": 3 },
+        { "clueId": "clue-4", "text": "Acoustic", "position": 4 },
+        { "clueId": "clue-5", "text": "Steel", "position": 5 }
+      ]
+    },
+    "candidate": {
+      "puzzleId": "pinpoint-900-2026-05-23",
+      "slug": "pinpoint-answer-900",
+      "canonicalUrl": "https://example.com/linkedin-pinpoint-answers/pinpoint-answer-900/",
+      "contentMode": "full-analysis",
+      "revisionId": "rev-evidence-ref-unknown",
+      "inputSnapshotHash": "__HASH_L1__",
+      "contentHash": "sha256:content-evidence-ref-unknown",
+      "answer": "Types of guitar",
+      "clues": [
+        { "clueId": "clue-1", "text": "Bass", "position": 1 },
+        { "clueId": "clue-2", "text": "Classical", "position": 2 },
+        { "clueId": "clue-3", "text": "Electric", "position": 3 },
+        { "clueId": "clue-4", "text": "Acoustic", "position": 4 },
+        { "clueId": "clue-5", "text": "Steel", "position": 5 }
+      ],
+      "clueRows": [
+        { "clueId": "clue-1", "fit": "Bass guitar", "whyItSupportsAnswer": "Bass is a guitar type.", "evidenceRefs": ["ev-bass"] },
+        { "clueId": "clue-2", "fit": "Classical guitar", "whyItSupportsAnswer": "Classical is a guitar type.", "evidenceRefs": ["ev-classical"] },
+        { "clueId": "clue-3", "fit": "Electric guitar", "whyItSupportsAnswer": "Electric is a guitar type.", "evidenceRefs": ["ev-electric"] },
+        { "clueId": "clue-4", "fit": "Acoustic guitar", "whyItSupportsAnswer": "Acoustic is a guitar type.", "evidenceRefs": ["ev-acoustic"] },
+        { "clueId": "clue-5", "fit": "Steel guitar", "whyItSupportsAnswer": "Steel is a guitar type.", "evidenceRefs": ["ev-steel"] }
+      ],
+      "reasoning": {
+        "pattern": "cumulative_confirmation",
+        "clueIds": ["clue-1", "clue-2", "clue-3"],
+        "text": "Bass and Classical point toward guitar types, while Electric, Acoustic, and Steel support the same answer from separate clues."
+      }
+    }
+  },
+  "expected": {
+    "outcome": "requires_review",
+    "policies": {
+      "indexPolicy": "review_required",
+      "sitemapPolicy": "include_after_audit",
+      "schemaPolicy": "article_only",
+      "internalLinkPolicy": "deemphasized",
+      "requiredAction": "review"
+    },
+    "issueCodes": ["UNSUPPORTED_CLUE_FIT"],
+    "mustCreateArtifact": true
+  }
+}

--- a/lib/puzzles/content-kitchen/fixtures/full-analysis-l2-missing-lookup-version.requires-review.json
+++ b/lib/puzzles/content-kitchen/fixtures/full-analysis-l2-missing-lookup-version.requires-review.json
@@ -1,14 +1,14 @@
 {
-  "name": "full-analysis-turning-point.valid",
+  "name": "full-analysis-l2-missing-lookup-version.requires-review",
   "input": {
     "canonicalConfig": {
       "siteBaseUrl": "https://example.com",
       "detailRoutePrefix": "/linkedin-pinpoint-answers",
       "trailingSlash": true
     },
-    "renderedHtml": "<main><h1>Types of guitar</h1><p>Bass Classical Electric Acoustic Steel</p><section>Electric changes the solve because it narrows the board from instruments generally to guitar types.</section></main>",
+    "renderedHtml": "<main><h1>Types of guitar</h1><p>Bass Classical Electric Acoustic Steel</p></main>",
     "evidenceRecords": [
-      { "evidenceId": "ev-bass", "clueId": "clue-1", "sourceLevel": "L2", "sourceType": "category_membership", "supportKind": "fit", "claim": "Bass is a member of Types of guitar.", "confidence": "high", "lookupVersion": "category_membership_2026_05_23" },
+      { "evidenceId": "ev-bass", "clueId": "clue-1", "sourceLevel": "L2", "sourceType": "category_membership", "supportKind": "fit", "claim": "Bass is a member of Types of guitar.", "confidence": "high" },
       { "evidenceId": "ev-classical", "clueId": "clue-2", "sourceLevel": "L2", "sourceType": "category_membership", "supportKind": "fit", "claim": "Classical is a member of Types of guitar.", "confidence": "high", "lookupVersion": "category_membership_2026_05_23" },
       { "evidenceId": "ev-electric", "clueId": "clue-3", "sourceLevel": "L2", "sourceType": "category_membership", "supportKind": "fit", "claim": "Electric is a member of Types of guitar.", "confidence": "high", "lookupVersion": "category_membership_2026_05_23" },
       { "evidenceId": "ev-acoustic", "clueId": "clue-4", "sourceLevel": "L2", "sourceType": "category_membership", "supportKind": "fit", "claim": "Acoustic is a member of Types of guitar.", "confidence": "high", "lookupVersion": "category_membership_2026_05_23" },
@@ -33,9 +33,9 @@
       "slug": "pinpoint-answer-900",
       "canonicalUrl": "https://example.com/linkedin-pinpoint-answers/pinpoint-answer-900/",
       "contentMode": "full-analysis",
-      "revisionId": "rev-full-analysis-turning-point",
+      "revisionId": "rev-l2-missing-lookup-version",
       "inputSnapshotHash": "__HASH_L1__",
-      "contentHash": "sha256:content-full-analysis-turning-point",
+      "contentHash": "sha256:content-l2-missing-lookup-version",
       "answer": "Types of guitar",
       "clues": [
         { "clueId": "clue-1", "text": "Bass", "position": 1 },
@@ -45,30 +45,29 @@
         { "clueId": "clue-5", "text": "Steel", "position": 5 }
       ],
       "clueRows": [
-        { "clueId": "clue-1", "clueText": "Bass", "fit": "Bass guitar", "whyItSupportsAnswer": "Bass is a standard guitar type.", "evidenceRefs": ["ev-bass"] },
-        { "clueId": "clue-2", "clueText": "Classical", "fit": "Classical guitar", "whyItSupportsAnswer": "Classical is a recognized guitar type.", "evidenceRefs": ["ev-classical"] },
-        { "clueId": "clue-3", "clueText": "Electric", "fit": "Electric guitar", "whyItSupportsAnswer": "Electric gives the strongest guitar-specific clue.", "evidenceRefs": ["ev-electric"] },
-        { "clueId": "clue-4", "clueText": "Acoustic", "fit": "Acoustic guitar", "whyItSupportsAnswer": "Acoustic supports the same answer set.", "evidenceRefs": ["ev-acoustic"] },
-        { "clueId": "clue-5", "clueText": "Steel", "fit": "Steel guitar", "whyItSupportsAnswer": "Steel confirms the board is about guitar types.", "evidenceRefs": ["ev-steel"] }
+        { "clueId": "clue-1", "fit": "Bass guitar", "whyItSupportsAnswer": "Bass is a guitar type.", "evidenceRefs": ["ev-bass"] },
+        { "clueId": "clue-2", "fit": "Classical guitar", "whyItSupportsAnswer": "Classical is a guitar type.", "evidenceRefs": ["ev-classical"] },
+        { "clueId": "clue-3", "fit": "Electric guitar", "whyItSupportsAnswer": "Electric is a guitar type.", "evidenceRefs": ["ev-electric"] },
+        { "clueId": "clue-4", "fit": "Acoustic guitar", "whyItSupportsAnswer": "Acoustic is a guitar type.", "evidenceRefs": ["ev-acoustic"] },
+        { "clueId": "clue-5", "fit": "Steel guitar", "whyItSupportsAnswer": "Steel is a guitar type.", "evidenceRefs": ["ev-steel"] }
       ],
       "reasoning": {
-        "pattern": "turning_point",
-        "clueId": "clue-3",
-        "brokenTheory": "general instruments",
-        "supportedTheory": "types of guitar",
-        "text": "Electric changes the solve because it narrows the board from instruments generally to guitar types, then Bass and Classical confirm that reading."
+        "pattern": "cumulative_confirmation",
+        "clueIds": ["clue-1", "clue-2", "clue-3"],
+        "text": "Bass and Classical point toward guitar types, while Electric, Acoustic, and Steel support the same answer from separate clues."
       }
     }
   },
   "expected": {
-    "outcome": "pass_full_analysis",
+    "outcome": "requires_review",
     "policies": {
-      "indexPolicy": "index",
-      "sitemapPolicy": "include",
+      "indexPolicy": "review_required",
+      "sitemapPolicy": "include_after_audit",
       "schemaPolicy": "article_only",
-      "internalLinkPolicy": "normal",
-      "requiredAction": "none"
+      "internalLinkPolicy": "deemphasized",
+      "requiredAction": "review"
     },
-    "issueCodes": []
+    "issueCodes": ["WEAK_FIT_EVIDENCE"],
+    "mustCreateArtifact": true
   }
 }

--- a/lib/puzzles/content-kitchen/fixtures/full-analysis-l4-only-evidence.requires-review.json
+++ b/lib/puzzles/content-kitchen/fixtures/full-analysis-l4-only-evidence.requires-review.json
@@ -1,0 +1,73 @@
+{
+  "name": "full-analysis-l4-only-evidence.requires-review",
+  "input": {
+    "canonicalConfig": {
+      "siteBaseUrl": "https://example.com",
+      "detailRoutePrefix": "/linkedin-pinpoint-answers",
+      "trailingSlash": true
+    },
+    "renderedHtml": "<main><h1>Types of guitar</h1><p>Bass Classical Electric Acoustic Steel</p></main>",
+    "evidenceRecords": [
+      { "evidenceId": "ev-bass", "clueId": "clue-1", "sourceLevel": "L4", "sourceType": "multi_model_consensus", "supportKind": "fit", "claim": "Bass is probably a guitar type.", "confidence": "medium" },
+      { "evidenceId": "ev-classical", "clueId": "clue-2", "sourceLevel": "L4", "sourceType": "multi_model_consensus", "supportKind": "fit", "claim": "Classical is probably a guitar type.", "confidence": "medium" },
+      { "evidenceId": "ev-electric", "clueId": "clue-3", "sourceLevel": "L4", "sourceType": "multi_model_consensus", "supportKind": "fit", "claim": "Electric is probably a guitar type.", "confidence": "medium" },
+      { "evidenceId": "ev-acoustic", "clueId": "clue-4", "sourceLevel": "L4", "sourceType": "multi_model_consensus", "supportKind": "fit", "claim": "Acoustic is probably a guitar type.", "confidence": "medium" },
+      { "evidenceId": "ev-steel", "clueId": "clue-5", "sourceLevel": "L4", "sourceType": "multi_model_consensus", "supportKind": "fit", "claim": "Steel is probably a guitar type.", "confidence": "medium" }
+    ],
+    "l1Input": {
+      "puzzleId": "pinpoint-900-2026-05-23",
+      "puzzleNumber": 900,
+      "logicalGameDate": "2026-05-23",
+      "source": "official_capture",
+      "answer": "Types of guitar",
+      "clues": [
+        { "clueId": "clue-1", "text": "Bass", "position": 1 },
+        { "clueId": "clue-2", "text": "Classical", "position": 2 },
+        { "clueId": "clue-3", "text": "Electric", "position": 3 },
+        { "clueId": "clue-4", "text": "Acoustic", "position": 4 },
+        { "clueId": "clue-5", "text": "Steel", "position": 5 }
+      ]
+    },
+    "candidate": {
+      "puzzleId": "pinpoint-900-2026-05-23",
+      "slug": "pinpoint-answer-900",
+      "canonicalUrl": "https://example.com/linkedin-pinpoint-answers/pinpoint-answer-900/",
+      "contentMode": "full-analysis",
+      "revisionId": "rev-l4-only-evidence",
+      "inputSnapshotHash": "__HASH_L1__",
+      "contentHash": "sha256:content-l4-only-evidence",
+      "answer": "Types of guitar",
+      "clues": [
+        { "clueId": "clue-1", "text": "Bass", "position": 1 },
+        { "clueId": "clue-2", "text": "Classical", "position": 2 },
+        { "clueId": "clue-3", "text": "Electric", "position": 3 },
+        { "clueId": "clue-4", "text": "Acoustic", "position": 4 },
+        { "clueId": "clue-5", "text": "Steel", "position": 5 }
+      ],
+      "clueRows": [
+        { "clueId": "clue-1", "fit": "Bass guitar", "whyItSupportsAnswer": "Bass is a guitar type.", "evidenceRefs": ["ev-bass"] },
+        { "clueId": "clue-2", "fit": "Classical guitar", "whyItSupportsAnswer": "Classical is a guitar type.", "evidenceRefs": ["ev-classical"] },
+        { "clueId": "clue-3", "fit": "Electric guitar", "whyItSupportsAnswer": "Electric is a guitar type.", "evidenceRefs": ["ev-electric"] },
+        { "clueId": "clue-4", "fit": "Acoustic guitar", "whyItSupportsAnswer": "Acoustic is a guitar type.", "evidenceRefs": ["ev-acoustic"] },
+        { "clueId": "clue-5", "fit": "Steel guitar", "whyItSupportsAnswer": "Steel is a guitar type.", "evidenceRefs": ["ev-steel"] }
+      ],
+      "reasoning": {
+        "pattern": "cumulative_confirmation",
+        "clueIds": ["clue-1", "clue-2", "clue-3"],
+        "text": "Bass and Classical point toward guitar types, while Electric, Acoustic, and Steel support the same answer from separate clues."
+      }
+    }
+  },
+  "expected": {
+    "outcome": "requires_review",
+    "policies": {
+      "indexPolicy": "review_required",
+      "sitemapPolicy": "include_after_audit",
+      "schemaPolicy": "article_only",
+      "internalLinkPolicy": "deemphasized",
+      "requiredAction": "review"
+    },
+    "issueCodes": ["L4_ONLY_EVIDENCE"],
+    "mustCreateArtifact": true
+  }
+}

--- a/lib/puzzles/content-kitchen/fixtures/full-analysis-low-confidence-evidence.requires-review.json
+++ b/lib/puzzles/content-kitchen/fixtures/full-analysis-low-confidence-evidence.requires-review.json
@@ -1,14 +1,14 @@
 {
-  "name": "full-analysis-turning-point.valid",
+  "name": "full-analysis-low-confidence-evidence.requires-review",
   "input": {
     "canonicalConfig": {
       "siteBaseUrl": "https://example.com",
       "detailRoutePrefix": "/linkedin-pinpoint-answers",
       "trailingSlash": true
     },
-    "renderedHtml": "<main><h1>Types of guitar</h1><p>Bass Classical Electric Acoustic Steel</p><section>Electric changes the solve because it narrows the board from instruments generally to guitar types.</section></main>",
+    "renderedHtml": "<main><h1>Types of guitar</h1><p>Bass Classical Electric Acoustic Steel</p></main>",
     "evidenceRecords": [
-      { "evidenceId": "ev-bass", "clueId": "clue-1", "sourceLevel": "L2", "sourceType": "category_membership", "supportKind": "fit", "claim": "Bass is a member of Types of guitar.", "confidence": "high", "lookupVersion": "category_membership_2026_05_23" },
+      { "evidenceId": "ev-bass", "clueId": "clue-1", "sourceLevel": "L2", "sourceType": "category_membership", "supportKind": "fit", "claim": "Bass may be a member of Types of guitar.", "confidence": "low", "lookupVersion": "category_membership_2026_05_23" },
       { "evidenceId": "ev-classical", "clueId": "clue-2", "sourceLevel": "L2", "sourceType": "category_membership", "supportKind": "fit", "claim": "Classical is a member of Types of guitar.", "confidence": "high", "lookupVersion": "category_membership_2026_05_23" },
       { "evidenceId": "ev-electric", "clueId": "clue-3", "sourceLevel": "L2", "sourceType": "category_membership", "supportKind": "fit", "claim": "Electric is a member of Types of guitar.", "confidence": "high", "lookupVersion": "category_membership_2026_05_23" },
       { "evidenceId": "ev-acoustic", "clueId": "clue-4", "sourceLevel": "L2", "sourceType": "category_membership", "supportKind": "fit", "claim": "Acoustic is a member of Types of guitar.", "confidence": "high", "lookupVersion": "category_membership_2026_05_23" },
@@ -33,9 +33,9 @@
       "slug": "pinpoint-answer-900",
       "canonicalUrl": "https://example.com/linkedin-pinpoint-answers/pinpoint-answer-900/",
       "contentMode": "full-analysis",
-      "revisionId": "rev-full-analysis-turning-point",
+      "revisionId": "rev-low-confidence-evidence",
       "inputSnapshotHash": "__HASH_L1__",
-      "contentHash": "sha256:content-full-analysis-turning-point",
+      "contentHash": "sha256:content-low-confidence-evidence",
       "answer": "Types of guitar",
       "clues": [
         { "clueId": "clue-1", "text": "Bass", "position": 1 },
@@ -45,30 +45,29 @@
         { "clueId": "clue-5", "text": "Steel", "position": 5 }
       ],
       "clueRows": [
-        { "clueId": "clue-1", "clueText": "Bass", "fit": "Bass guitar", "whyItSupportsAnswer": "Bass is a standard guitar type.", "evidenceRefs": ["ev-bass"] },
-        { "clueId": "clue-2", "clueText": "Classical", "fit": "Classical guitar", "whyItSupportsAnswer": "Classical is a recognized guitar type.", "evidenceRefs": ["ev-classical"] },
-        { "clueId": "clue-3", "clueText": "Electric", "fit": "Electric guitar", "whyItSupportsAnswer": "Electric gives the strongest guitar-specific clue.", "evidenceRefs": ["ev-electric"] },
-        { "clueId": "clue-4", "clueText": "Acoustic", "fit": "Acoustic guitar", "whyItSupportsAnswer": "Acoustic supports the same answer set.", "evidenceRefs": ["ev-acoustic"] },
-        { "clueId": "clue-5", "clueText": "Steel", "fit": "Steel guitar", "whyItSupportsAnswer": "Steel confirms the board is about guitar types.", "evidenceRefs": ["ev-steel"] }
+        { "clueId": "clue-1", "fit": "Bass guitar", "whyItSupportsAnswer": "Bass is a guitar type.", "evidenceRefs": ["ev-bass"] },
+        { "clueId": "clue-2", "fit": "Classical guitar", "whyItSupportsAnswer": "Classical is a guitar type.", "evidenceRefs": ["ev-classical"] },
+        { "clueId": "clue-3", "fit": "Electric guitar", "whyItSupportsAnswer": "Electric is a guitar type.", "evidenceRefs": ["ev-electric"] },
+        { "clueId": "clue-4", "fit": "Acoustic guitar", "whyItSupportsAnswer": "Acoustic is a guitar type.", "evidenceRefs": ["ev-acoustic"] },
+        { "clueId": "clue-5", "fit": "Steel guitar", "whyItSupportsAnswer": "Steel is a guitar type.", "evidenceRefs": ["ev-steel"] }
       ],
       "reasoning": {
-        "pattern": "turning_point",
-        "clueId": "clue-3",
-        "brokenTheory": "general instruments",
-        "supportedTheory": "types of guitar",
-        "text": "Electric changes the solve because it narrows the board from instruments generally to guitar types, then Bass and Classical confirm that reading."
+        "pattern": "cumulative_confirmation",
+        "clueIds": ["clue-1", "clue-2", "clue-3"],
+        "text": "Bass and Classical point toward guitar types, while Electric, Acoustic, and Steel support the same answer from separate clues."
       }
     }
   },
   "expected": {
-    "outcome": "pass_full_analysis",
+    "outcome": "requires_review",
     "policies": {
-      "indexPolicy": "index",
-      "sitemapPolicy": "include",
+      "indexPolicy": "review_required",
+      "sitemapPolicy": "include_after_audit",
       "schemaPolicy": "article_only",
-      "internalLinkPolicy": "normal",
-      "requiredAction": "none"
+      "internalLinkPolicy": "deemphasized",
+      "requiredAction": "review"
     },
-    "issueCodes": []
+    "issueCodes": ["FULL_ANALYSIS_WITH_LOW_CONFIDENCE"],
+    "mustCreateArtifact": true
   }
 }

--- a/lib/puzzles/content-kitchen/fixtures/full-analysis-prohibited-source.requires-review.json
+++ b/lib/puzzles/content-kitchen/fixtures/full-analysis-prohibited-source.requires-review.json
@@ -1,14 +1,14 @@
 {
-  "name": "full-analysis-turning-point.valid",
+  "name": "full-analysis-prohibited-source.requires-review",
   "input": {
     "canonicalConfig": {
       "siteBaseUrl": "https://example.com",
       "detailRoutePrefix": "/linkedin-pinpoint-answers",
       "trailingSlash": true
     },
-    "renderedHtml": "<main><h1>Types of guitar</h1><p>Bass Classical Electric Acoustic Steel</p><section>Electric changes the solve because it narrows the board from instruments generally to guitar types.</section></main>",
+    "renderedHtml": "<main><h1>Types of guitar</h1><p>Bass Classical Electric Acoustic Steel</p></main>",
     "evidenceRecords": [
-      { "evidenceId": "ev-bass", "clueId": "clue-1", "sourceLevel": "L2", "sourceType": "category_membership", "supportKind": "fit", "claim": "Bass is a member of Types of guitar.", "confidence": "high", "lookupVersion": "category_membership_2026_05_23" },
+      { "evidenceId": "ev-bass", "clueId": "clue-1", "sourceLevel": "L3", "sourceType": "competitor_answer_page", "supportKind": "fit", "claim": "A competitor page says Bass fits.", "confidence": "high", "retrievedAt": "2026-05-23T00:00:00.000Z" },
       { "evidenceId": "ev-classical", "clueId": "clue-2", "sourceLevel": "L2", "sourceType": "category_membership", "supportKind": "fit", "claim": "Classical is a member of Types of guitar.", "confidence": "high", "lookupVersion": "category_membership_2026_05_23" },
       { "evidenceId": "ev-electric", "clueId": "clue-3", "sourceLevel": "L2", "sourceType": "category_membership", "supportKind": "fit", "claim": "Electric is a member of Types of guitar.", "confidence": "high", "lookupVersion": "category_membership_2026_05_23" },
       { "evidenceId": "ev-acoustic", "clueId": "clue-4", "sourceLevel": "L2", "sourceType": "category_membership", "supportKind": "fit", "claim": "Acoustic is a member of Types of guitar.", "confidence": "high", "lookupVersion": "category_membership_2026_05_23" },
@@ -33,9 +33,9 @@
       "slug": "pinpoint-answer-900",
       "canonicalUrl": "https://example.com/linkedin-pinpoint-answers/pinpoint-answer-900/",
       "contentMode": "full-analysis",
-      "revisionId": "rev-full-analysis-turning-point",
+      "revisionId": "rev-prohibited-source",
       "inputSnapshotHash": "__HASH_L1__",
-      "contentHash": "sha256:content-full-analysis-turning-point",
+      "contentHash": "sha256:content-prohibited-source",
       "answer": "Types of guitar",
       "clues": [
         { "clueId": "clue-1", "text": "Bass", "position": 1 },
@@ -45,30 +45,29 @@
         { "clueId": "clue-5", "text": "Steel", "position": 5 }
       ],
       "clueRows": [
-        { "clueId": "clue-1", "clueText": "Bass", "fit": "Bass guitar", "whyItSupportsAnswer": "Bass is a standard guitar type.", "evidenceRefs": ["ev-bass"] },
-        { "clueId": "clue-2", "clueText": "Classical", "fit": "Classical guitar", "whyItSupportsAnswer": "Classical is a recognized guitar type.", "evidenceRefs": ["ev-classical"] },
-        { "clueId": "clue-3", "clueText": "Electric", "fit": "Electric guitar", "whyItSupportsAnswer": "Electric gives the strongest guitar-specific clue.", "evidenceRefs": ["ev-electric"] },
-        { "clueId": "clue-4", "clueText": "Acoustic", "fit": "Acoustic guitar", "whyItSupportsAnswer": "Acoustic supports the same answer set.", "evidenceRefs": ["ev-acoustic"] },
-        { "clueId": "clue-5", "clueText": "Steel", "fit": "Steel guitar", "whyItSupportsAnswer": "Steel confirms the board is about guitar types.", "evidenceRefs": ["ev-steel"] }
+        { "clueId": "clue-1", "fit": "Bass guitar", "whyItSupportsAnswer": "Bass is a guitar type.", "evidenceRefs": ["ev-bass"] },
+        { "clueId": "clue-2", "fit": "Classical guitar", "whyItSupportsAnswer": "Classical is a guitar type.", "evidenceRefs": ["ev-classical"] },
+        { "clueId": "clue-3", "fit": "Electric guitar", "whyItSupportsAnswer": "Electric is a guitar type.", "evidenceRefs": ["ev-electric"] },
+        { "clueId": "clue-4", "fit": "Acoustic guitar", "whyItSupportsAnswer": "Acoustic is a guitar type.", "evidenceRefs": ["ev-acoustic"] },
+        { "clueId": "clue-5", "fit": "Steel guitar", "whyItSupportsAnswer": "Steel is a guitar type.", "evidenceRefs": ["ev-steel"] }
       ],
       "reasoning": {
-        "pattern": "turning_point",
-        "clueId": "clue-3",
-        "brokenTheory": "general instruments",
-        "supportedTheory": "types of guitar",
-        "text": "Electric changes the solve because it narrows the board from instruments generally to guitar types, then Bass and Classical confirm that reading."
+        "pattern": "cumulative_confirmation",
+        "clueIds": ["clue-1", "clue-2", "clue-3"],
+        "text": "Bass and Classical point toward guitar types, while Electric, Acoustic, and Steel support the same answer from separate clues."
       }
     }
   },
   "expected": {
-    "outcome": "pass_full_analysis",
+    "outcome": "requires_review",
     "policies": {
-      "indexPolicy": "index",
-      "sitemapPolicy": "include",
+      "indexPolicy": "review_required",
+      "sitemapPolicy": "include_after_audit",
       "schemaPolicy": "article_only",
-      "internalLinkPolicy": "normal",
-      "requiredAction": "none"
+      "internalLinkPolicy": "deemphasized",
+      "requiredAction": "review"
     },
-    "issueCodes": []
+    "issueCodes": ["PROHIBITED_EVIDENCE_SOURCE"],
+    "mustCreateArtifact": true
   }
 }

--- a/lib/puzzles/content-kitchen/issue-registry.ts
+++ b/lib/puzzles/content-kitchen/issue-registry.ts
@@ -137,6 +137,54 @@ export const CONTENT_KITCHEN_ISSUE_REGISTRY: IssueCodeDefinition[] = [
     defaultRequiredAction: "enrich",
     description: "Internal link is not route-shaped or is absent from the provided route index.",
   },
+  {
+    code: "UNSUPPORTED_CLUE_FIT",
+    phaseOwner: "PR7",
+    defaultSeverity: "P0",
+    defaultOutcome: "requires_review",
+    defaultRequiredAction: "review",
+    description: "A full-analysis clue row lacks a matching clue-fit evidence record.",
+  },
+  {
+    code: "WEAK_FIT_EVIDENCE",
+    phaseOwner: "PR7",
+    defaultSeverity: "P1",
+    defaultOutcome: "requires_review",
+    defaultRequiredAction: "review",
+    description: "A full-analysis clue row has evidence, but it is not strong enough for automatic full-analysis.",
+  },
+  {
+    code: "L4_ONLY_EVIDENCE",
+    phaseOwner: "PR7",
+    defaultSeverity: "P1",
+    defaultOutcome: "requires_review",
+    defaultRequiredAction: "review",
+    description: "A full-analysis clue row is supported only by model-consensus evidence.",
+  },
+  {
+    code: "FULL_ANALYSIS_WITH_LOW_CONFIDENCE",
+    phaseOwner: "PR7",
+    defaultSeverity: "P1",
+    defaultOutcome: "requires_review",
+    defaultRequiredAction: "review",
+    description: "A full-analysis clue row has only low-confidence evidence.",
+  },
+  {
+    code: "PROHIBITED_EVIDENCE_SOURCE",
+    phaseOwner: "PR7",
+    defaultSeverity: "P0",
+    defaultOutcome: "requires_review",
+    defaultRequiredAction: "review",
+    description: "A candidate uses a prohibited source such as a competitor page, answer aggregator, AI summary, snippet, or generated page.",
+  },
+  {
+    code: "EVIDENCE_SOURCE_CONFLICT",
+    phaseOwner: "PR7",
+    defaultSeverity: "P1",
+    defaultOutcome: "requires_review",
+    defaultRequiredAction: "review",
+    description: "A candidate has an unresolved evidence conflict.",
+  },
 ];
 
 export const CONTENT_KITCHEN_ISSUE_DEFINITIONS = new Map<ContentKitchenIssueCode, IssueCodeDefinition>(
@@ -156,5 +204,11 @@ export function getPr6P0IssueCodes(): ContentKitchenIssueCode[] {
     .filter((definition) => {
       return definition.defaultSeverity === "P0" && definition.phaseOwner.startsWith("PR6");
     })
+    .map((definition) => definition.code);
+}
+
+export function getPr7IssueCodes(): ContentKitchenIssueCode[] {
+  return CONTENT_KITCHEN_ISSUE_REGISTRY
+    .filter((definition) => definition.phaseOwner === "PR7")
     .map((definition) => definition.code);
 }

--- a/lib/puzzles/content-kitchen/types.ts
+++ b/lib/puzzles/content-kitchen/types.ts
@@ -46,7 +46,13 @@ export type ContentKitchenIssueCode =
   | "GENERIC_REASONING_PATTERN"
   | "FAQ_SCHEMA_WITHOUT_VISIBLE_FAQ"
   | "INVALID_FAQ_STRUCTURE"
-  | "INTERNAL_LINK_BROKEN";
+  | "INTERNAL_LINK_BROKEN"
+  | "UNSUPPORTED_CLUE_FIT"
+  | "WEAK_FIT_EVIDENCE"
+  | "L4_ONLY_EVIDENCE"
+  | "FULL_ANALYSIS_WITH_LOW_CONFIDENCE"
+  | "PROHIBITED_EVIDENCE_SOURCE"
+  | "EVIDENCE_SOURCE_CONFLICT";
 
 export type Pr6aIssueCode = ContentKitchenIssueCode;
 
@@ -109,6 +115,49 @@ export type FullAnalysisReasoning =
   | TurningPointReasoning
   | CumulativeConfirmationReasoning;
 
+export type EvidenceSourceLevel = "L1" | "L2" | "L3" | "L4" | "L5";
+
+export type EvidenceSourceType =
+  | "official_capture"
+  | "category_membership"
+  | "alias_dictionary"
+  | "deterministic_lookup"
+  | "retrievable_source"
+  | "wikidata"
+  | "wikipedia"
+  | "dictionary_source"
+  | "official_source"
+  | "multi_model_consensus"
+  | "human_review"
+  | "competitor_answer_page"
+  | "answer_aggregator"
+  | "ai_summary"
+  | "search_snippet"
+  | "generated_page"
+  | "unknown";
+
+export type EvidenceSupportKind = "fact" | "fit";
+
+export type EvidenceConfidence = "high" | "medium" | "low";
+
+export type EvidenceConflictStatus = "none" | "unresolved" | "resolved";
+
+export type ContentKitchenEvidenceRecord = {
+  evidenceId: string;
+  clueId?: string;
+  sourceLevel: EvidenceSourceLevel;
+  sourceType: EvidenceSourceType;
+  supportKind: EvidenceSupportKind;
+  claim: string;
+  confidence: EvidenceConfidence;
+  lookupVersion?: string;
+  retrievedAt?: string;
+  humanVerifiedBy?: string;
+  humanVerifiedAt?: string;
+  conflictStatus?: EvidenceConflictStatus;
+  notes?: string;
+};
+
 export type FaqCandidate = {
   question: string;
   answer: string;
@@ -163,6 +212,7 @@ export type ValidateCandidateInput = {
   renderedHtml?: string;
   allowAnswerFirstIndex?: boolean;
   existingRoutes?: string[];
+  evidenceRecords?: Partial<ContentKitchenEvidenceRecord>[];
 };
 
 export type ValidateCandidateOutput = {

--- a/lib/puzzles/content-kitchen/validate-candidate.ts
+++ b/lib/puzzles/content-kitchen/validate-candidate.ts
@@ -5,12 +5,14 @@ import {
   normalizeIdentityMatch,
   normalizeIdentityText,
 } from "./identity";
+import { validateFullAnalysisEvidence } from "./evidence";
 import { validateFullAnalysisStructure } from "./full-analysis";
 import {
   BLOCK_PUBLISH_POLICIES,
   DOWNGRADE_TO_ANSWER_FIRST_POLICIES,
   derivePolicies,
   FULL_ANALYSIS_PASS_POLICIES,
+  FULL_ANALYSIS_REVIEW_POLICIES,
   REVIEW_POLICIES,
 } from "./policies";
 import {
@@ -332,7 +334,7 @@ export function validateCandidate(input: ValidateCandidateInput): ValidateCandid
     }
 
     if (!renderedHtmlShowsAnswerAndClues(input.renderedHtml, validatedL1)) {
-      return output("requires_review", REVIEW_POLICIES, [
+      return output("requires_review", FULL_ANALYSIS_REVIEW_POLICIES, [
         makeIssue(
           "ANSWER_HIDDEN_FROM_RENDERED_HTML",
           "renderedHtml",
@@ -341,6 +343,16 @@ export function validateCandidate(input: ValidateCandidateInput): ValidateCandid
           { blocking: false, candidateRevisionId },
         ),
       ]);
+    }
+
+    const evidenceIssues = validateFullAnalysisEvidence({
+      candidate,
+      l1Input: validatedL1,
+      evidenceRecords: input.evidenceRecords,
+    });
+
+    if (evidenceIssues.length > 0) {
+      return output("requires_review", FULL_ANALYSIS_REVIEW_POLICIES, evidenceIssues);
     }
 
     return output("pass_full_analysis", FULL_ANALYSIS_PASS_POLICIES, []);

--- a/scripts/check-content-kitchen-contract.ts
+++ b/scripts/check-content-kitchen-contract.ts
@@ -7,6 +7,7 @@ import {
   CONTENT_KITCHEN_ISSUE_REGISTRY,
   getIssueDefinition,
   getPr6P0IssueCodes,
+  getPr7IssueCodes,
 } from "../lib/puzzles/content-kitchen/issue-registry";
 import { buildReviewArtifactV0, shouldCreateReviewArtifact } from "../lib/puzzles/content-kitchen/review-artifact";
 import { validateCandidate } from "../lib/puzzles/content-kitchen/validate-candidate";
@@ -143,6 +144,23 @@ function assertPr6P0Coverage(fixtures: Fixture[]) {
   assert.deepEqual(missing, [], "every PR6 P0 issue code should have at least one negative fixture");
 }
 
+function assertPr7Coverage(fixtures: Fixture[]) {
+  const negativeIssueCodes = new Set<ContentKitchenIssueCode>();
+
+  for (const fixture of fixtures) {
+    if (fixture.expected.outcome === "pass_answer_first" || fixture.expected.outcome === "pass_full_analysis") {
+      continue;
+    }
+
+    for (const issueCode of fixture.expected.issueCodes ?? []) {
+      negativeIssueCodes.add(issueCode);
+    }
+  }
+
+  const missing = getPr7IssueCodes().filter((issueCode) => !negativeIssueCodes.has(issueCode));
+  assert.deepEqual(missing, [], "every PR7 issue code should have at least one negative fixture");
+}
+
 function assertIssueRegistryIsStable() {
   const seen = new Set<ContentKitchenIssueCode>();
   for (const definition of CONTENT_KITCHEN_ISSUE_REGISTRY) {
@@ -228,6 +246,7 @@ async function main() {
   checkHashExcludesVolatileFields();
   assertIssueRegistryIsStable();
   assertPr6P0Coverage(fixtures);
+  assertPr7Coverage(fixtures);
   await assertExamplesAreValidJson();
   console.log(`content-kitchen contract fixtures passed (${fileNames.length} fixtures)`);
 }


### PR DESCRIPTION
## Summary
- add PR7 evidence record types, L2 allowlist, and prohibited evidence source rules
- require full-analysis clue rows to have real fit evidence records before auto-pass
- add fixtures for unknown refs, weak L2 lookup metadata, L4-only evidence, prohibited sources, low confidence, and unresolved conflicts
- extend content-kitchen fixture checks so every PR7 issue code has fixture coverage

## Verification
- npm run test:content-kitchen
- npm run typecheck
- npm run lint
- npm run validate:data
- git diff --check