### PR TITLE
Add PR8 clue fit generator

### DIFF
--- a/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
+++ b/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
@@ -1970,6 +1970,15 @@ PR8 second implementation slice:
 - do not infer `phrase_pattern`, `wordplay`, or `entity_set` without dedicated later rules
 - do not change generator, Worker, sitemap, rendering, or publish flow
 
+PR8 third implementation slice:
+
+- add a local clue-fit generator for `category_membership`
+- generate one clue-fit slot per L1 clue only from reviewed dictionary evidence
+- return evidence records next to the generated slots so validation can trace every claim
+- fail when dictionaries are missing, puzzle type is unsupported, answer category is missing, or coverage is not 5/5
+- preserve any safely generated clue-fit rows in failed output for review/debugging
+- do not connect this generator to live publishing or LLM generation yet
+
 ### PR9 — Answer-First Enrichment SLA
 
 Goal: make `answer-first` temporary.

--- a/lib/puzzles/content-kitchen/clue-fit-generator.ts
+++ b/lib/puzzles/content-kitchen/clue-fit-generator.ts
@@ -1,0 +1,166 @@
+import { buildCategoryMembershipEvidenceRecords } from "./dictionary";
+import { normalizeIdentityMatch, normalizeIdentityText } from "./identity";
+import {
+  CONTENT_KITCHEN_CLUE_COUNT,
+  type ContentKitchenDictionaries,
+  type ContentKitchenEvidenceRecord,
+  type FullAnalysisClueFitGenerationIssue,
+  type FullAnalysisClueFitGenerationIssueCode,
+  type FullAnalysisClueFitGenerationResult,
+  type FullAnalysisClueFitSlot,
+  type FullAnalysisPuzzleTypeClassification,
+  type L1PuzzleInput,
+} from "./types";
+
+export type GenerateFullAnalysisClueFitsInput = {
+  l1Input: L1PuzzleInput;
+  classification: FullAnalysisPuzzleTypeClassification;
+  dictionaries?: ContentKitchenDictionaries;
+  evidenceIdPrefix?: string;
+};
+
+function makeIssue(
+  issueCode: FullAnalysisClueFitGenerationIssueCode,
+  fieldPath: string,
+  message: string,
+  suggestedAction: string,
+): FullAnalysisClueFitGenerationIssue {
+  return {
+    issueCode,
+    fieldPath,
+    message,
+    suggestedAction,
+  };
+}
+
+function evidenceByClueId(records: ContentKitchenEvidenceRecord[]): Map<string, ContentKitchenEvidenceRecord> {
+  const byClueId = new Map<string, ContentKitchenEvidenceRecord>();
+
+  for (const record of records) {
+    const clueId = normalizeIdentityMatch(record.clueId);
+    if (clueId) {
+      byClueId.set(clueId, record);
+    }
+  }
+
+  return byClueId;
+}
+
+function buildClueFit(clue: L1PuzzleInput["clues"][number], category: string, evidenceId: string): FullAnalysisClueFitSlot {
+  const clueText = normalizeIdentityText(clue.text);
+
+  return {
+    clueId: clue.clueId,
+    clueText,
+    fit: `${clueText} is a member of ${category}.`,
+    whyItSupportsAnswer: `The reviewed dictionary links ${clueText} to ${category}, so this clue supports the shared answer category.`,
+    evidenceRefs: [evidenceId],
+  };
+}
+
+export function generateFullAnalysisClueFits(
+  input: GenerateFullAnalysisClueFitsInput,
+): FullAnalysisClueFitGenerationResult {
+  const issues: FullAnalysisClueFitGenerationIssue[] = [];
+  const answerCategory = normalizeIdentityText(input.classification.answerCategory);
+
+  if (input.classification.puzzleType !== "category_membership") {
+    return {
+      ok: false,
+      clueFits: [],
+      evidenceRecords: [],
+      issues: [
+        makeIssue(
+          "UNSUPPORTED_PUZZLE_TYPE",
+          "classification.puzzleType",
+          "The local clue-fit generator only supports category_membership in this PR8 slice.",
+          "Keep this candidate out of local clue-fit generation until a later generator supports its puzzle type.",
+        ),
+      ],
+    };
+  }
+
+  if (!answerCategory) {
+    return {
+      ok: false,
+      clueFits: [],
+      evidenceRecords: [],
+      issues: [
+        makeIssue(
+          "MISSING_ANSWER_CATEGORY",
+          "classification.answerCategory",
+          "Category-membership clue-fit generation needs an answer category.",
+          "Run puzzle type classification with reviewed dictionary coverage first.",
+        ),
+      ],
+    };
+  }
+
+  if (!input.dictionaries) {
+    return {
+      ok: false,
+      clueFits: [],
+      evidenceRecords: [],
+      issues: [
+        makeIssue(
+          "MISSING_REVIEWED_DICTIONARIES",
+          "dictionaries",
+          "Local clue-fit generation needs reviewed content-kitchen dictionaries.",
+          "Load reviewed dictionaries before generating clue-fit slots.",
+        ),
+      ],
+    };
+  }
+
+  const evidenceRecords = buildCategoryMembershipEvidenceRecords({
+    l1Input: input.l1Input,
+    category: answerCategory,
+    dictionary: input.dictionaries.categoryMembership,
+    evidenceIdPrefix: input.evidenceIdPrefix ?? "slot",
+  });
+  const evidence = evidenceByClueId(evidenceRecords);
+  const clueFits: FullAnalysisClueFitSlot[] = [];
+
+  for (const clue of input.l1Input.clues) {
+    const record = evidence.get(normalizeIdentityMatch(clue.clueId));
+    if (!record) {
+      issues.push(
+        makeIssue(
+          "MISSING_REVIEWED_CATEGORY_MEMBER",
+          `l1Input.clues[${clue.position - 1}]`,
+          "A clue does not have reviewed category-membership evidence.",
+          "Add the clue/category pair to the reviewed dictionary or send the candidate to review.",
+        ),
+      );
+      continue;
+    }
+
+    clueFits.push(buildClueFit(clue, answerCategory, record.evidenceId));
+  }
+
+  if (clueFits.length !== CONTENT_KITCHEN_CLUE_COUNT || evidenceRecords.length !== CONTENT_KITCHEN_CLUE_COUNT) {
+    issues.push(
+      makeIssue(
+        "INCOMPLETE_CLUE_FIT_COVERAGE",
+        "clueFits",
+        "Local clue-fit generation did not produce exactly five clue-fit slots with evidence.",
+        "Require 5/5 reviewed dictionary coverage before assembling full-analysis content.",
+      ),
+    );
+  }
+
+  if (issues.length > 0) {
+    return {
+      ok: false,
+      clueFits,
+      evidenceRecords,
+      issues,
+    };
+  }
+
+  return {
+    ok: true,
+    clueFits,
+    evidenceRecords,
+  };
+}

