### PR TITLE
Add PR8 reasoning pattern generator

### DIFF
--- a/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
+++ b/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
@@ -1979,6 +1979,15 @@ PR8 third implementation slice:
 - preserve any safely generated clue-fit rows in failed output for review/debugging
 - do not connect this generator to live publishing or LLM generation yet
 
+PR8 fourth implementation slice:
+
+- add a local reasoning pattern generator for `category_membership`
+- generate `cumulative_confirmation` only after complete 5/5 clue-fit coverage exists
+- carry evidence refs from the clue-fit rows into the reasoning slot
+- fail when puzzle type is unsupported, answer category is missing, clue-fit coverage is incomplete, or evidence refs are missing
+- do not generate turning-point reasoning until a later slice has specific false-start support
+- do not connect this generator to live publishing or LLM generation yet
+
 ### PR9 — Answer-First Enrichment SLA
 
 Goal: make `answer-first` temporary.

--- a/lib/puzzles/content-kitchen/reasoning-generator.ts
+++ b/lib/puzzles/content-kitchen/reasoning-generator.ts
@@ -1,0 +1,138 @@
+import { normalizeIdentityMatch, normalizeIdentityText } from "./identity";
+import {
+  CONTENT_KITCHEN_CLUE_COUNT,
+  type FullAnalysisClueFitSlot,
+  type FullAnalysisPuzzleTypeClassification,
+  type FullAnalysisReasoningGenerationIssue,
+  type FullAnalysisReasoningGenerationIssueCode,
+  type FullAnalysisReasoningGenerationResult,
+  type L1PuzzleInput,
+} from "./types";
+
+export type GenerateFullAnalysisReasoningInput = {
+  l1Input: L1PuzzleInput;
+  classification: FullAnalysisPuzzleTypeClassification;
+  clueFits: FullAnalysisClueFitSlot[];
+};
+
+function makeIssue(
+  issueCode: FullAnalysisReasoningGenerationIssueCode,
+  fieldPath: string,
+  message: string,
+  suggestedAction: string,
+): FullAnalysisReasoningGenerationIssue {
+  return {
+    issueCode,
+    fieldPath,
+    message,
+    suggestedAction,
+  };
+}
+
+function unique(values: string[]): string[] {
+  return [...new Set(values.map(normalizeIdentityText).filter(Boolean))];
+}
+
+function clueFitById(clueFits: FullAnalysisClueFitSlot[]): Map<string, FullAnalysisClueFitSlot> {
+  const byId = new Map<string, FullAnalysisClueFitSlot>();
+  for (const clueFit of clueFits) {
+    const clueId = normalizeIdentityMatch(clueFit.clueId);
+    if (clueId) {
+      byId.set(clueId, clueFit);
+    }
+  }
+  return byId;
+}
+
+function formatClueList(clueTexts: string[]): string {
+  if (clueTexts.length <= 2) {
+    return clueTexts.join(" and ");
+  }
+
+  return `${clueTexts.slice(0, -1).join(", ")}, and ${clueTexts[clueTexts.length - 1]}`;
+}
+
+export function generateFullAnalysisReasoning(
+  input: GenerateFullAnalysisReasoningInput,
+): FullAnalysisReasoningGenerationResult {
+  if (input.classification.puzzleType !== "category_membership") {
+    return {
+      ok: false,
+      issues: [
+        makeIssue(
+          "UNSUPPORTED_REASONING_PUZZLE_TYPE",
+          "classification.puzzleType",
+          "The local reasoning generator only supports category_membership in this PR8 slice.",
+          "Keep this candidate out of local reasoning generation until a later generator supports its puzzle type.",
+        ),
+      ],
+    };
+  }
+
+  const answerCategory = normalizeIdentityText(input.classification.answerCategory);
+  if (!answerCategory) {
+    return {
+      ok: false,
+      issues: [
+        makeIssue(
+          "MISSING_REASONING_ANSWER_CATEGORY",
+          "classification.answerCategory",
+          "Category-membership reasoning needs an answer category.",
+          "Run puzzle type classification before generating reasoning.",
+        ),
+      ],
+    };
+  }
+
+  const issues: FullAnalysisReasoningGenerationIssue[] = [];
+  const fitsById = clueFitById(input.clueFits);
+  const clueIds = input.l1Input.clues.map((clue) => clue.clueId);
+  const orderedFits = input.l1Input.clues.flatMap((clue) => {
+    const fit = fitsById.get(normalizeIdentityMatch(clue.clueId));
+    return fit ? [fit] : [];
+  });
+
+  if (input.clueFits.length !== CONTENT_KITCHEN_CLUE_COUNT || orderedFits.length !== CONTENT_KITCHEN_CLUE_COUNT) {
+    issues.push(
+      makeIssue(
+        "INCOMPLETE_REASONING_CLUE_FIT_COVERAGE",
+        "clueFits",
+        "Reasoning generation needs exactly five clue-fit slots, one per L1 clue.",
+        "Generate complete 5/5 clue-fit coverage before reasoning.",
+      ),
+    );
+  }
+
+  for (let index = 0; index < orderedFits.length; index += 1) {
+    const fit = orderedFits[index];
+    if (!Array.isArray(fit.evidenceRefs) || fit.evidenceRefs.length === 0 || fit.evidenceRefs.some((ref) => !normalizeIdentityText(ref))) {
+      issues.push(
+        makeIssue(
+          "MISSING_REASONING_EVIDENCE_REF",
+          `clueFits[${index}].evidenceRefs`,
+          "Reasoning generation needs evidence refs from every clue-fit slot.",
+          "Attach evidence refs to every clue-fit slot before reasoning.",
+        ),
+      );
+    }
+  }
+
+  if (issues.length > 0) {
+    return {
+      ok: false,
+      issues,
+    };
+  }
+
+  const clueTexts = input.l1Input.clues.map((clue) => normalizeIdentityText(clue.text));
+  const evidenceRefs = unique(orderedFits.flatMap((fit) => fit.evidenceRefs));
+  return {
+    ok: true,
+    reasoning: {
+      pattern: "cumulative_confirmation",
+      clueIds,
+      text: `Reviewed dictionary evidence links ${formatClueList(clueTexts)} to ${answerCategory}; that five-clue pattern confirms ${answerCategory} as the answer.`,
+      evidenceRefs,
+    },
+  };
+}

