### PR TITLE
Add PR7 dictionary diff records

### DIFF
--- a/lib/puzzles/content-kitchen/dictionaries/diffs/2026-05-23-alias-dictionary-seed.json
+++ b/lib/puzzles/content-kitchen/dictionaries/diffs/2026-05-23-alias-dictionary-seed.json
@@ -1,0 +1,45 @@
+{
+  "schemaVersion": "content-kitchen-dictionary-diff-v0",
+  "dictionaryName": "alias_dictionary",
+  "fromVersion": "none",
+  "toVersion": "alias_dictionary_2026_05_23",
+  "createdAt": "2026-05-23T00:00:00.000Z",
+  "reviewedBy": "pinpoint-editor",
+  "reviewedAt": "2026-05-23T00:00:00.000Z",
+  "changes": [
+    {
+      "type": "add",
+      "aliasType": "category",
+      "canonicalValue": "Types of guitar",
+      "normalizedCanonicalValue": "types of guitar",
+      "alias": "guitar types",
+      "normalizedAlias": "guitar types",
+      "sourceNote": "Common wording alias for the seeded PR7 fixture category.",
+      "reviewer": "pinpoint-editor",
+      "risk": "low"
+    },
+    {
+      "type": "add",
+      "aliasType": "category",
+      "canonicalValue": "Types of guitar",
+      "normalizedCanonicalValue": "types of guitar",
+      "alias": "guitar family",
+      "normalizedAlias": "guitar family",
+      "sourceNote": "Common wording alias for the seeded PR7 fixture category.",
+      "reviewer": "pinpoint-editor",
+      "risk": "low"
+    },
+    {
+      "type": "add",
+      "aliasType": "answer",
+      "canonicalValue": "Types of guitar",
+      "normalizedCanonicalValue": "types of guitar",
+      "alias": "Kinds of guitar",
+      "normalizedAlias": "kinds of guitar",
+      "sourceNote": "Common wording alias for the seeded PR7 fixture answer.",
+      "reviewer": "pinpoint-editor",
+      "risk": "low"
+    }
+  ],
+  "affectedPublishedPages": []
+}

--- a/lib/puzzles/content-kitchen/dictionaries/diffs/2026-05-23-category-membership-seed.json
+++ b/lib/puzzles/content-kitchen/dictionaries/diffs/2026-05-23-category-membership-seed.json
@@ -1,0 +1,62 @@
+{
+  "schemaVersion": "content-kitchen-dictionary-diff-v0",
+  "dictionaryName": "category_membership",
+  "fromVersion": "none",
+  "toVersion": "category_membership_2026_05_23",
+  "createdAt": "2026-05-23T00:00:00.000Z",
+  "reviewedBy": "pinpoint-editor",
+  "reviewedAt": "2026-05-23T00:00:00.000Z",
+  "changes": [
+    {
+      "type": "add",
+      "category": "Types of guitar",
+      "normalizedCategory": "types of guitar",
+      "member": "Bass",
+      "normalizedMember": "bass",
+      "sourceNote": "Seeded PR7 fixture dictionary entry for content-kitchen validation.",
+      "reviewer": "pinpoint-editor",
+      "risk": "low"
+    },
+    {
+      "type": "add",
+      "category": "Types of guitar",
+      "normalizedCategory": "types of guitar",
+      "member": "Classical",
+      "normalizedMember": "classical",
+      "sourceNote": "Seeded PR7 fixture dictionary entry for content-kitchen validation.",
+      "reviewer": "pinpoint-editor",
+      "risk": "low"
+    },
+    {
+      "type": "add",
+      "category": "Types of guitar",
+      "normalizedCategory": "types of guitar",
+      "member": "Electric",
+      "normalizedMember": "electric",
+      "sourceNote": "Seeded PR7 fixture dictionary entry for content-kitchen validation.",
+      "reviewer": "pinpoint-editor",
+      "risk": "low"
+    },
+    {
+      "type": "add",
+      "category": "Types of guitar",
+      "normalizedCategory": "types of guitar",
+      "member": "Acoustic",
+      "normalizedMember": "acoustic",
+      "sourceNote": "Seeded PR7 fixture dictionary entry for content-kitchen validation.",
+      "reviewer": "pinpoint-editor",
+      "risk": "low"
+    },
+    {
+      "type": "add",
+      "category": "Types of guitar",
+      "normalizedCategory": "types of guitar",
+      "member": "Steel",
+      "normalizedMember": "steel",
+      "sourceNote": "Seeded PR7 fixture dictionary entry for content-kitchen validation.",
+      "reviewer": "pinpoint-editor",
+      "risk": "low"
+    }
+  ],
+  "affectedPublishedPages": []
+}

