### PR TITLE
Add PR7 local dictionary readers

### DIFF
--- a/lib/puzzles/content-kitchen/dictionaries/alias_dictionary.json
+++ b/lib/puzzles/content-kitchen/dictionaries/alias_dictionary.json
@@ -1,0 +1,47 @@
+{
+  "dictionaryName": "alias_dictionary",
+  "schemaVersion": "content-kitchen-alias-dictionary-v0",
+  "versionId": "alias_dictionary_2026_05_23",
+  "owner": "pinpoint-editor",
+  "reviewedBy": "pinpoint-editor",
+  "reviewedAt": "2026-05-23T00:00:00.000Z",
+  "reviewStatus": "reviewed",
+  "entries": [
+    {
+      "aliasType": "category",
+      "canonicalValue": "Types of guitar",
+      "normalizedCanonicalValue": "types of guitar",
+      "alias": "guitar types",
+      "normalizedAlias": "guitar types",
+      "sourceNote": "Common wording alias for the seeded PR7 fixture category.",
+      "reviewer": "pinpoint-editor",
+      "risk": "low",
+      "createdAt": "2026-05-23T00:00:00.000Z",
+      "updatedAt": "2026-05-23T00:00:00.000Z"
+    },
+    {
+      "aliasType": "category",
+      "canonicalValue": "Types of guitar",
+      "normalizedCanonicalValue": "types of guitar",
+      "alias": "guitar family",
+      "normalizedAlias": "guitar family",
+      "sourceNote": "Common wording alias for the seeded PR7 fixture category.",
+      "reviewer": "pinpoint-editor",
+      "risk": "low",
+      "createdAt": "2026-05-23T00:00:00.000Z",
+      "updatedAt": "2026-05-23T00:00:00.000Z"
+    },
+    {
+      "aliasType": "answer",
+      "canonicalValue": "Types of guitar",
+      "normalizedCanonicalValue": "types of guitar",
+      "alias": "Kinds of guitar",
+      "normalizedAlias": "kinds of guitar",
+      "sourceNote": "Common wording alias for the seeded PR7 fixture answer.",
+      "reviewer": "pinpoint-editor",
+      "risk": "low",
+      "createdAt": "2026-05-23T00:00:00.000Z",
+      "updatedAt": "2026-05-23T00:00:00.000Z"
+    }
+  ]
+}

--- a/lib/puzzles/content-kitchen/dictionaries/category_membership.json
+++ b/lib/puzzles/content-kitchen/dictionaries/category_membership.json
@@ -1,0 +1,66 @@
+{
+  "dictionaryName": "category_membership",
+  "schemaVersion": "content-kitchen-category-membership-v0",
+  "versionId": "category_membership_2026_05_23",
+  "owner": "pinpoint-editor",
+  "reviewedBy": "pinpoint-editor",
+  "reviewedAt": "2026-05-23T00:00:00.000Z",
+  "reviewStatus": "reviewed",
+  "entries": [
+    {
+      "category": "Types of guitar",
+      "normalizedCategory": "types of guitar",
+      "member": "Bass",
+      "normalizedMember": "bass",
+      "sourceNote": "Seeded PR7 fixture dictionary entry for content-kitchen validation.",
+      "reviewer": "pinpoint-editor",
+      "risk": "low",
+      "createdAt": "2026-05-23T00:00:00.000Z",
+      "updatedAt": "2026-05-23T00:00:00.000Z"
+    },
+    {
+      "category": "Types of guitar",
+      "normalizedCategory": "types of guitar",
+      "member": "Classical",
+      "normalizedMember": "classical",
+      "sourceNote": "Seeded PR7 fixture dictionary entry for content-kitchen validation.",
+      "reviewer": "pinpoint-editor",
+      "risk": "low",
+      "createdAt": "2026-05-23T00:00:00.000Z",
+      "updatedAt": "2026-05-23T00:00:00.000Z"
+    },
+    {
+      "category": "Types of guitar",
+      "normalizedCategory": "types of guitar",
+      "member": "Electric",
+      "normalizedMember": "electric",
+      "sourceNote": "Seeded PR7 fixture dictionary entry for content-kitchen validation.",
+      "reviewer": "pinpoint-editor",
+      "risk": "low",
+      "createdAt": "2026-05-23T00:00:00.000Z",
+      "updatedAt": "2026-05-23T00:00:00.000Z"
+    },
+    {
+      "category": "Types of guitar",
+      "normalizedCategory": "types of guitar",
+      "member": "Acoustic",
+      "normalizedMember": "acoustic",
+      "sourceNote": "Seeded PR7 fixture dictionary entry for content-kitchen validation.",
+      "reviewer": "pinpoint-editor",
+      "risk": "low",
+      "createdAt": "2026-05-23T00:00:00.000Z",
+      "updatedAt": "2026-05-23T00:00:00.000Z"
+    },
+    {
+      "category": "Types of guitar",
+      "normalizedCategory": "types of guitar",
+      "member": "Steel",
+      "normalizedMember": "steel",
+      "sourceNote": "Seeded PR7 fixture dictionary entry for content-kitchen validation.",
+      "reviewer": "pinpoint-editor",
+      "risk": "low",
+      "createdAt": "2026-05-23T00:00:00.000Z",
+      "updatedAt": "2026-05-23T00:00:00.000Z"
+    }
+  ]
+}