--- a/lib/puzzles/content-kitchen/types.ts
+++ b/lib/puzzles/content-kitchen/types.ts
@@ -399,6 +399,29 @@ export type FullAnalysisClueFitGenerationResult =
       issues: FullAnalysisClueFitGenerationIssue[];
     };
 
+export type FullAnalysisReasoningGenerationIssueCode =
+  | "UNSUPPORTED_REASONING_PUZZLE_TYPE"
+  | "MISSING_REASONING_ANSWER_CATEGORY"
+  | "INCOMPLETE_REASONING_CLUE_FIT_COVERAGE"
+  | "MISSING_REASONING_EVIDENCE_REF";
+
+export type FullAnalysisReasoningGenerationIssue = {
+  issueCode: FullAnalysisReasoningGenerationIssueCode;
+  fieldPath: string;
+  message: string;
+  suggestedAction: string;
+};
+
+export type FullAnalysisReasoningGenerationResult =
+  | {
+      ok: true;
+      reasoning: FullAnalysisReasoning;
+    }
+  | {
+      ok: false;
+      issues: FullAnalysisReasoningGenerationIssue[];
+    };
+
 export type InternalLinkCandidate = {
   href: string;
   label?: string;

--- a/scripts/check-content-kitchen-contract.ts
+++ b/scripts/check-content-kitchen-contract.ts
@@ -16,6 +16,7 @@ import { generateFullAnalysisClueFits } from "../lib/puzzles/content-kitchen/clu
 import { validateFullAnalysisSlotPlan } from "../lib/puzzles/content-kitchen/full-analysis-slots";
 import { hashInputSnapshot } from "../lib/puzzles/content-kitchen/identity";
 import { classifyFullAnalysisPuzzleType } from "../lib/puzzles/content-kitchen/puzzle-type-classifier";
+import { generateFullAnalysisReasoning } from "../lib/puzzles/content-kitchen/reasoning-generator";
 import {
   CONTENT_KITCHEN_ISSUE_REGISTRY,
   getIssueDefinition,
@@ -706,6 +707,120 @@ function assertClueFitGenerator(dictionaries: ContentKitchenDictionaries) {
   );
 }
 
+function assertReasoningPatternGenerator(dictionaries: ContentKitchenDictionaries) {
+  const l1Input = makeSlotContractL1Input();
+  const classification = classifyFullAnalysisPuzzleType({
+    l1Input,
+    dictionaries,
+  });
+  const generatedFits = generateFullAnalysisClueFits({
+    l1Input,
+    classification,
+    dictionaries,
+    evidenceIdPrefix: "slot",
+  });
+  assert.equal(generatedFits.ok, true, "reasoning generator setup should produce clue fits");
+  if (!generatedFits.ok) {
+    throw new Error("expected clue-fit generation to pass before reasoning generation");
+  }
+
+  const generatedReasoning = generateFullAnalysisReasoning({
+    l1Input,
+    classification,
+    clueFits: generatedFits.clueFits,
+  });
+  assert.equal(generatedReasoning.ok, true, "reasoning generator should produce reasoning for complete clue fits");
+  if (!generatedReasoning.ok) {
+    throw new Error("expected reasoning generation to pass");
+  }
+  assert.equal(
+    generatedReasoning.reasoning.pattern,
+    "cumulative_confirmation",
+    "reasoning generator should use cumulative confirmation for category membership",
+  );
+  assert.deepEqual(
+    generatedReasoning.reasoning.clueIds,
+    l1Input.clues.map((clue) => clue.clueId),
+    "reasoning generator should cite all L1 clue ids in order",
+  );
+  assert.equal(
+    generatedReasoning.reasoning.evidenceRefs?.length,
+    5,
+    "reasoning generator should carry all clue-fit evidence refs",
+  );
+  assert.ok(
+    generatedReasoning.reasoning.text.includes("Types of guitar"),
+    "reasoning text should mention the selected answer category",
+  );
+
+  const generatedSlotPlan: FullAnalysisSlotPlanV0 = {
+    ...makeValidSlotPlan(),
+    clueFits: generatedFits.clueFits,
+    reasoning: generatedReasoning.reasoning,
+  };
+  assert.deepEqual(
+    validateFullAnalysisSlotPlan({ l1Input, slotPlan: generatedSlotPlan }),
+    [],
+    "generated reasoning should satisfy the full-analysis slot contract",
+  );
+
+  const unsupported = generateFullAnalysisReasoning({
+    l1Input,
+    classification: {
+      ...classification,
+      puzzleType: "unknown",
+      answerCategory: undefined,
+    },
+    clueFits: generatedFits.clueFits,
+  });
+  assert.equal(unsupported.ok, false, "unknown puzzle type should not generate reasoning");
+  if (unsupported.ok) {
+    throw new Error("expected unsupported reasoning generation to fail");
+  }
+  assert.deepEqual(
+    unsupported.issues.map((issue) => issue.issueCode),
+    ["UNSUPPORTED_REASONING_PUZZLE_TYPE"],
+    "unsupported reasoning should return a clear issue code",
+  );
+
+  const incomplete = generateFullAnalysisReasoning({
+    l1Input,
+    classification,
+    clueFits: generatedFits.clueFits.slice(0, 4),
+  });
+  assert.equal(incomplete.ok, false, "incomplete clue fits should not generate reasoning");
+  if (incomplete.ok) {
+    throw new Error("expected incomplete reasoning generation to fail");
+  }
+  assert.ok(
+    incomplete.issues.some((issue) => issue.issueCode === "INCOMPLETE_REASONING_CLUE_FIT_COVERAGE"),
+    "incomplete reasoning should report incomplete clue-fit coverage",
+  );
+
+  const missingEvidence = generateFullAnalysisReasoning({
+    l1Input,
+    classification,
+    clueFits: generatedFits.clueFits.map((fit, index) => {
+      if (index === 0) {
+        return {
+          ...fit,
+          evidenceRefs: [],
+        };
+      }
+
+      return fit;
+    }),
+  });
+  assert.equal(missingEvidence.ok, false, "missing evidence refs should not generate reasoning");
+  if (missingEvidence.ok) {
+    throw new Error("expected missing-evidence reasoning generation to fail");
+  }
+  assert.ok(
+    missingEvidence.issues.some((issue) => issue.issueCode === "MISSING_REASONING_EVIDENCE_REF"),
+    "missing-evidence reasoning should report missing evidence refs",
+  );
+}
+
 async function main() {
   const fileNames = (await readdir(FIXTURE_DIR)).filter((fileName) => fileName.endsWith(".json")).sort();
   assert.ok(fileNames.length >= 6, "content kitchen should have at least 6 fixtures");
@@ -735,6 +850,7 @@ async function main() {
   const dictionaries = await assertDictionariesAreReadable();
   assertPuzzleTypeClassifier(dictionaries);
   assertClueFitGenerator(dictionaries);
+  assertReasoningPatternGenerator(dictionaries);
   console.log(`content-kitchen contract fixtures passed (${fileNames.length} fixtures)`);
 }
 


### PR DESCRIPTION
## Summary
- add a local category_membership reasoning generator
- generate cumulative_confirmation reasoning only after complete 5/5 clue-fit coverage
- carry clue-fit evidence refs into the reasoning slot
- keep unsupported, missing-category, incomplete coverage, and missing-evidence paths as explicit failures

## Tests
- npm run test:content-kitchen
- npm run typecheck
- npm run lint
- npm run validate:data
- npm run build
- git diff --check

Note: components/layout/NavBar.tsx has unrelated local unstaged changes and is not included in this PR.