--- a/lib/puzzles/content-kitchen/dictionary.ts
+++ b/lib/puzzles/content-kitchen/dictionary.ts
@@ -1,4 +1,4 @@
-import { readFile } from "node:fs/promises";
+import { readdir, readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { normalizeIdentityMatch, normalizeIdentityText } from "./identity";
 import type {
@@ -8,7 +8,12 @@ import type {
   CategoryMembershipEntry,
   ContentKitchenDictionaries,
   ContentKitchenDictionaryBase,
+  ContentKitchenDictionaryDiff,
   ContentKitchenEvidenceRecord,
+  DictionaryChangeType,
+  DictionaryDiffAffectedPage,
+  DictionaryDiffChange,
+  DictionaryName,
   DictionaryReviewStatus,
   DictionaryRisk,
   L1PuzzleInput,
@@ -25,6 +30,8 @@ export const DEFAULT_CATEGORY_MEMBERSHIP_EVIDENCE_ID_PREFIX = "ev";
 
 const DICTIONARY_REVIEW_STATUSES = new Set<DictionaryReviewStatus>(["draft", "shadow", "reviewed"]);
 const DICTIONARY_RISKS = new Set<DictionaryRisk>(["low", "medium", "high"]);
+const DICTIONARY_NAMES = new Set<DictionaryName>(["category_membership", "alias_dictionary"]);
+const DICTIONARY_CHANGE_TYPES = new Set<DictionaryChangeType>(["add", "update", "delete"]);
 const ALIAS_TYPES = new Set<AliasDictionaryEntry["aliasType"]>(["answer", "category", "clue", "phrase"]);
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -181,6 +188,127 @@ function validateAliasEntry(input: unknown, index: number): AliasDictionaryEntry
   };
 }
 
+function validateDictionaryName(value: unknown, fieldPath: string): DictionaryName {
+  const dictionaryName = requireString(value, fieldPath) as DictionaryName;
+  if (!DICTIONARY_NAMES.has(dictionaryName)) {
+    throw new Error(`${fieldPath} is unsupported`);
+  }
+  return dictionaryName;
+}
+
+function validateChangeType(value: unknown, fieldPath: string): DictionaryChangeType {
+  const type = requireString(value, fieldPath) as DictionaryChangeType;
+  if (!DICTIONARY_CHANGE_TYPES.has(type)) {
+    throw new Error(`${fieldPath} is unsupported`);
+  }
+  return type;
+}
+
+function optionalString(value: unknown): string | undefined {
+  const normalized = normalizeIdentityText(value);
+  return normalized || undefined;
+}
+
+function validateCategoryDiffFields(input: Record<string, unknown>, fieldPath: string) {
+  const category = requireString(input.category, `${fieldPath}.category`);
+  const normalizedCategory = requireString(input.normalizedCategory, `${fieldPath}.normalizedCategory`);
+  const member = requireString(input.member, `${fieldPath}.member`);
+  const normalizedMember = requireString(input.normalizedMember, `${fieldPath}.normalizedMember`);
+
+  if (normalizedCategory !== normalizeDictionaryValue(category)) {
+    throw new Error(`${fieldPath}.normalizedCategory must match normalized category`);
+  }
+
+  if (normalizedMember !== normalizeDictionaryValue(member)) {
+    throw new Error(`${fieldPath}.normalizedMember must match normalized member`);
+  }
+
+  return {
+    category,
+    normalizedCategory,
+    member,
+    normalizedMember,
+  };
+}
+
+function validateAliasDiffFields(input: Record<string, unknown>, fieldPath: string) {
+  const aliasType = requireString(input.aliasType, `${fieldPath}.aliasType`) as AliasDictionaryEntry["aliasType"];
+  if (!ALIAS_TYPES.has(aliasType)) {
+    throw new Error(`${fieldPath}.aliasType is unsupported`);
+  }
+
+  const canonicalValue = requireString(input.canonicalValue, `${fieldPath}.canonicalValue`);
+  const normalizedCanonicalValue = requireString(input.normalizedCanonicalValue, `${fieldPath}.normalizedCanonicalValue`);
+  const alias = requireString(input.alias, `${fieldPath}.alias`);
+  const normalizedAlias = requireString(input.normalizedAlias, `${fieldPath}.normalizedAlias`);
+
+  if (normalizedCanonicalValue !== normalizeDictionaryValue(canonicalValue)) {
+    throw new Error(`${fieldPath}.normalizedCanonicalValue must match normalized canonicalValue`);
+  }
+
+  if (normalizedAlias !== normalizeDictionaryValue(alias)) {
+    throw new Error(`${fieldPath}.normalizedAlias must match normalized alias`);
+  }
+
+  return {
+    aliasType,
+    canonicalValue,
+    normalizedCanonicalValue,
+    alias,
+    normalizedAlias,
+  };
+}
+
+function validateDictionaryDiffChange(
+  input: unknown,
+  index: number,
+  dictionaryName: DictionaryName,
+): DictionaryDiffChange {
+  if (!isRecord(input)) {
+    throw new Error(`changes[${index}] must be an object`);
+  }
+
+  const fieldPath = `changes[${index}]`;
+  const base = {
+    type: validateChangeType(input.type, `${fieldPath}.type`),
+    sourceNote: requireString(input.sourceNote, `${fieldPath}.sourceNote`),
+    reviewer: requireString(input.reviewer, `${fieldPath}.reviewer`),
+    risk: validateRisk(input.risk, `${fieldPath}.risk`),
+  };
+
+  if (dictionaryName === "category_membership") {
+    return {
+      ...base,
+      ...validateCategoryDiffFields(input, fieldPath),
+    };
+  }
+
+  return {
+    ...base,
+    ...validateAliasDiffFields(input, fieldPath),
+  };
+}
+
+function validateAffectedPage(input: unknown, index: number): DictionaryDiffAffectedPage {
+  if (!isRecord(input)) {
+    throw new Error(`affectedPublishedPages[${index}] must be an object`);
+  }
+
+  const fieldPath = `affectedPublishedPages[${index}]`;
+  if (typeof input.needsReview !== "boolean") {
+    throw new Error(`${fieldPath}.needsReview must be boolean`);
+  }
+
+  return {
+    slug: requireString(input.slug, `${fieldPath}.slug`),
+    ...(optionalString(input.canonicalUrl) ? { canonicalUrl: optionalString(input.canonicalUrl) } : {}),
+    ...(optionalString(input.revisionId) ? { revisionId: optionalString(input.revisionId) } : {}),
+    ...(optionalString(input.lookupVersion) ? { lookupVersion: optionalString(input.lookupVersion) } : {}),
+    reason: requireString(input.reason, `${fieldPath}.reason`),
+    needsReview: input.needsReview,
+  };
+}
+
 function assertNoDuplicateKeys(keys: string[], label: string) {
   const seen = new Set<string>();
   for (const key of keys) {
@@ -245,6 +373,47 @@ async function readJson(path: string): Promise<unknown> {
   return JSON.parse(await readFile(path, "utf8")) as unknown;
 }
 
+export function validateDictionaryDiff(input: unknown): ContentKitchenDictionaryDiff {
+  if (!isRecord(input)) {
+    throw new Error("dictionary diff must be an object");
+  }
+
+  const schemaVersion = requireString(input.schemaVersion, "schemaVersion");
+  if (schemaVersion !== "content-kitchen-dictionary-diff-v0") {
+    throw new Error("schemaVersion must be content-kitchen-dictionary-diff-v0");
+  }
+
+  const dictionaryName = validateDictionaryName(input.dictionaryName, "dictionaryName");
+  const fromVersion = requireString(input.fromVersion, "fromVersion");
+  const toVersion = requireString(input.toVersion, "toVersion");
+  if (fromVersion === toVersion) {
+    throw new Error("fromVersion and toVersion must differ");
+  }
+
+  if (!Array.isArray(input.changes) || input.changes.length === 0) {
+    throw new Error("changes must be a non-empty array");
+  }
+
+  const changes = input.changes.map((change, index) => {
+    return validateDictionaryDiffChange(change, index, dictionaryName);
+  });
+  const affectedPublishedPages = Array.isArray(input.affectedPublishedPages)
+    ? input.affectedPublishedPages.map(validateAffectedPage)
+    : [];
+
+  return {
+    schemaVersion,
+    dictionaryName,
+    fromVersion,
+    toVersion,
+    createdAt: requireIsoUtc(input.createdAt, "createdAt"),
+    reviewedBy: requireString(input.reviewedBy, "reviewedBy"),
+    reviewedAt: requireIsoUtc(input.reviewedAt, "reviewedAt"),
+    changes,
+    affectedPublishedPages,
+  };
+}
+
 export async function readContentKitchenDictionaries(rootDir = process.cwd()): Promise<ContentKitchenDictionaries> {
   const dictionaryDir = resolve(rootDir, "lib", "puzzles", "content-kitchen", "dictionaries");
   const [categoryMembershipJson, aliasDictionaryJson] = await Promise.all([
@@ -256,6 +425,17 @@ export async function readContentKitchenDictionaries(rootDir = process.cwd()): P
     categoryMembership: validateCategoryMembershipDictionary(categoryMembershipJson),
     aliasDictionary: validateAliasDictionary(aliasDictionaryJson),
   };
+}
+
+export async function readContentKitchenDictionaryDiffs(rootDir = process.cwd()): Promise<ContentKitchenDictionaryDiff[]> {
+  const diffDir = resolve(rootDir, "lib", "puzzles", "content-kitchen", "dictionaries", "diffs");
+  const fileNames = (await readdir(diffDir)).filter((fileName) => fileName.endsWith(".json")).sort();
+  const diffs = await Promise.all(
+    fileNames.map(async (fileName) => {
+      return validateDictionaryDiff(await readJson(resolve(diffDir, fileName)));
+    }),
+  );
+  return diffs;
 }
 
 export function lookupCategoryMembership(
@@ -307,4 +487,9 @@ export function buildCategoryMembershipEvidenceRecords(input: CategoryEvidenceIn
       },
     ];
   });
+}
+
+export function dictionaryDiffRequiresReviewArtifacts(diff: ContentKitchenDictionaryDiff): boolean {
+  return diff.changes.some((change) => change.risk === "medium" || change.risk === "high") &&
+    diff.affectedPublishedPages.some((page) => page.needsReview);
 }

--- a/lib/puzzles/content-kitchen/types.ts
+++ b/lib/puzzles/content-kitchen/types.ts
@@ -160,6 +160,8 @@ export type ContentKitchenEvidenceRecord = {
 
 export type DictionaryReviewStatus = "draft" | "shadow" | "reviewed";
 export type DictionaryRisk = "low" | "medium" | "high";
+export type DictionaryName = "category_membership" | "alias_dictionary";
+export type DictionaryChangeType = "add" | "update" | "delete";
 
 export type ContentKitchenDictionaryBase = {
   dictionaryName: string;
@@ -211,6 +213,43 @@ export type AliasDictionary = ContentKitchenDictionaryBase & {
 export type ContentKitchenDictionaries = {
   categoryMembership: CategoryMembershipDictionary;
   aliasDictionary: AliasDictionary;
+};
+
+export type DictionaryDiffChange = {
+  type: DictionaryChangeType;
+  category?: string;
+  normalizedCategory?: string;
+  member?: string;
+  normalizedMember?: string;
+  aliasType?: AliasDictionaryEntry["aliasType"];
+  canonicalValue?: string;
+  normalizedCanonicalValue?: string;
+  alias?: string;
+  normalizedAlias?: string;
+  sourceNote: string;
+  reviewer: string;
+  risk: DictionaryRisk;
+};
+
+export type DictionaryDiffAffectedPage = {
+  slug: string;
+  canonicalUrl?: string;
+  revisionId?: string;
+  lookupVersion?: string;
+  reason: string;
+  needsReview: boolean;
+};
+
+export type ContentKitchenDictionaryDiff = {
+  schemaVersion: "content-kitchen-dictionary-diff-v0";
+  dictionaryName: DictionaryName;
+  fromVersion: string;
+  toVersion: string;
+  createdAt: string;
+  reviewedBy: string;
+  reviewedAt: string;
+  changes: DictionaryDiffChange[];
+  affectedPublishedPages: DictionaryDiffAffectedPage[];
 };
 
 export type FaqCandidate = {

--- a/scripts/check-content-kitchen-contract.ts
+++ b/scripts/check-content-kitchen-contract.ts
@@ -4,9 +4,11 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   buildCategoryMembershipEvidenceRecords,
+  dictionaryDiffRequiresReviewArtifacts,
   lookupAliases,
   lookupCategoryMembership,
   readContentKitchenDictionaries,
+  readContentKitchenDictionaryDiffs,
 } from "../lib/puzzles/content-kitchen/dictionary";
 import { hashInputSnapshot } from "../lib/puzzles/content-kitchen/identity";
 import {
@@ -191,6 +193,7 @@ async function assertExamplesAreValidJson() {
 
 async function assertDictionariesAreReadable() {
   const dictionaries = await readContentKitchenDictionaries(ROOT);
+  const dictionaryDiffs = await readContentKitchenDictionaryDiffs(ROOT);
 
   assert.equal(
     dictionaries.categoryMembership.versionId,
@@ -201,6 +204,27 @@ async function assertDictionariesAreReadable() {
     dictionaries.aliasDictionary.versionId,
     "alias_dictionary_2026_05_23",
     "alias dictionary version should be stable",
+  );
+  assert.ok(dictionaryDiffs.length >= 2, "dictionary diffs should record checked-in dictionary changes");
+
+  const categoryDiff = dictionaryDiffs.find((diff) => diff.toVersion === dictionaries.categoryMembership.versionId);
+  assert.ok(categoryDiff, "category membership dictionary should have a matching diff record");
+  assert.equal(categoryDiff.dictionaryName, "category_membership", "category diff should identify its dictionary");
+  assert.equal(categoryDiff.changes.length, 5, "category seed diff should record five additions");
+  assert.equal(
+    dictionaryDiffRequiresReviewArtifacts(categoryDiff),
+    false,
+    "low-risk seed category diff should not require review artifacts",
+  );
+
+  const aliasDiff = dictionaryDiffs.find((diff) => diff.toVersion === dictionaries.aliasDictionary.versionId);
+  assert.ok(aliasDiff, "alias dictionary should have a matching diff record");
+  assert.equal(aliasDiff.dictionaryName, "alias_dictionary", "alias diff should identify its dictionary");
+  assert.equal(aliasDiff.changes.length, 3, "alias seed diff should record three additions");
+  assert.equal(
+    dictionaryDiffRequiresReviewArtifacts(aliasDiff),
+    false,
+    "low-risk seed alias diff should not require review artifacts",
   );
 
   for (const member of ["Bass", "Classical", "Electric", "Acoustic", "Steel"]) {


### PR DESCRIPTION
## Summary
- add dictionary diff types for category and alias dictionary changes
- add seed diff records for the checked-in category_membership and alias_dictionary files
- add diff validation, loading, and review-artifact helper behavior
- extend content-kitchen checks so dictionary versions must have matching diff records

## Verification
- npm run test:content-kitchen
- npm run typecheck
- npm run lint
- npm run validate:data
- git diff --check