### PR TITLE
Add PR8 puzzle type classifier

### DIFF
--- a/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
+++ b/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
@@ -1961,6 +1961,15 @@ PR8 first implementation slice:
 - require two to four FAQ slots before a full-analysis slot plan can be assembled
 - leave puzzle type classifier, slot generators, deterministic assembler, and repair loop for later PR8 slices
 
+PR8 second implementation slice:
+
+- add a conservative puzzle type classifier before generation
+- classify as `category_membership` only when reviewed local dictionaries can map all five L1 clues to one category
+- mark direct answer/category matches and reviewed answer aliases as high confidence
+- keep partial, missing, or ambiguous dictionary coverage as `unknown`
+- do not infer `phrase_pattern`, `wordplay`, or `entity_set` without dedicated later rules
+- do not change generator, Worker, sitemap, rendering, or publish flow
+
 ### PR9 — Answer-First Enrichment SLA
 
 Goal: make `answer-first` temporary.

--- a/lib/puzzles/content-kitchen/puzzle-type-classifier.ts
+++ b/lib/puzzles/content-kitchen/puzzle-type-classifier.ts
@@ -1,0 +1,190 @@
+import { normalizeIdentityMatch, normalizeIdentityText } from "./identity";
+import {
+  CONTENT_KITCHEN_CLUE_COUNT,
+  type AliasDictionary,
+  type CategoryMembershipDictionary,
+  type ContentKitchenDictionaries,
+  type FullAnalysisPuzzleTypeCandidateCategory,
+  type FullAnalysisPuzzleTypeClassification,
+  type FullAnalysisPuzzleTypeClassificationReason,
+  type L1PuzzleInput,
+} from "./types";
+
+export type ClassifyFullAnalysisPuzzleTypeInput = {
+  l1Input: L1PuzzleInput;
+  dictionaries?: ContentKitchenDictionaries;
+  answerCategoryHint?: string;
+};
+
+type CategoryCoverage = {
+  category: string;
+  normalizedCategory: string;
+  lookupVersion: string;
+  matchedClueIds: Set<string>;
+};
+
+function stableReasonCodes(
+  reasonCodes: FullAnalysisPuzzleTypeClassificationReason[],
+): FullAnalysisPuzzleTypeClassificationReason[] {
+  return [...new Set(reasonCodes)];
+}
+
+function toCandidateCategory(coverage: CategoryCoverage): FullAnalysisPuzzleTypeCandidateCategory {
+  return {
+    category: coverage.category,
+    matchedClueCount: coverage.matchedClueIds.size,
+    matchedClueIds: [...coverage.matchedClueIds].sort(),
+    lookupVersion: coverage.lookupVersion,
+  };
+}
+
+function sortCandidateCategories(
+  categories: FullAnalysisPuzzleTypeCandidateCategory[],
+): FullAnalysisPuzzleTypeCandidateCategory[] {
+  return [...categories].sort((left, right) => {
+    if (right.matchedClueCount !== left.matchedClueCount) {
+      return right.matchedClueCount - left.matchedClueCount;
+    }
+
+    return left.category.localeCompare(right.category);
+  });
+}
+
+function buildCategoryCoverage(
+  l1Input: L1PuzzleInput,
+  dictionary: CategoryMembershipDictionary,
+): FullAnalysisPuzzleTypeCandidateCategory[] {
+  const coverageByCategory = new Map<string, CategoryCoverage>();
+
+  for (const clue of l1Input.clues) {
+    const normalizedClueText = normalizeIdentityMatch(clue.text);
+    if (!normalizedClueText) {
+      continue;
+    }
+
+    const matchingEntries = dictionary.entries.filter((entry) => entry.normalizedMember === normalizedClueText);
+    for (const entry of matchingEntries) {
+      const coverage = coverageByCategory.get(entry.normalizedCategory) ?? {
+        category: entry.category,
+        normalizedCategory: entry.normalizedCategory,
+        lookupVersion: dictionary.versionId,
+        matchedClueIds: new Set<string>(),
+      };
+      coverage.matchedClueIds.add(normalizeIdentityText(clue.clueId));
+      coverageByCategory.set(entry.normalizedCategory, coverage);
+    }
+  }
+
+  return sortCandidateCategories([...coverageByCategory.values()].map(toCandidateCategory));
+}
+
+function categoryMatchesAnswerHint(
+  category: FullAnalysisPuzzleTypeCandidateCategory,
+  answerHint: string,
+  aliasDictionary: AliasDictionary,
+): FullAnalysisPuzzleTypeClassificationReason | null {
+  const normalizedHint = normalizeIdentityMatch(answerHint);
+  if (!normalizedHint) {
+    return null;
+  }
+
+  if (normalizeIdentityMatch(category.category) === normalizedHint) {
+    return "ANSWER_CATEGORY_HINT_MATCHED";
+  }
+
+  const aliasMatch = aliasDictionary.entries.some((entry) => {
+    return (
+      (entry.aliasType === "answer" || entry.aliasType === "category") &&
+      entry.normalizedAlias === normalizedHint &&
+      entry.normalizedCanonicalValue === normalizeIdentityMatch(category.category)
+    );
+  });
+
+  return aliasMatch ? "ANSWER_ALIAS_MATCHED_CATEGORY" : null;
+}
+
+function unknownClassification(
+  l1Input: L1PuzzleInput,
+  candidateCategories: FullAnalysisPuzzleTypeCandidateCategory[],
+  reasonCodes: FullAnalysisPuzzleTypeClassificationReason[],
+): FullAnalysisPuzzleTypeClassification {
+  const bestCategory = candidateCategories[0];
+  const matchedClueIds = bestCategory?.matchedClueIds ?? [];
+
+  return {
+    puzzleType: "unknown",
+    confidence: "low",
+    matchedClueCount: bestCategory?.matchedClueCount ?? 0,
+    matchedClueIds,
+    unmatchedClueIds: l1Input.clues
+      .map((clue) => clue.clueId)
+      .filter((clueId) => !matchedClueIds.includes(clueId)),
+    candidateCategories,
+    reasonCodes: stableReasonCodes(reasonCodes),
+  };
+}
+
+export function classifyFullAnalysisPuzzleType(
+  input: ClassifyFullAnalysisPuzzleTypeInput,
+): FullAnalysisPuzzleTypeClassification {
+  const dictionaries = input.dictionaries;
+  if (!dictionaries) {
+    return unknownClassification(input.l1Input, [], ["NO_REVIEWED_CATEGORY_COVERAGE"]);
+  }
+
+  const answerHint = normalizeIdentityText(input.answerCategoryHint) || normalizeIdentityText(input.l1Input.answer);
+  const candidateCategories = buildCategoryCoverage(input.l1Input, dictionaries.categoryMembership);
+  const reasonCodes: FullAnalysisPuzzleTypeClassificationReason[] = [];
+
+  if (candidateCategories.length === 0) {
+    return unknownClassification(input.l1Input, [], ["NO_REVIEWED_CATEGORY_COVERAGE"]);
+  }
+
+  const fullCoverageCategories = candidateCategories.filter((category) => {
+    return category.matchedClueCount === CONTENT_KITCHEN_CLUE_COUNT;
+  });
+
+  if (fullCoverageCategories.length === 0) {
+    reasonCodes.push("PARTIAL_REVIEWED_CATEGORY_COVERAGE");
+    return unknownClassification(input.l1Input, candidateCategories, reasonCodes);
+  }
+
+  const answerMatchedCategories = fullCoverageCategories.flatMap((category) => {
+    const matchReason = categoryMatchesAnswerHint(category, answerHint, dictionaries.aliasDictionary);
+    return matchReason ? [{ category, matchReason }] : [];
+  });
+
+  if (answerMatchedCategories.length === 1) {
+    const selected = answerMatchedCategories[0].category;
+    return {
+      puzzleType: "category_membership",
+      confidence: "high",
+      answerCategory: selected.category,
+      matchedClueCount: selected.matchedClueCount,
+      matchedClueIds: selected.matchedClueIds,
+      unmatchedClueIds: [],
+      candidateCategories,
+      reasonCodes: stableReasonCodes([
+        "ALL_CLUES_MATCH_REVIEWED_CATEGORY",
+        answerMatchedCategories[0].matchReason,
+      ]),
+    };
+  }
+
+  if (fullCoverageCategories.length === 1) {
+    const selected = fullCoverageCategories[0];
+    return {
+      puzzleType: "category_membership",
+      confidence: "medium",
+      answerCategory: selected.category,
+      matchedClueCount: selected.matchedClueCount,
+      matchedClueIds: selected.matchedClueIds,
+      unmatchedClueIds: [],
+      candidateCategories,
+      reasonCodes: ["ALL_CLUES_MATCH_REVIEWED_CATEGORY"],
+    };
+  }
+
+  reasonCodes.push("AMBIGUOUS_REVIEWED_CATEGORY_COVERAGE");
+  return unknownClassification(input.l1Input, candidateCategories, reasonCodes);
+}