--- a/lib/puzzles/content-kitchen/types.ts
+++ b/lib/puzzles/content-kitchen/types.ts
@@ -372,6 +372,33 @@ export type FullAnalysisSlotIssue = {
   suggestedAction: string;
 };
 
+export type FullAnalysisClueFitGenerationIssueCode =
+  | "UNSUPPORTED_PUZZLE_TYPE"
+  | "MISSING_ANSWER_CATEGORY"
+  | "MISSING_REVIEWED_DICTIONARIES"
+  | "MISSING_REVIEWED_CATEGORY_MEMBER"
+  | "INCOMPLETE_CLUE_FIT_COVERAGE";
+
+export type FullAnalysisClueFitGenerationIssue = {
+  issueCode: FullAnalysisClueFitGenerationIssueCode;
+  fieldPath: string;
+  message: string;
+  suggestedAction: string;
+};
+
+export type FullAnalysisClueFitGenerationResult =
+  | {
+      ok: true;
+      clueFits: FullAnalysisClueFitSlot[];
+      evidenceRecords: ContentKitchenEvidenceRecord[];
+    }
+  | {
+      ok: false;
+      clueFits: FullAnalysisClueFitSlot[];
+      evidenceRecords: ContentKitchenEvidenceRecord[];
+      issues: FullAnalysisClueFitGenerationIssue[];
+    };
+
 export type InternalLinkCandidate = {
   href: string;
   label?: string;

--- a/scripts/check-content-kitchen-contract.ts
+++ b/scripts/check-content-kitchen-contract.ts
@@ -12,6 +12,7 @@ import {
   readContentKitchenDictionaries,
   readContentKitchenDictionaryDiffs,
 } from "../lib/puzzles/content-kitchen/dictionary";
+import { generateFullAnalysisClueFits } from "../lib/puzzles/content-kitchen/clue-fit-generator";
 import { validateFullAnalysisSlotPlan } from "../lib/puzzles/content-kitchen/full-analysis-slots";
 import { hashInputSnapshot } from "../lib/puzzles/content-kitchen/identity";
 import { classifyFullAnalysisPuzzleType } from "../lib/puzzles/content-kitchen/puzzle-type-classifier";
@@ -603,6 +604,108 @@ function assertPuzzleTypeClassifier(dictionaries: ContentKitchenDictionaries) {
   );
 }
 
