### PR TITLE
Add PR7 affected page lookup

### DIFF
--- a/lib/puzzles/content-kitchen/dictionary.ts
+++ b/lib/puzzles/content-kitchen/dictionary.ts
@@ -10,6 +10,8 @@ import type {
   ContentKitchenDictionaryBase,
   ContentKitchenDictionaryDiff,
   ContentKitchenEvidenceRecord,
+  ContentMode,
+  DictionaryAffectedPageQuery,
   DictionaryChangeType,
   DictionaryDiffAffectedPage,
   DictionaryDiffChange,
@@ -17,6 +19,7 @@ import type {
   DictionaryReviewStatus,
   DictionaryRisk,
   L1PuzzleInput,
+  PublishedEvidenceUsageRecord,
 } from "./types";
 
 type CategoryEvidenceInput = {
@@ -24,6 +27,14 @@ type CategoryEvidenceInput = {
   category: string;
   dictionary: CategoryMembershipDictionary;
   evidenceIdPrefix?: string;
+};
+
+type PublishedEvidenceUsageInput = {
+  slug: string;
+  canonicalUrl?: string;
+  revisionId: string;
+  contentMode?: ContentMode;
+  evidenceRecords: Partial<ContentKitchenEvidenceRecord>[];
 };
 
 export const DEFAULT_CATEGORY_MEMBERSHIP_EVIDENCE_ID_PREFIX = "ev";
@@ -483,6 +494,11 @@ export function buildCategoryMembershipEvidenceRecords(input: CategoryEvidenceIn
         claim: `${entry.member} is reviewed as a member of ${entry.category}.`,
         confidence: entry.risk === "low" ? "high" : "medium",
         lookupVersion: input.dictionary.versionId,
+        dictionaryName: "category_membership",
+        dictionaryCategory: entry.category,
+        normalizedDictionaryCategory: entry.normalizedCategory,
+        dictionaryMember: entry.member,
+        normalizedDictionaryMember: entry.normalizedMember,
         notes: entry.sourceNote,
       },
     ];
@@ -492,4 +508,79 @@ export function buildCategoryMembershipEvidenceRecords(input: CategoryEvidenceIn
 export function dictionaryDiffRequiresReviewArtifacts(diff: ContentKitchenDictionaryDiff): boolean {
   return diff.changes.some((change) => change.risk === "medium" || change.risk === "high") &&
     diff.affectedPublishedPages.some((page) => page.needsReview);
+}
+
+export function buildPublishedEvidenceUsageRecords(input: PublishedEvidenceUsageInput): PublishedEvidenceUsageRecord[] {
+  return input.evidenceRecords.flatMap((record) => {
+    const evidenceId = normalizeIdentityText(record.evidenceId);
+    if (!evidenceId) {
+      return [];
+    }
+
+    return [
+      {
+        slug: input.slug,
+        ...(optionalString(input.canonicalUrl) ? { canonicalUrl: optionalString(input.canonicalUrl) } : {}),
+        revisionId: input.revisionId,
+        ...(input.contentMode ? { contentMode: input.contentMode } : {}),
+        evidenceId,
+        ...(optionalString(record.clueId) ? { clueId: optionalString(record.clueId) } : {}),
+        ...(optionalString(record.lookupVersion) ? { lookupVersion: optionalString(record.lookupVersion) } : {}),
+        ...(record.dictionaryName ? { dictionaryName: record.dictionaryName } : {}),
+        ...(optionalString(record.dictionaryCategory) ? { dictionaryCategory: optionalString(record.dictionaryCategory) } : {}),
+        ...(optionalString(record.normalizedDictionaryCategory)
+          ? { normalizedDictionaryCategory: optionalString(record.normalizedDictionaryCategory) }
+          : {}),
+        ...(optionalString(record.dictionaryMember) ? { dictionaryMember: optionalString(record.dictionaryMember) } : {}),
+        ...(optionalString(record.normalizedDictionaryMember)
+          ? { normalizedDictionaryMember: optionalString(record.normalizedDictionaryMember) }
+          : {}),
+      },
+    ];
+  });
+}
+
+export function findAffectedPublishedPages(
+  usageRecords: PublishedEvidenceUsageRecord[],
+  query: DictionaryAffectedPageQuery,
+): DictionaryDiffAffectedPage[] {
+  const lookupVersion = normalizeIdentityText(query.lookupVersion);
+  const dictionaryName = query.dictionaryName;
+  const normalizedCategory = normalizeDictionaryValue(query.category);
+  const normalizedMember = normalizeDictionaryValue(query.member);
+  const affected = new Map<string, DictionaryDiffAffectedPage>();
+
+  for (const record of usageRecords) {
+    if (lookupVersion && record.lookupVersion !== lookupVersion) {
+      continue;
+    }
+
+    if (dictionaryName && record.dictionaryName !== dictionaryName) {
+      continue;
+    }
+
+    if (normalizedCategory && record.normalizedDictionaryCategory !== normalizedCategory) {
+      continue;
+    }
+
+    if (normalizedMember && record.normalizedDictionaryMember !== normalizedMember) {
+      continue;
+    }
+
+    const key = `${record.slug}:${record.revisionId}`;
+    if (!affected.has(key)) {
+      affected.set(key, {
+        slug: record.slug,
+        ...(record.canonicalUrl ? { canonicalUrl: record.canonicalUrl } : {}),
+        revisionId: record.revisionId,
+        ...(record.lookupVersion ? { lookupVersion: record.lookupVersion } : {}),
+        reason: `Uses dictionary evidence ${record.evidenceId}.`,
+        needsReview: true,
+      });
+    }
+  }
+
+  return [...affected.values()].sort((left, right) => {
+    return `${left.slug}:${left.revisionId ?? ""}`.localeCompare(`${right.slug}:${right.revisionId ?? ""}`);
+  });
 }

--- a/lib/puzzles/content-kitchen/types.ts
+++ b/lib/puzzles/content-kitchen/types.ts
@@ -155,6 +155,11 @@ export type ContentKitchenEvidenceRecord = {
   humanVerifiedBy?: string;
   humanVerifiedAt?: string;
   conflictStatus?: EvidenceConflictStatus;
+  dictionaryName?: DictionaryName;
+  dictionaryCategory?: string;
+  normalizedDictionaryCategory?: string;
+  dictionaryMember?: string;
+  normalizedDictionaryMember?: string;
   notes?: string;
 };
 
@@ -250,6 +255,28 @@ export type ContentKitchenDictionaryDiff = {
   reviewedAt: string;
   changes: DictionaryDiffChange[];
   affectedPublishedPages: DictionaryDiffAffectedPage[];
+};
+
+export type PublishedEvidenceUsageRecord = {
+  slug: string;
+  canonicalUrl?: string;
+  revisionId: string;
+  contentMode?: ContentMode;
+  evidenceId: string;
+  clueId?: string;
+  lookupVersion?: string;
+  dictionaryName?: DictionaryName;
+  dictionaryCategory?: string;
+  normalizedDictionaryCategory?: string;
+  dictionaryMember?: string;
+  normalizedDictionaryMember?: string;
+};
+
+export type DictionaryAffectedPageQuery = {
+  lookupVersion?: string;
+  dictionaryName?: DictionaryName;
+  category?: string;
+  member?: string;
 };
 
 export type FaqCandidate = {

--- a/scripts/check-content-kitchen-contract.ts
+++ b/scripts/check-content-kitchen-contract.ts
@@ -4,7 +4,9 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   buildCategoryMembershipEvidenceRecords,
+  buildPublishedEvidenceUsageRecords,
   dictionaryDiffRequiresReviewArtifacts,
+  findAffectedPublishedPages,
   lookupAliases,
   lookupCategoryMembership,
   readContentKitchenDictionaries,
@@ -273,6 +275,37 @@ async function assertDictionariesAreReadable() {
     evidenceRecords,
   });
   assert.equal(actual.outcome, "pass_full_analysis", "dictionary-built evidence should support full-analysis validation");
+
+  const usageRecords = buildPublishedEvidenceUsageRecords({
+    slug: "pinpoint-answer-900",
+    canonicalUrl: "https://example.com/linkedin-pinpoint-answers/pinpoint-answer-900/",
+    revisionId: "rev-full-analysis-cumulative",
+    contentMode: "full-analysis",
+    evidenceRecords,
+  });
+  assert.equal(usageRecords.length, 5, "published evidence usage index should include one row per evidence record");
+
+  const affectedByVersion = findAffectedPublishedPages(usageRecords, {
+    lookupVersion: dictionaries.categoryMembership.versionId,
+    dictionaryName: "category_membership",
+  });
+  assert.deepEqual(
+    affectedByVersion.map((page) => page.slug),
+    ["pinpoint-answer-900"],
+    "affected page lookup should find pages by dictionary lookup version",
+  );
+
+  const affectedByMember = findAffectedPublishedPages(usageRecords, {
+    dictionaryName: "category_membership",
+    category: "Types of guitar",
+    member: "Bass",
+  });
+  assert.deepEqual(
+    affectedByMember.map((page) => page.slug),
+    ["pinpoint-answer-900"],
+    "affected page lookup should find pages by dictionary category and member",
+  );
+  assert.equal(affectedByMember[0]?.needsReview, true, "affected pages should be marked for review by default");
 
   const dictionaryDerived = validateCandidate({
     ...hydratedInput,


### PR DESCRIPTION
## Summary
- add dictionary metadata to content-kitchen evidence records
- add published evidence usage records for indexing which pages used dictionary evidence
- add affected-page lookup by lookupVersion and category/member
- extend content-kitchen checks to prove affected published pages can be found

## Verification
- npm run test:content-kitchen
- npm run typecheck
- npm run lint
- npm run validate:data
- git diff --check