### PR TITLE
Derive PR7 evidence from local dictionaries

### DIFF
--- a/lib/puzzles/content-kitchen/dictionary.ts
+++ b/lib/puzzles/content-kitchen/dictionary.ts
@@ -21,6 +21,8 @@ type CategoryEvidenceInput = {
   evidenceIdPrefix?: string;
 };
 
+export const DEFAULT_CATEGORY_MEMBERSHIP_EVIDENCE_ID_PREFIX = "ev";
+
 const DICTIONARY_REVIEW_STATUSES = new Set<DictionaryReviewStatus>(["draft", "shadow", "reviewed"]);
 const DICTIONARY_RISKS = new Set<DictionaryRisk>(["low", "medium", "high"]);
 const ALIAS_TYPES = new Set<AliasDictionaryEntry["aliasType"]>(["answer", "category", "clue", "phrase"]);
@@ -279,7 +281,7 @@ export function lookupAliases(
 
 export function buildCategoryMembershipEvidenceRecords(input: CategoryEvidenceInput): ContentKitchenEvidenceRecord[] {
   const category = normalizeIdentityText(input.category);
-  const evidenceIdPrefix = normalizeIdentityText(input.evidenceIdPrefix) || "l2-category";
+  const evidenceIdPrefix = normalizeIdentityText(input.evidenceIdPrefix) || DEFAULT_CATEGORY_MEMBERSHIP_EVIDENCE_ID_PREFIX;
 
   return input.l1Input.clues.flatMap((clue) => {
     const entry = lookupCategoryMembership(input.dictionary, {

--- a/lib/puzzles/content-kitchen/types.ts
+++ b/lib/puzzles/content-kitchen/types.ts
@@ -232,6 +232,7 @@ export type ContentCandidate = {
   inputSnapshotHash: string;
   contentHash: string;
   answer: string;
+  answerCategory?: string;
   clues: ContentCandidateClue[];
   summary?: string;
   clueRows?: FullAnalysisClueRowCandidate[];
@@ -268,6 +269,7 @@ export type ValidateCandidateInput = {
   allowAnswerFirstIndex?: boolean;
   existingRoutes?: string[];
   evidenceRecords?: Partial<ContentKitchenEvidenceRecord>[];
+  dictionaries?: ContentKitchenDictionaries;
 };
 
 export type ValidateCandidateOutput = {

--- a/lib/puzzles/content-kitchen/validate-candidate.ts
+++ b/lib/puzzles/content-kitchen/validate-candidate.ts
@@ -5,6 +5,7 @@ import {
   normalizeIdentityMatch,
   normalizeIdentityText,
 } from "./identity";
+import { buildCategoryMembershipEvidenceRecords } from "./dictionary";
 import { validateFullAnalysisEvidence } from "./evidence";
 import { validateFullAnalysisStructure } from "./full-analysis";
 import {
@@ -19,6 +20,7 @@ import {
   CONTENT_KITCHEN_CLUE_COUNT,
   type ContentCandidate,
   type ContentCandidateClue,
+  type ContentKitchenEvidenceRecord,
   type ContentKitchenIssueCode,
   type L1PuzzleClue,
   type L1PuzzleInput,
@@ -133,6 +135,30 @@ function renderedHtmlHasNoindex(renderedHtml: string | undefined): boolean {
 
 function isContentMode(value: unknown): value is ContentCandidate["contentMode"] {
   return value === "answer-first" || value === "full-analysis";
+}
+
+function resolveEvidenceRecords(
+  input: ValidateCandidateInput,
+  candidate: Partial<ContentCandidate>,
+  l1Input: L1PuzzleInput,
+): Partial<ContentKitchenEvidenceRecord>[] | undefined {
+  if (Array.isArray(input.evidenceRecords) && input.evidenceRecords.length > 0) {
+    return input.evidenceRecords;
+  }
+
+  const categoryMembership = input.dictionaries?.categoryMembership;
+  const category = normalizeIdentityText(candidate.answerCategory || candidate.answer);
+  if (!categoryMembership || !category) {
+    return input.evidenceRecords;
+  }
+
+  const dictionaryEvidence = buildCategoryMembershipEvidenceRecords({
+    l1Input,
+    category,
+    dictionary: categoryMembership,
+  });
+
+  return dictionaryEvidence.length > 0 ? dictionaryEvidence : input.evidenceRecords;
 }
 
 export function validateCandidate(input: ValidateCandidateInput): ValidateCandidateOutput {
@@ -348,7 +374,7 @@ export function validateCandidate(input: ValidateCandidateInput): ValidateCandid
     const evidenceIssues = validateFullAnalysisEvidence({
       candidate,
       l1Input: validatedL1,
-      evidenceRecords: input.evidenceRecords,
+      evidenceRecords: resolveEvidenceRecords(input, candidate, validatedL1),
     });
 
     if (evidenceIssues.length > 0) {

--- a/scripts/check-content-kitchen-contract.ts
+++ b/scripts/check-content-kitchen-contract.ts
@@ -249,6 +249,21 @@ async function assertDictionariesAreReadable() {
     evidenceRecords,
   });
   assert.equal(actual.outcome, "pass_full_analysis", "dictionary-built evidence should support full-analysis validation");
+
+  const dictionaryDerived = validateCandidate({
+    ...hydratedInput,
+    candidate: {
+      ...hydratedInput.candidate,
+      answerCategory: "Types of guitar",
+    },
+    evidenceRecords: undefined,
+    dictionaries,
+  });
+  assert.equal(
+    dictionaryDerived.outcome,
+    "pass_full_analysis",
+    "validator should derive category-membership evidence from reviewed dictionaries",
+  );
 }
 
 function checkHashExcludesVolatileFields() {


### PR DESCRIPTION
## Summary
- allow validateCandidate to derive L2 category-membership evidence from reviewed local dictionaries when explicit evidenceRecords are not provided
- add optional candidate.answerCategory and ValidateCandidateInput.dictionaries fields
- make the default dictionary evidence id prefix match existing fixture evidenceRefs
- extend content-kitchen checks to prove dictionary-derived evidence can pass full-analysis validation

## Verification
- npm run test:content-kitchen
- npm run typecheck
- npm run lint
- npm run validate:data
- git diff --check