### PR TITLE
Document PR7 implementation status

### DIFF
--- a/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
+++ b/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
@@ -1903,6 +1903,31 @@ Acceptance:
 - competitor pages cannot be used as L2/L3 evidence
 - ambiguous clue fits require deterministic lookup, stronger independent support, or human review
 
+Status as of 2026-05-23:
+
+Implemented in PR7 v0:
+
+- PR #61 added the content-kitchen evidence source validator, PR7 issue codes, L2 allowlist, L4-only handling, prohibited source handling, low-confidence handling, and unresolved-conflict handling.
+- PR #62 added reviewed local JSON dictionaries: `category_membership.json` and `alias_dictionary.json`, plus dictionary readers and validation.
+- PR #63 allowed `validateCandidate` to derive L2 category-membership evidence from reviewed local dictionaries when explicit `evidenceRecords` are not supplied.
+- PR #64 added dictionary diff records so checked-in dictionary changes record version movement, reviewer, risk, and affected-page placeholders.
+- PR #65 added a v0 affected-page lookup shape using published evidence usage records, lookup version, dictionary category, and dictionary member.
+
+Still not implemented in PR7 v0:
+
+- no production publish path reads these dictionaries yet
+- no Worker queue or release flow uses dictionary-derived evidence yet
+- no review UI exists for dictionary diffs or affected pages yet
+- no persistent production store exists for published evidence usage records yet
+- no L3 retrieval/search provider is enabled
+- no automatic `full-analysis` publishing is enabled from this layer alone
+
+Current boundary:
+
+- PR7 v0 proves the local contract and validation behavior.
+- It is safe for fixtures, tests, shadow/manual review work, and later integration.
+- It is not yet permission to turn on production auto-publish.
+
 ### PR8 — Full-Analysis Generator
 
 Goal: replace one-shot article generation with structured slot generation.

--- a/docs/pinpoint-content-kitchen-rollout-playbook-2026-05-23.md
+++ b/docs/pinpoint-content-kitchen-rollout-playbook-2026-05-23.md
@@ -269,6 +269,16 @@ Before PR7 can support automatic `full-analysis`:
 - dictionary versioning must be recorded
 - affected-page lookup by dictionary version must be possible
 
+PR7 v0 implementation status as of 2026-05-23:
+
+- local reviewed dictionary files exist for `category_membership.json` and `alias_dictionary.json`
+- dictionary readers validate owner, reviewer, review timestamp, review status, version id, normalized keys, source notes, and risk
+- validator can derive L2 category-membership evidence from reviewed local dictionaries
+- dictionary diffs are checked in for current seed versions
+- affected-page lookup has a v0 shape based on published evidence usage records
+
+This does not enable automatic production `full-analysis` publishing yet. Auto-publish still needs production integration, persisted usage records, review ownership, review capacity, rollout owner, cost budget, and canary approval.
+
 Unreviewed dictionary changes:
 
 - may run in shadow


### PR DESCRIPTION
## Summary
- document what PR7 v0 has implemented across PR #61 through PR #65
- call out what is still not production-integrated
- update rollout playbook evidence-owner status without enabling auto-publish

## Verification
- npm run test:content-kitchen
- npm run validate:data via pre-push hook
- git diff --check