--- a/lib/puzzles/content-kitchen/dictionary.ts
+++ b/lib/puzzles/content-kitchen/dictionary.ts
@@ -1,0 +1,308 @@
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { normalizeIdentityMatch, normalizeIdentityText } from "./identity";
+import type {
+  AliasDictionary,
+  AliasDictionaryEntry,
+  CategoryMembershipDictionary,
+  CategoryMembershipEntry,
+  ContentKitchenDictionaries,
+  ContentKitchenDictionaryBase,
+  ContentKitchenEvidenceRecord,
+  DictionaryReviewStatus,
+  DictionaryRisk,
+  L1PuzzleInput,
+} from "./types";
+
+type CategoryEvidenceInput = {
+  l1Input: L1PuzzleInput;
+  category: string;
+  dictionary: CategoryMembershipDictionary;
+  evidenceIdPrefix?: string;
+};
+
+const DICTIONARY_REVIEW_STATUSES = new Set<DictionaryReviewStatus>(["draft", "shadow", "reviewed"]);
+const DICTIONARY_RISKS = new Set<DictionaryRisk>(["low", "medium", "high"]);
+const ALIAS_TYPES = new Set<AliasDictionaryEntry["aliasType"]>(["answer", "category", "clue", "phrase"]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function isIsoUtc(value: unknown): boolean {
+  return /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/.test(normalizeIdentityText(value));
+}
+
+function normalizeDictionaryValue(value: unknown): string {
+  return normalizeIdentityMatch(value);
+}
+
+function safeEvidenceId(value: string): string {
+  return normalizeIdentityMatch(value).replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "") || "unknown";
+}
+
+function requireString(value: unknown, fieldPath: string): string {
+  const normalized = normalizeIdentityText(value);
+  if (!normalized) {
+    throw new Error(`${fieldPath} is required`);
+  }
+  return normalized;
+}
+
+function requireIsoUtc(value: unknown, fieldPath: string): string {
+  const normalized = requireString(value, fieldPath);
+  if (!isIsoUtc(normalized)) {
+    throw new Error(`${fieldPath} must be an ISO UTC timestamp`);
+  }
+  return normalized;
+}
+
+function validateDictionaryBase(
+  input: unknown,
+  expectedName: ContentKitchenDictionaryBase["dictionaryName"],
+  expectedSchemaVersion: ContentKitchenDictionaryBase["schemaVersion"],
+): ContentKitchenDictionaryBase {
+  if (!isRecord(input)) {
+    throw new Error(`${expectedName} dictionary must be an object`);
+  }
+
+  const dictionaryName = requireString(input.dictionaryName, "dictionaryName");
+  const schemaVersion = requireString(input.schemaVersion, "schemaVersion");
+  const versionId = requireString(input.versionId, "versionId");
+  const owner = requireString(input.owner, "owner");
+  const reviewedBy = requireString(input.reviewedBy, "reviewedBy");
+  const reviewedAt = requireIsoUtc(input.reviewedAt, "reviewedAt");
+  const reviewStatus = requireString(input.reviewStatus, "reviewStatus") as DictionaryReviewStatus;
+
+  if (dictionaryName !== expectedName) {
+    throw new Error(`dictionaryName must be ${expectedName}`);
+  }
+
+  if (schemaVersion !== expectedSchemaVersion) {
+    throw new Error(`${dictionaryName}.schemaVersion must be ${expectedSchemaVersion}`);
+  }
+
+  if (!DICTIONARY_REVIEW_STATUSES.has(reviewStatus)) {
+    throw new Error(`${dictionaryName}.reviewStatus is unsupported`);
+  }
+
+  if (reviewStatus !== "reviewed") {
+    throw new Error(`${dictionaryName} must be reviewed before it can support L2 evidence`);
+  }
+
+  return {
+    dictionaryName,
+    schemaVersion,
+    versionId,
+    owner,
+    reviewedBy,
+    reviewedAt,
+    reviewStatus,
+  };
+}
+
+function validateRisk(value: unknown, fieldPath: string): DictionaryRisk {
+  const risk = requireString(value, fieldPath) as DictionaryRisk;
+  if (!DICTIONARY_RISKS.has(risk)) {
+    throw new Error(`${fieldPath} is unsupported`);
+  }
+  return risk;
+}
+
+function validateCategoryEntry(input: unknown, index: number): CategoryMembershipEntry {
+  if (!isRecord(input)) {
+    throw new Error(`entries[${index}] must be an object`);
+  }
+
+  const fieldPath = `entries[${index}]`;
+  const category = requireString(input.category, `${fieldPath}.category`);
+  const normalizedCategory = requireString(input.normalizedCategory, `${fieldPath}.normalizedCategory`);
+  const member = requireString(input.member, `${fieldPath}.member`);
+  const normalizedMember = requireString(input.normalizedMember, `${fieldPath}.normalizedMember`);
+
+  if (normalizedCategory !== normalizeDictionaryValue(category)) {
+    throw new Error(`${fieldPath}.normalizedCategory must match normalized category`);
+  }
+
+  if (normalizedMember !== normalizeDictionaryValue(member)) {
+    throw new Error(`${fieldPath}.normalizedMember must match normalized member`);
+  }
+
+  return {
+    category,
+    normalizedCategory,
+    member,
+    normalizedMember,
+    sourceNote: requireString(input.sourceNote, `${fieldPath}.sourceNote`),
+    reviewer: requireString(input.reviewer, `${fieldPath}.reviewer`),
+    risk: validateRisk(input.risk, `${fieldPath}.risk`),
+    createdAt: requireIsoUtc(input.createdAt, `${fieldPath}.createdAt`),
+    updatedAt: requireIsoUtc(input.updatedAt, `${fieldPath}.updatedAt`),
+  };
+}
+
+function validateAliasEntry(input: unknown, index: number): AliasDictionaryEntry {
+  if (!isRecord(input)) {
+    throw new Error(`entries[${index}] must be an object`);
+  }
+
+  const fieldPath = `entries[${index}]`;
+  const aliasType = requireString(input.aliasType, `${fieldPath}.aliasType`) as AliasDictionaryEntry["aliasType"];
+  if (!ALIAS_TYPES.has(aliasType)) {
+    throw new Error(`${fieldPath}.aliasType is unsupported`);
+  }
+
+  const canonicalValue = requireString(input.canonicalValue, `${fieldPath}.canonicalValue`);
+  const normalizedCanonicalValue = requireString(input.normalizedCanonicalValue, `${fieldPath}.normalizedCanonicalValue`);
+  const alias = requireString(input.alias, `${fieldPath}.alias`);
+  const normalizedAlias = requireString(input.normalizedAlias, `${fieldPath}.normalizedAlias`);
+
+  if (normalizedCanonicalValue !== normalizeDictionaryValue(canonicalValue)) {
+    throw new Error(`${fieldPath}.normalizedCanonicalValue must match normalized canonicalValue`);
+  }
+
+  if (normalizedAlias !== normalizeDictionaryValue(alias)) {
+    throw new Error(`${fieldPath}.normalizedAlias must match normalized alias`);
+  }
+
+  return {
+    aliasType,
+    canonicalValue,
+    normalizedCanonicalValue,
+    alias,
+    normalizedAlias,
+    sourceNote: requireString(input.sourceNote, `${fieldPath}.sourceNote`),
+    reviewer: requireString(input.reviewer, `${fieldPath}.reviewer`),
+    risk: validateRisk(input.risk, `${fieldPath}.risk`),
+    createdAt: requireIsoUtc(input.createdAt, `${fieldPath}.createdAt`),
+    updatedAt: requireIsoUtc(input.updatedAt, `${fieldPath}.updatedAt`),
+  };
+}
+
+function assertNoDuplicateKeys(keys: string[], label: string) {
+  const seen = new Set<string>();
+  for (const key of keys) {
+    if (seen.has(key)) {
+      throw new Error(`${label} contains duplicate key: ${key}`);
+    }
+    seen.add(key);
+  }
+}
+
+export function validateCategoryMembershipDictionary(input: unknown): CategoryMembershipDictionary {
+  const base = validateDictionaryBase(
+    input,
+    "category_membership",
+    "content-kitchen-category-membership-v0",
+  );
+
+  if (!isRecord(input) || !Array.isArray(input.entries) || input.entries.length === 0) {
+    throw new Error("category_membership.entries must be a non-empty array");
+  }
+
+  const entries = input.entries.map(validateCategoryEntry);
+  assertNoDuplicateKeys(
+    entries.map((entry) => `${entry.normalizedCategory}:${entry.normalizedMember}`),
+    "category_membership.entries",
+  );
+
+  return {
+    ...base,
+    dictionaryName: "category_membership",
+    schemaVersion: "content-kitchen-category-membership-v0",
+    entries,
+  };
+}
+
+export function validateAliasDictionary(input: unknown): AliasDictionary {
+  const base = validateDictionaryBase(
+    input,
+    "alias_dictionary",
+    "content-kitchen-alias-dictionary-v0",
+  );
+
+  if (!isRecord(input) || !Array.isArray(input.entries) || input.entries.length === 0) {
+    throw new Error("alias_dictionary.entries must be a non-empty array");
+  }
+
+  const entries = input.entries.map(validateAliasEntry);
+  assertNoDuplicateKeys(
+    entries.map((entry) => `${entry.aliasType}:${entry.normalizedAlias}:${entry.normalizedCanonicalValue}`),
+    "alias_dictionary.entries",
+  );
+
+  return {
+    ...base,
+    dictionaryName: "alias_dictionary",
+    schemaVersion: "content-kitchen-alias-dictionary-v0",
+    entries,
+  };
+}
+
+async function readJson(path: string): Promise<unknown> {
+  return JSON.parse(await readFile(path, "utf8")) as unknown;
+}
+
+export async function readContentKitchenDictionaries(rootDir = process.cwd()): Promise<ContentKitchenDictionaries> {
+  const dictionaryDir = resolve(rootDir, "lib", "puzzles", "content-kitchen", "dictionaries");
+  const [categoryMembershipJson, aliasDictionaryJson] = await Promise.all([
+    readJson(resolve(dictionaryDir, "category_membership.json")),
+    readJson(resolve(dictionaryDir, "alias_dictionary.json")),
+  ]);
+
+  return {
+    categoryMembership: validateCategoryMembershipDictionary(categoryMembershipJson),
+    aliasDictionary: validateAliasDictionary(aliasDictionaryJson),
+  };
+}
+
+export function lookupCategoryMembership(
+  dictionary: CategoryMembershipDictionary,
+  input: { category: string; member: string },
+): CategoryMembershipEntry | null {
+  const normalizedCategory = normalizeDictionaryValue(input.category);
+  const normalizedMember = normalizeDictionaryValue(input.member);
+  return dictionary.entries.find((entry) => {
+    return entry.normalizedCategory === normalizedCategory && entry.normalizedMember === normalizedMember;
+  }) ?? null;
+}
+
+export function lookupAliases(
+  dictionary: AliasDictionary,
+  input: { alias: string; aliasType?: AliasDictionaryEntry["aliasType"] },
+): AliasDictionaryEntry[] {
+  const normalizedAlias = normalizeDictionaryValue(input.alias);
+  return dictionary.entries.filter((entry) => {
+    return entry.normalizedAlias === normalizedAlias && (!input.aliasType || entry.aliasType === input.aliasType);
+  });
+}
+
+export function buildCategoryMembershipEvidenceRecords(input: CategoryEvidenceInput): ContentKitchenEvidenceRecord[] {
+  const category = normalizeIdentityText(input.category);
+  const evidenceIdPrefix = normalizeIdentityText(input.evidenceIdPrefix) || "l2-category";
+
+  return input.l1Input.clues.flatMap((clue) => {
+    const entry = lookupCategoryMembership(input.dictionary, {
+      category,
+      member: clue.text,
+    });
+
+    if (!entry) {
+      return [];
+    }
+
+    return [
+      {
+        evidenceId: `${evidenceIdPrefix}-${safeEvidenceId(clue.text)}`,
+        clueId: clue.clueId,
+        sourceLevel: "L2",
+        sourceType: "category_membership",
+        supportKind: "fit",
+        claim: `${entry.member} is reviewed as a member of ${entry.category}.`,
+        confidence: entry.risk === "low" ? "high" : "medium",
+        lookupVersion: input.dictionary.versionId,
+        notes: entry.sourceNote,
+      },
+    ];
+  });
+}

