### PR TITLE
Add PR8 full-analysis slot contract

### DIFF
--- a/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
+++ b/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
@@ -1950,6 +1950,17 @@ Acceptance:
 - false starts are omitted when unsupported
 - competitor-style synthetic fixtures produce readable pages without template collapse
 
+PR8 first implementation slice:
+
+- add only the `full-analysis-slot-plan-v0` contract and local validator
+- do not change the live generator, Worker, sitemap, rendering, or publish flow
+- require exactly five clue-fit slots, one per L1 clue, each with evidence refs
+- require a supported reasoning slot before deterministic assembly can happen
+- require `falseStart.status = "omitted"` when no supported false start exists
+- allow `falseStart.status = "included"` only when rejectedTheory and whyRejected are both present
+- require two to four FAQ slots before a full-analysis slot plan can be assembled
+- leave puzzle type classifier, slot generators, deterministic assembler, and repair loop for later PR8 slices
+
 ### PR9 — Answer-First Enrichment SLA
 
 Goal: make `answer-first` temporary.

--- a/lib/puzzles/content-kitchen/full-analysis-slots.ts
+++ b/lib/puzzles/content-kitchen/full-analysis-slots.ts
@@ -1,0 +1,347 @@
+import { normalizeIdentityMatch, normalizeIdentityText } from "./identity";
+import {
+  CONTENT_KITCHEN_CLUE_COUNT,
+  type FullAnalysisClueFitSlot,
+  type FullAnalysisReasoning,
+  type FullAnalysisSlotIssue,
+  type FullAnalysisSlotIssueCode,
+  type FullAnalysisSlotPlanV0,
+  type L1PuzzleInput,
+} from "./types";
+
+export type ValidateFullAnalysisSlotPlanInput = {
+  l1Input: L1PuzzleInput;
+  slotPlan?: Partial<FullAnalysisSlotPlanV0> | null;
+};
+
+const SUPPORTED_PUZZLE_TYPES = new Set([
+  "category_membership",
+  "phrase_pattern",
+  "wordplay",
+  "entity_set",
+  "unknown",
+]);
+
+function makeIssue(
+  issueCode: FullAnalysisSlotIssueCode,
+  fieldPath: string,
+  message: string,
+  suggestedAction: string,
+): FullAnalysisSlotIssue {
+  return {
+    issueCode,
+    fieldPath,
+    message,
+    suggestedAction,
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function hasText(value: unknown): boolean {
+  return Boolean(normalizeIdentityText(value));
+}
+
+function hasStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.length > 0 && value.every(hasText);
+}
+
+function getKnownL1ClueIds(l1Input: L1PuzzleInput): Set<string> {
+  return new Set(l1Input.clues.map((clue) => normalizeIdentityMatch(clue.clueId)));
+}
+
+function validatePuzzleType(slotPlan: Partial<FullAnalysisSlotPlanV0>, issues: FullAnalysisSlotIssue[]) {
+  if (slotPlan.slotVersion !== "full-analysis-slot-plan-v0") {
+    issues.push(
+      makeIssue(
+        "INVALID_SLOT_PLAN_VERSION",
+        "slotPlan.slotVersion",
+        "Full-analysis slot plan must use the v0 slot version.",
+        "Set slotVersion to full-analysis-slot-plan-v0.",
+      ),
+    );
+  }
+
+  if (!hasText(slotPlan.puzzleType) || !SUPPORTED_PUZZLE_TYPES.has(String(slotPlan.puzzleType))) {
+    issues.push(
+      makeIssue(
+        "MISSING_SLOT_PUZZLE_TYPE",
+        "slotPlan.puzzleType",
+        "Full-analysis slot plan needs one supported puzzle type.",
+        "Set puzzleType before generating clue-fit slots.",
+      ),
+    );
+  }
+}
+
+function validateClueFits(input: ValidateFullAnalysisSlotPlanInput, issues: FullAnalysisSlotIssue[]) {
+  const clueFits = input.slotPlan?.clueFits;
+  const clueFitList = Array.isArray(clueFits) ? clueFits : [];
+  const knownClueIds = getKnownL1ClueIds(input.l1Input);
+  const seenClueIds = new Set<string>();
+
+  if (!Array.isArray(clueFits) || clueFits.length !== CONTENT_KITCHEN_CLUE_COUNT) {
+    issues.push(
+      makeIssue(
+        "MISSING_SLOT_CLUE_FIT",
+        "slotPlan.clueFits",
+        "Full-analysis slot plan must include exactly five clue-fit slots.",
+        "Add one clue-fit slot for every L1 clue.",
+      ),
+    );
+  }
+
+  for (let index = 0; index < clueFitList.length; index += 1) {
+    const clueFit = clueFitList[index] as Partial<FullAnalysisClueFitSlot> | undefined;
+    const fieldPath = `slotPlan.clueFits[${index}]`;
+
+    if (!isRecord(clueFit)) {
+      issues.push(
+        makeIssue(
+          "MISSING_SLOT_CLUE_FIT",
+          fieldPath,
+          "Each clue-fit slot must be an object.",
+          "Regenerate this clue-fit slot.",
+        ),
+      );
+      continue;
+    }
+
+    const clueId = normalizeIdentityText(clueFit.clueId);
+    const normalizedClueId = normalizeIdentityMatch(clueId);
+    if (!clueId || !knownClueIds.has(normalizedClueId)) {
+      issues.push(
+        makeIssue(
+          "UNKNOWN_SLOT_CLUE",
+          `${fieldPath}.clueId`,
+          "Clue-fit slot must point to one known L1 clue id.",
+          "Use the exact L1 clue id for this slot.",
+        ),
+      );
+    } else if (seenClueIds.has(normalizedClueId)) {
+      issues.push(
+        makeIssue(
+          "DUPLICATE_SLOT_CLUE_FIT",
+          `${fieldPath}.clueId`,
+          "A clue id appears in more than one clue-fit slot.",
+          "Keep exactly one clue-fit slot per L1 clue.",
+        ),
+      );
+    } else {
+      seenClueIds.add(normalizedClueId);
+    }
+
+    if (!hasText(clueFit.fit) || !hasText(clueFit.whyItSupportsAnswer)) {
+      issues.push(
+        makeIssue(
+          "MISSING_SLOT_CLUE_FIT",
+          fieldPath,
+          "Each clue-fit slot needs fit and whyItSupportsAnswer.",
+          "Add specific fit text before assembling full-analysis content.",
+        ),
+      );
+    }
+
+    if (!hasStringArray(clueFit.evidenceRefs)) {
+      issues.push(
+        makeIssue(
+          "MISSING_SLOT_EVIDENCE_REF",
+          `${fieldPath}.evidenceRefs`,
+          "Each clue-fit slot needs at least one evidence ref.",
+          "Attach evidence refs before assembling full-analysis content.",
+        ),
+      );
+    }
+  }
+
+  for (const clue of input.l1Input.clues) {
+    if (!seenClueIds.has(normalizeIdentityMatch(clue.clueId))) {
+      issues.push(
+        makeIssue(
+          "MISSING_SLOT_CLUE_FIT",
+          "slotPlan.clueFits",
+          "Full-analysis slot plan is missing an L1 clue fit.",
+          "Add one clue-fit slot for every L1 clue.",
+        ),
+      );
+    }
+  }
+}
+
+function validateReasoning(input: ValidateFullAnalysisSlotPlanInput, issues: FullAnalysisSlotIssue[]) {
+  const reasoning = input.slotPlan?.reasoning as Partial<FullAnalysisReasoning> | undefined;
+  const knownClueIds = getKnownL1ClueIds(input.l1Input);
+
+  if (!isRecord(reasoning)) {
+    issues.push(
+      makeIssue(
+        "MISSING_SLOT_REASONING",
+        "slotPlan.reasoning",
+        "Full-analysis slot plan needs one reasoning slot.",
+        "Add turning_point or cumulative_confirmation reasoning.",
+      ),
+    );
+    return;
+  }
+
+  if (!hasText(reasoning.text)) {
+    issues.push(
+      makeIssue(
+        "MISSING_SLOT_REASONING",
+        "slotPlan.reasoning.text",
+        "Reasoning slot needs non-empty text.",
+        "Explain the clue path before assembling full-analysis content.",
+      ),
+    );
+  }
+
+  if (reasoning.pattern === "turning_point") {
+    const clueId = normalizeIdentityText(reasoning.clueId);
+    if (!clueId || !knownClueIds.has(normalizeIdentityMatch(clueId))) {
+      issues.push(
+        makeIssue(
+          "UNSUPPORTED_SLOT_REASONING",
+          "slotPlan.reasoning.clueId",
+          "Turning-point reasoning must name one known L1 clue id.",
+          "Use one L1 clue id as the turning point.",
+        ),
+      );
+    }
+
+    if (!hasText(reasoning.brokenTheory) || !hasText(reasoning.supportedTheory)) {
+      issues.push(
+        makeIssue(
+          "UNSUPPORTED_SLOT_REASONING",
+          "slotPlan.reasoning",
+          "Turning-point reasoning needs brokenTheory and supportedTheory.",
+          "Add both theory fields.",
+        ),
+      );
+    }
+    return;
+  }
+
+  if (reasoning.pattern === "cumulative_confirmation") {
+    const clueIds = Array.isArray(reasoning.clueIds) ? reasoning.clueIds.map(normalizeIdentityText).filter(Boolean) : [];
+    const knownUniqueIds = new Set(clueIds.map(normalizeIdentityMatch).filter((clueId) => knownClueIds.has(clueId)));
+    if (knownUniqueIds.size < 2) {
+      issues.push(
+        makeIssue(
+          "UNSUPPORTED_SLOT_REASONING",
+          "slotPlan.reasoning.clueIds",
+          "Cumulative-confirmation reasoning needs at least two known L1 clue ids.",
+          "Reference at least two exact L1 clue ids.",
+        ),
+      );
+    }
+    return;
+  }
+
+  issues.push(
+    makeIssue(
+      "UNSUPPORTED_SLOT_REASONING",
+      "slotPlan.reasoning.pattern",
+      "Reasoning slot must use turning_point or cumulative_confirmation.",
+      "Use one supported reasoning pattern.",
+    ),
+  );
+}
+
+function validateFalseStart(slotPlan: Partial<FullAnalysisSlotPlanV0>, issues: FullAnalysisSlotIssue[]) {
+  const falseStart = slotPlan.falseStart;
+
+  if (!isRecord(falseStart)) {
+    issues.push(
+      makeIssue(
+        "INVALID_FALSE_START_SLOT",
+        "slotPlan.falseStart",
+        "Full-analysis slot plan needs a false-start slot, even when omitted.",
+        "Set falseStart.status to omitted or included.",
+      ),
+    );
+    return;
+  }
+
+  if (falseStart.status === "omitted") {
+    return;
+  }
+
+  if (falseStart.status !== "included") {
+    issues.push(
+      makeIssue(
+        "INVALID_FALSE_START_SLOT",
+        "slotPlan.falseStart.status",
+        "False-start slot status must be omitted or included.",
+        "Use omitted when there is no supported false start.",
+      ),
+    );
+    return;
+  }
+
+  if (!hasText(falseStart.rejectedTheory) || !hasText(falseStart.whyRejected)) {
+    issues.push(
+      makeIssue(
+        "INVALID_FALSE_START_SLOT",
+        "slotPlan.falseStart",
+        "Included false-start slot needs rejectedTheory and whyRejected.",
+        "Fill both fields or mark the false-start slot as omitted.",
+      ),
+    );
+  }
+}
+
+function validateFaq(slotPlan: Partial<FullAnalysisSlotPlanV0>, issues: FullAnalysisSlotIssue[]) {
+  const faqItems = slotPlan.faqItems;
+
+  if (!Array.isArray(faqItems) || faqItems.length < 2 || faqItems.length > 4) {
+    issues.push(
+      makeIssue(
+        "MISSING_SLOT_FAQ",
+        "slotPlan.faqItems",
+        "Full-analysis slot plan needs two to four FAQ items.",
+        "Generate specific FAQ items or keep the plan out of assembly.",
+      ),
+    );
+    return;
+  }
+
+  for (let index = 0; index < faqItems.length; index += 1) {
+    const faqItem = faqItems[index];
+    if (!hasText(faqItem?.question) || !hasText(faqItem?.answer)) {
+      issues.push(
+        makeIssue(
+          "MISSING_SLOT_FAQ",
+          `slotPlan.faqItems[${index}]`,
+          "FAQ slot needs question and answer text.",
+          "Regenerate this FAQ item.",
+        ),
+      );
+    }
+  }
+}
+
+export function validateFullAnalysisSlotPlan(input: ValidateFullAnalysisSlotPlanInput): FullAnalysisSlotIssue[] {
+  const slotPlan = input.slotPlan;
+  const issues: FullAnalysisSlotIssue[] = [];
+
+  if (!isRecord(slotPlan)) {
+    return [
+      makeIssue(
+        "INVALID_SLOT_PLAN_VERSION",
+        "slotPlan",
+        "Full-analysis slot plan must be an object.",
+        "Create a full-analysis-slot-plan-v0 object.",
+      ),
+    ];
+  }
+
+  validatePuzzleType(slotPlan, issues);
+  validateClueFits(input, issues);
+  validateReasoning(input, issues);
+  validateFalseStart(slotPlan, issues);
+  validateFaq(slotPlan, issues);
+
+  return issues;
+}

--- a/lib/puzzles/content-kitchen/types.ts
+++ b/lib/puzzles/content-kitchen/types.ts
@@ -284,6 +284,68 @@ export type FaqCandidate = {
   answer: string;
 };
 
+export type FullAnalysisPuzzleType =
+  | "category_membership"
+  | "phrase_pattern"
+  | "wordplay"
+  | "entity_set"
+  | "unknown";
+
+export type FullAnalysisSlotInput = {
+  l1Input: L1PuzzleInput;
+  answerCategory?: string;
+  evidenceRecords?: Partial<ContentKitchenEvidenceRecord>[];
+};
+
+export type FullAnalysisClueFitSlot = FullAnalysisClueRowCandidate;
+
+export type FullAnalysisFalseStartSlot =
+  | {
+      status: "omitted";
+      rejectedTheory?: string;
+      whyRejected?: string;
+      evidenceRefs?: string[];
+    }
+  | {
+      status: "included";
+      rejectedTheory: string;
+      whyRejected: string;
+      evidenceRefs?: string[];
+    };
+
+export type FullAnalysisFaqSlot = FaqCandidate & {
+  evidenceRefs?: string[];
+};
+
+export type FullAnalysisSlotPlanV0 = {
+  slotVersion: "full-analysis-slot-plan-v0";
+  puzzleType: FullAnalysisPuzzleType;
+  answerCategory?: string;
+  clueFits: FullAnalysisClueFitSlot[];
+  reasoning: FullAnalysisReasoning;
+  falseStart: FullAnalysisFalseStartSlot;
+  faqItems: FullAnalysisFaqSlot[];
+};
+
+export type FullAnalysisSlotIssueCode =
+  | "INVALID_SLOT_PLAN_VERSION"
+  | "MISSING_SLOT_PUZZLE_TYPE"
+  | "MISSING_SLOT_CLUE_FIT"
+  | "DUPLICATE_SLOT_CLUE_FIT"
+  | "UNKNOWN_SLOT_CLUE"
+  | "MISSING_SLOT_EVIDENCE_REF"
+  | "MISSING_SLOT_REASONING"
+  | "UNSUPPORTED_SLOT_REASONING"
+  | "INVALID_FALSE_START_SLOT"
+  | "MISSING_SLOT_FAQ";
+
+export type FullAnalysisSlotIssue = {
+  issueCode: FullAnalysisSlotIssueCode;
+  fieldPath: string;
+  message: string;
+  suggestedAction: string;
+};
+
 export type InternalLinkCandidate = {
   href: string;
   label?: string;

--- a/scripts/check-content-kitchen-contract.ts
+++ b/scripts/check-content-kitchen-contract.ts
@@ -12,6 +12,7 @@ import {
   readContentKitchenDictionaries,
   readContentKitchenDictionaryDiffs,
 } from "../lib/puzzles/content-kitchen/dictionary";
+import { validateFullAnalysisSlotPlan } from "../lib/puzzles/content-kitchen/full-analysis-slots";
 import { hashInputSnapshot } from "../lib/puzzles/content-kitchen/identity";
 import {
   CONTENT_KITCHEN_ISSUE_REGISTRY,
@@ -23,6 +24,8 @@ import { buildReviewArtifactV0, shouldCreateReviewArtifact } from "../lib/puzzle
 import { validateCandidate } from "../lib/puzzles/content-kitchen/validate-candidate";
 import type {
   ContentKitchenIssueCode,
+  FullAnalysisSlotIssueCode,
+  FullAnalysisSlotPlanV0,
   L1PuzzleInput,
   ValidateCandidateInput,
   ValidationOutcome,
@@ -364,6 +367,151 @@ function checkHashExcludesVolatileFields() {
   );
 }
 
+function makeSlotContractL1Input(): L1PuzzleInput {
+  return {
+    puzzleId: "pinpoint-900-2026-05-23",
+    puzzleNumber: 900,
+    logicalGameDate: "2026-05-23",
+    source: "official_capture",
+    answer: "Types of guitar",
+    clues: [
+      { clueId: "clue-1", text: "Bass", position: 1 },
+      { clueId: "clue-2", text: "Classical", position: 2 },
+      { clueId: "clue-3", text: "Electric", position: 3 },
+      { clueId: "clue-4", text: "Acoustic", position: 4 },
+      { clueId: "clue-5", text: "Steel", position: 5 },
+    ],
+  };
+}
+
+function makeValidSlotPlan(): FullAnalysisSlotPlanV0 {
+  const l1Input = makeSlotContractL1Input();
+
+  return {
+    slotVersion: "full-analysis-slot-plan-v0",
+    puzzleType: "category_membership",
+    answerCategory: "Types of guitar",
+    clueFits: l1Input.clues.map((clue) => ({
+      clueId: clue.clueId,
+      clueText: clue.text,
+      fit: `${clue.text} is a type of guitar.`,
+      whyItSupportsAnswer: `${clue.text} supports the shared category Types of guitar.`,
+      evidenceRefs: [`ev-${clue.clueId}`],
+    })),
+    reasoning: {
+      pattern: "cumulative_confirmation",
+      clueIds: ["clue-1", "clue-2", "clue-3"],
+      text: "Bass, Classical, and Electric all work as named types of guitar, so the other clues confirm the same category.",
+      evidenceRefs: ["ev-clue-1", "ev-clue-2", "ev-clue-3"],
+    },
+    falseStart: {
+      status: "omitted",
+    },
+    faqItems: [
+      {
+        question: "Why is Bass a fit?",
+        answer: "Bass is a type of guitar in this clue set.",
+        evidenceRefs: ["ev-clue-1"],
+      },
+      {
+        question: "Why is Electric a fit?",
+        answer: "Electric is another type of guitar in the same category.",
+        evidenceRefs: ["ev-clue-3"],
+      },
+    ],
+  };
+}
+
+function getSlotIssueCodes(slotPlan: Partial<FullAnalysisSlotPlanV0>): FullAnalysisSlotIssueCode[] {
+  return validateFullAnalysisSlotPlan({
+    l1Input: makeSlotContractL1Input(),
+    slotPlan,
+  }).map((issue) => issue.issueCode);
+}
+
+function assertSlotIssueIncluded(
+  name: string,
+  slotPlan: Partial<FullAnalysisSlotPlanV0>,
+  expectedIssueCode: FullAnalysisSlotIssueCode,
+) {
+  assert.ok(
+    getSlotIssueCodes(slotPlan).includes(expectedIssueCode),
+    `${name}: expected slot issue ${expectedIssueCode}`,
+  );
+}
+
+function assertFullAnalysisSlotContract() {
+  const validPlan = makeValidSlotPlan();
+  assert.deepEqual(getSlotIssueCodes(validPlan), [], "valid full-analysis slot plan should pass");
+
+  const includedFalseStart: FullAnalysisSlotPlanV0 = {
+    ...validPlan,
+    falseStart: {
+      status: "included",
+      rejectedTheory: "The clues might be instrument parts.",
+      whyRejected: "The clues fit better as whole guitar types, not parts.",
+      evidenceRefs: ["ev-clue-1"],
+    },
+  };
+  assert.deepEqual(getSlotIssueCodes(includedFalseStart), [], "included false-start slot should pass when complete");
+
+  const duplicateClueFit: FullAnalysisSlotPlanV0 = {
+    ...validPlan,
+    clueFits: validPlan.clueFits.map((clueFit, index) => {
+      if (index === 4) {
+        return {
+          ...clueFit,
+          clueId: "clue-1",
+        };
+      }
+
+      return clueFit;
+    }),
+  };
+  assertSlotIssueIncluded("duplicate clue fit", duplicateClueFit, "DUPLICATE_SLOT_CLUE_FIT");
+
+  const unknownClueFit: FullAnalysisSlotPlanV0 = {
+    ...validPlan,
+    clueFits: validPlan.clueFits.map((clueFit, index) => {
+      if (index === 0) {
+        return {
+          ...clueFit,
+          clueId: "not-a-real-clue",
+        };
+      }
+
+      return clueFit;
+    }),
+  };
+  assertSlotIssueIncluded("unknown clue fit", unknownClueFit, "UNKNOWN_SLOT_CLUE");
+
+  assertSlotIssueIncluded(
+    "weak cumulative reasoning",
+    {
+      ...validPlan,
+      reasoning: {
+        pattern: "cumulative_confirmation",
+        clueIds: ["clue-1"],
+        text: "Only one clue is not enough to support cumulative reasoning.",
+      },
+    },
+    "UNSUPPORTED_SLOT_REASONING",
+  );
+
+  assertSlotIssueIncluded(
+    "incomplete false start",
+    {
+      ...validPlan,
+      falseStart: {
+        status: "included",
+        rejectedTheory: "The answer might be instrument parts.",
+        whyRejected: "",
+      },
+    },
+    "INVALID_FALSE_START_SLOT",
+  );
+}
+
 async function main() {
   const fileNames = (await readdir(FIXTURE_DIR)).filter((fileName) => fileName.endsWith(".json")).sort();
   assert.ok(fileNames.length >= 6, "content kitchen should have at least 6 fixtures");
@@ -385,6 +533,7 @@ async function main() {
   }
 
   checkHashExcludesVolatileFields();
+  assertFullAnalysisSlotContract();
   assertIssueRegistryIsStable();
   assertPr6P0Coverage(fixtures);
   assertPr7Coverage(fixtures);


### PR DESCRIPTION
## Summary
- add full-analysis-slot-plan-v0 types and a local slot validator
- require five clue-fit slots, supported reasoning, explicit false-start state, and 2-4 FAQ slots
- cover the slot contract in the content-kitchen contract test and document the first PR8 slice

## Tests
- npm run test:content-kitchen
- npm run typecheck
- npm run lint
- npm run validate:data
- npm run build
- git diff --check