+function assertClueFitGenerator(dictionaries: ContentKitchenDictionaries) {
+  const l1Input = makeSlotContractL1Input();
+  const classification = classifyFullAnalysisPuzzleType({
+    l1Input,
+    dictionaries,
+  });
+  const generated = generateFullAnalysisClueFits({
+    l1Input,
+    classification,
+    dictionaries,
+    evidenceIdPrefix: "slot",
+  });
+
+  assert.equal(generated.ok, true, "clue-fit generator should produce slots for reviewed category membership");
+  if (!generated.ok) {
+    throw new Error("expected clue-fit generation to pass");
+  }
+  assert.equal(generated.clueFits.length, 5, "clue-fit generator should produce five clue-fit slots");
+  assert.equal(generated.evidenceRecords.length, 5, "clue-fit generator should produce five evidence records");
+  assert.deepEqual(
+    generated.clueFits.map((clueFit) => clueFit.clueId),
+    l1Input.clues.map((clue) => clue.clueId),
+    "clue-fit generator should preserve L1 clue order",
+  );
+  assert.ok(
+    generated.clueFits.every((clueFit) => clueFit.evidenceRefs.length === 1 && clueFit.whyItSupportsAnswer.includes("Types of guitar")),
+    "generated clue fits should cite one evidence ref and explain the answer category",
+  );
+
+  const generatedSlotPlan: FullAnalysisSlotPlanV0 = {
+    ...makeValidSlotPlan(),
+    clueFits: generated.clueFits,
+  };
+  assert.deepEqual(
+    validateFullAnalysisSlotPlan({ l1Input, slotPlan: generatedSlotPlan }),
+    [],
+    "generated clue-fit slots should satisfy the full-analysis slot contract",
+  );
+
+  const unsupported = generateFullAnalysisClueFits({
+    l1Input,
+    classification: {
+      ...classification,
+      puzzleType: "unknown",
+      answerCategory: undefined,
+    },
+    dictionaries,
+  });
+  assert.equal(unsupported.ok, false, "unknown puzzle type should not generate clue-fit slots");
+  if (unsupported.ok) {
+    throw new Error("expected unsupported clue-fit generation to fail");
+  }
+  assert.deepEqual(
+    unsupported.issues.map((issue) => issue.issueCode),
+    ["UNSUPPORTED_PUZZLE_TYPE"],
+    "unsupported puzzle type should return a clear issue code",
+  );
+
+  const noDictionaries = generateFullAnalysisClueFits({
+    l1Input,
+    classification,
+  });
+  assert.equal(noDictionaries.ok, false, "missing dictionaries should not generate clue-fit slots");
+  if (noDictionaries.ok) {
+    throw new Error("expected missing-dictionary clue-fit generation to fail");
+  }
+  assert.deepEqual(
+    noDictionaries.issues.map((issue) => issue.issueCode),
+    ["MISSING_REVIEWED_DICTIONARIES"],
+    "missing dictionaries should return a clear issue code",
+  );
+
+  const incompleteL1 = {
+    ...l1Input,
+    clues: [
+      { clueId: "clue-1", text: "Bass", position: 1 },
+      { clueId: "clue-2", text: "Classical", position: 2 },
+      { clueId: "clue-3", text: "Electric", position: 3 },
+      { clueId: "clue-4", text: "Acoustic", position: 4 },
+      { clueId: "clue-5", text: "Not in dictionary", position: 5 },
+    ],
+  };
+  const incomplete = generateFullAnalysisClueFits({
+    l1Input: incompleteL1,
+    classification,
+    dictionaries,
+  });
+  assert.equal(incomplete.ok, false, "incomplete dictionary coverage should not pass clue-fit generation");
+  if (incomplete.ok) {
+    throw new Error("expected incomplete clue-fit generation to fail");
+  }
+  assert.equal(incomplete.clueFits.length, 4, "incomplete generation should keep generated safe clue fits");
+  assert.ok(
+    incomplete.issues.some((issue) => issue.issueCode === "MISSING_REVIEWED_CATEGORY_MEMBER"),
+    "incomplete generation should report the missing dictionary member",
+  );
+  assert.ok(
+    incomplete.issues.some((issue) => issue.issueCode === "INCOMPLETE_CLUE_FIT_COVERAGE"),
+    "incomplete generation should report incomplete 5/5 coverage",
+  );
+}
+
 async function main() {
   const fileNames = (await readdir(FIXTURE_DIR)).filter((fileName) => fileName.endsWith(".json")).sort();
   assert.ok(fileNames.length >= 6, "content kitchen should have at least 6 fixtures");
@@ -631,6 +734,7 @@ async function main() {
   await assertExamplesAreValidJson();
   const dictionaries = await assertDictionariesAreReadable();
   assertPuzzleTypeClassifier(dictionaries);
+  assertClueFitGenerator(dictionaries);
   console.log(`content-kitchen contract fixtures passed (${fileNames.length} fixtures)`);
 }
 


### PR DESCRIPTION
## Summary
- add a local category_membership clue-fit generator
- generate five clue-fit slots only from reviewed dictionary evidence
- return evidence records next to generated slots for traceability
- keep unsupported, missing-dictionary, and incomplete 5/5 coverage paths as explicit failures

## Tests
- npm run test:content-kitchen
- npm run typecheck
- npm run lint
- npm run validate:data
- npm run build
- git diff --check