--- a/lib/puzzles/content-kitchen/types.ts
+++ b/lib/puzzles/content-kitchen/types.ts
@@ -291,6 +291,32 @@ export type FullAnalysisPuzzleType =
   | "entity_set"
   | "unknown";
 
+export type FullAnalysisPuzzleTypeClassificationReason =
+  | "ANSWER_CATEGORY_HINT_MATCHED"
+  | "ANSWER_ALIAS_MATCHED_CATEGORY"
+  | "ALL_CLUES_MATCH_REVIEWED_CATEGORY"
+  | "PARTIAL_REVIEWED_CATEGORY_COVERAGE"
+  | "AMBIGUOUS_REVIEWED_CATEGORY_COVERAGE"
+  | "NO_REVIEWED_CATEGORY_COVERAGE";
+
+export type FullAnalysisPuzzleTypeCandidateCategory = {
+  category: string;
+  matchedClueCount: number;
+  matchedClueIds: string[];
+  lookupVersion: string;
+};
+
+export type FullAnalysisPuzzleTypeClassification = {
+  puzzleType: FullAnalysisPuzzleType;
+  confidence: EvidenceConfidence;
+  answerCategory?: string;
+  matchedClueCount: number;
+  matchedClueIds: string[];
+  unmatchedClueIds: string[];
+  candidateCategories: FullAnalysisPuzzleTypeCandidateCategory[];
+  reasonCodes: FullAnalysisPuzzleTypeClassificationReason[];
+};
+
 export type FullAnalysisSlotInput = {
   l1Input: L1PuzzleInput;
   answerCategory?: string;

--- a/scripts/check-content-kitchen-contract.ts
+++ b/scripts/check-content-kitchen-contract.ts
@@ -14,6 +14,7 @@ import {
 } from "../lib/puzzles/content-kitchen/dictionary";
 import { validateFullAnalysisSlotPlan } from "../lib/puzzles/content-kitchen/full-analysis-slots";
 import { hashInputSnapshot } from "../lib/puzzles/content-kitchen/identity";
+import { classifyFullAnalysisPuzzleType } from "../lib/puzzles/content-kitchen/puzzle-type-classifier";
 import {
   CONTENT_KITCHEN_ISSUE_REGISTRY,
   getIssueDefinition,
@@ -23,6 +24,7 @@ import {
 import { buildReviewArtifactV0, shouldCreateReviewArtifact } from "../lib/puzzles/content-kitchen/review-artifact";
 import { validateCandidate } from "../lib/puzzles/content-kitchen/validate-candidate";
 import type {
+  ContentKitchenDictionaries,
   ContentKitchenIssueCode,
   FullAnalysisSlotIssueCode,
   FullAnalysisSlotPlanV0,
@@ -196,7 +198,7 @@ async function assertExamplesAreValidJson() {
   }
 }
 
-async function assertDictionariesAreReadable() {
+async function assertDictionariesAreReadable(): Promise<ContentKitchenDictionaries> {
   const dictionaries = await readContentKitchenDictionaries(ROOT);
   const dictionaryDiffs = await readContentKitchenDictionaryDiffs(ROOT);
 
@@ -324,6 +326,8 @@ async function assertDictionariesAreReadable() {
     "pass_full_analysis",
     "validator should derive category-membership evidence from reviewed dictionaries",
   );
+
+  return dictionaries;
 }
 
 function checkHashExcludesVolatileFields() {
@@ -512,6 +516,93 @@ function assertFullAnalysisSlotContract() {
   );
 }
 
+function assertPuzzleTypeClassifier(dictionaries: ContentKitchenDictionaries) {
+  const l1Input = makeSlotContractL1Input();
+  const direct = classifyFullAnalysisPuzzleType({
+    l1Input,
+    dictionaries,
+  });
+
+  assert.equal(direct.puzzleType, "category_membership", "classifier should detect reviewed category membership");
+  assert.equal(direct.confidence, "high", "direct answer/category match should be high confidence");
+  assert.equal(direct.answerCategory, "Types of guitar", "classifier should return the selected category");
+  assert.equal(direct.matchedClueCount, 5, "classifier should match all five clues");
+  assert.deepEqual(direct.unmatchedClueIds, [], "classifier should have no unmatched clues for full coverage");
+  assert.ok(
+    direct.reasonCodes.includes("ANSWER_CATEGORY_HINT_MATCHED"),
+    "classifier should explain direct answer/category match",
+  );
+
+  const alias = classifyFullAnalysisPuzzleType({
+    l1Input: {
+      ...l1Input,
+      answer: "Kinds of guitar",
+    },
+    dictionaries,
+  });
+  assert.equal(alias.puzzleType, "category_membership", "classifier should use reviewed answer aliases");
+  assert.equal(alias.confidence, "high", "reviewed answer alias should be high confidence");
+  assert.ok(
+    alias.reasonCodes.includes("ANSWER_ALIAS_MATCHED_CATEGORY"),
+    "classifier should explain answer alias match",
+  );
+
+  const partial = classifyFullAnalysisPuzzleType({
+    l1Input: {
+      ...l1Input,
+      answer: "Unknown category",
+      clues: [
+        { clueId: "clue-1", text: "Bass", position: 1 },
+        { clueId: "clue-2", text: "Alpha", position: 2 },
+        { clueId: "clue-3", text: "Bravo", position: 3 },
+        { clueId: "clue-4", text: "Charlie", position: 4 },
+        { clueId: "clue-5", text: "Delta", position: 5 },
+      ],
+    },
+    dictionaries,
+  });
+  assert.equal(partial.puzzleType, "unknown", "partial category coverage should stay unknown");
+  assert.equal(partial.confidence, "low", "partial category coverage should stay low confidence");
+  assert.equal(partial.matchedClueCount, 1, "partial category coverage should report best match count");
+  assert.ok(
+    partial.reasonCodes.includes("PARTIAL_REVIEWED_CATEGORY_COVERAGE"),
+    "classifier should explain partial category coverage",
+  );
+
+  const noDictionary = classifyFullAnalysisPuzzleType({ l1Input });
+  assert.equal(noDictionary.puzzleType, "unknown", "classifier should stay unknown without dictionaries");
+  assert.ok(
+    noDictionary.reasonCodes.includes("NO_REVIEWED_CATEGORY_COVERAGE"),
+    "classifier should explain missing reviewed coverage",
+  );
+
+  const ambiguous = classifyFullAnalysisPuzzleType({
+    l1Input: {
+      ...l1Input,
+      answer: "Shared set",
+    },
+    dictionaries: {
+      ...dictionaries,
+      categoryMembership: {
+        ...dictionaries.categoryMembership,
+        entries: [
+          ...dictionaries.categoryMembership.entries,
+          ...dictionaries.categoryMembership.entries.map((entry) => ({
+            ...entry,
+            category: "Instrument labels",
+            normalizedCategory: "instrument labels",
+          })),
+        ],
+      },
+    },
+  });
+  assert.equal(ambiguous.puzzleType, "unknown", "ambiguous full category coverage should stay unknown");
+  assert.ok(
+    ambiguous.reasonCodes.includes("AMBIGUOUS_REVIEWED_CATEGORY_COVERAGE"),
+    "classifier should explain ambiguous reviewed coverage",
+  );
+}
+
 async function main() {
   const fileNames = (await readdir(FIXTURE_DIR)).filter((fileName) => fileName.endsWith(".json")).sort();
   assert.ok(fileNames.length >= 6, "content kitchen should have at least 6 fixtures");
@@ -538,7 +629,8 @@ async function main() {
   assertPr6P0Coverage(fixtures);
   assertPr7Coverage(fixtures);
   await assertExamplesAreValidJson();
-  await assertDictionariesAreReadable();
+  const dictionaries = await assertDictionariesAreReadable();
+  assertPuzzleTypeClassifier(dictionaries);
   console.log(`content-kitchen contract fixtures passed (${fileNames.length} fixtures)`);
 }
 


### PR DESCRIPTION
## Summary
- add a conservative full-analysis puzzle type classifier
- classify reviewed 5/5 category dictionary coverage as category_membership
- keep partial, missing, and ambiguous dictionary coverage as unknown
- cover direct answer/category matches, answer aliases, partial coverage, missing dictionaries, and ambiguous coverage in content-kitchen tests

## Tests
- npm run test:content-kitchen
- npm run typecheck
- npm run lint
- npm run validate:data
- npm run build
- git diff --check