--- a/lib/puzzles/content-kitchen/types.ts
+++ b/lib/puzzles/content-kitchen/types.ts
@@ -158,6 +158,61 @@ export type ContentKitchenEvidenceRecord = {
   notes?: string;
 };
 
+export type DictionaryReviewStatus = "draft" | "shadow" | "reviewed";
+export type DictionaryRisk = "low" | "medium" | "high";
+
+export type ContentKitchenDictionaryBase = {
+  dictionaryName: string;
+  schemaVersion: string;
+  versionId: string;
+  owner: string;
+  reviewedBy: string;
+  reviewedAt: string;
+  reviewStatus: DictionaryReviewStatus;
+};
+
+export type CategoryMembershipEntry = {
+  category: string;
+  normalizedCategory: string;
+  member: string;
+  normalizedMember: string;
+  sourceNote: string;
+  reviewer: string;
+  risk: DictionaryRisk;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type CategoryMembershipDictionary = ContentKitchenDictionaryBase & {
+  dictionaryName: "category_membership";
+  schemaVersion: "content-kitchen-category-membership-v0";
+  entries: CategoryMembershipEntry[];
+};
+
+export type AliasDictionaryEntry = {
+  aliasType: "answer" | "category" | "clue" | "phrase";
+  canonicalValue: string;
+  normalizedCanonicalValue: string;
+  alias: string;
+  normalizedAlias: string;
+  sourceNote: string;
+  reviewer: string;
+  risk: DictionaryRisk;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type AliasDictionary = ContentKitchenDictionaryBase & {
+  dictionaryName: "alias_dictionary";
+  schemaVersion: "content-kitchen-alias-dictionary-v0";
+  entries: AliasDictionaryEntry[];
+};
+
+export type ContentKitchenDictionaries = {
+  categoryMembership: CategoryMembershipDictionary;
+  aliasDictionary: AliasDictionary;
+};
+
 export type FaqCandidate = {
   question: string;
   answer: string;

--- a/scripts/check-content-kitchen-contract.ts
+++ b/scripts/check-content-kitchen-contract.ts
@@ -2,6 +2,12 @@ import assert from "node:assert/strict";
 import { readdir, readFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  buildCategoryMembershipEvidenceRecords,
+  lookupAliases,
+  lookupCategoryMembership,
+  readContentKitchenDictionaries,
+} from "../lib/puzzles/content-kitchen/dictionary";
 import { hashInputSnapshot } from "../lib/puzzles/content-kitchen/identity";
 import {
   CONTENT_KITCHEN_ISSUE_REGISTRY,
@@ -13,6 +19,7 @@ import { buildReviewArtifactV0, shouldCreateReviewArtifact } from "../lib/puzzle
 import { validateCandidate } from "../lib/puzzles/content-kitchen/validate-candidate";
 import type {
   ContentKitchenIssueCode,
+  L1PuzzleInput,
   ValidateCandidateInput,
   ValidationOutcome,
   ValidationPolicies,
@@ -182,6 +189,68 @@ async function assertExamplesAreValidJson() {
   }
 }
 
+async function assertDictionariesAreReadable() {
+  const dictionaries = await readContentKitchenDictionaries(ROOT);
+
+  assert.equal(
+    dictionaries.categoryMembership.versionId,
+    "category_membership_2026_05_23",
+    "category membership dictionary version should be stable",
+  );
+  assert.equal(
+    dictionaries.aliasDictionary.versionId,
+    "alias_dictionary_2026_05_23",
+    "alias dictionary version should be stable",
+  );
+
+  for (const member of ["Bass", "Classical", "Electric", "Acoustic", "Steel"]) {
+    assert.ok(
+      lookupCategoryMembership(dictionaries.categoryMembership, {
+        category: "Types of guitar",
+        member,
+      }),
+      `category_membership should include ${member} as a Types of guitar member`,
+    );
+  }
+
+  const categoryAliases = lookupAliases(dictionaries.aliasDictionary, {
+    alias: "guitar types",
+    aliasType: "category",
+  });
+  assert.equal(categoryAliases.length, 1, "alias_dictionary should resolve category aliases");
+  assert.equal(categoryAliases[0]?.canonicalValue, "Types of guitar", "category alias should point to canonical value");
+
+  const fixture = await readFixture("full-analysis-cumulative-confirmation.valid.json");
+  const hydratedInput = hydrateFixtureInput(fixture.input);
+  assert.ok(hydratedInput.l1Input, "dictionary evidence fixture should include L1 input");
+  assert.ok(hydratedInput.candidate, "dictionary evidence fixture should include a candidate");
+  const l1Input = hydratedInput.l1Input as L1PuzzleInput;
+
+  const evidenceRecords = buildCategoryMembershipEvidenceRecords({
+    l1Input,
+    category: "Types of guitar",
+    dictionary: dictionaries.categoryMembership,
+    evidenceIdPrefix: "ev",
+  });
+
+  assert.equal(evidenceRecords.length, 5, "category membership dictionary should produce five L2 evidence records");
+  assert.ok(
+    evidenceRecords.every((record) => {
+      return record.sourceLevel === "L2" &&
+        record.sourceType === "category_membership" &&
+        record.supportKind === "fit" &&
+        record.lookupVersion === dictionaries.categoryMembership.versionId;
+    }),
+    "dictionary-built evidence records should be reviewed L2 fit evidence",
+  );
+
+  const actual = validateCandidate({
+    ...hydratedInput,
+    evidenceRecords,
+  });
+  assert.equal(actual.outcome, "pass_full_analysis", "dictionary-built evidence should support full-analysis validation");
+}
+
 function checkHashExcludesVolatileFields() {
   const base = {
     puzzleId: "pinpoint-900-2026-05-23",
@@ -248,6 +317,7 @@ async function main() {
   assertPr6P0Coverage(fixtures);
   assertPr7Coverage(fixtures);
   await assertExamplesAreValidJson();
+  await assertDictionariesAreReadable();
   console.log(`content-kitchen contract fixtures passed (${fileNames.length} fixtures)`);
 }
 


### PR DESCRIPTION
## Summary
- add reviewed local v0 dictionaries for category membership and aliases
- add dictionary validation, lookup helpers, and L2 category-membership evidence builder
- extend content-kitchen checks to prove dictionaries are readable and can create five L2 fit evidence records for a full-analysis candidate

## Verification
- npm run test:content-kitchen
- npm run typecheck
- npm run lint
- npm run validate:data
- git diff --check