### PR TITLE
Add PR8 false start generator

### DIFF
--- a/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
+++ b/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
@@ -1988,6 +1988,15 @@ PR8 fourth implementation slice:
 - do not generate turning-point reasoning until a later slice has specific false-start support
 - do not connect this generator to live publishing or LLM generation yet
 
+PR8 fifth implementation slice:
+
+- add the false-start generator empty-state path
+- return `falseStart.status = "omitted"` when no supported false-start evidence exists
+- include a reason code so review/debugging can see why no false start was generated
+- do not invent a rejected theory just to fill the article
+- do not generate `falseStart.status = "included"` until a later slice defines supported false-start evidence
+- do not connect this generator to live publishing or LLM generation yet
+
 ### PR9 — Answer-First Enrichment SLA
 
 Goal: make `answer-first` temporary.

--- a/lib/puzzles/content-kitchen/false-start-generator.ts
+++ b/lib/puzzles/content-kitchen/false-start-generator.ts
@@ -1,0 +1,10 @@
+import type { FullAnalysisFalseStartGenerationResult } from "./types";
+
+export function generateFullAnalysisFalseStart(): FullAnalysisFalseStartGenerationResult {
+  return {
+    falseStart: {
+      status: "omitted",
+    },
+    reasonCodes: ["NO_SUPPORTED_FALSE_START_EVIDENCE"],
+  };
+}

--- a/lib/puzzles/content-kitchen/types.ts
+++ b/lib/puzzles/content-kitchen/types.ts
@@ -422,6 +422,14 @@ export type FullAnalysisReasoningGenerationResult =
       issues: FullAnalysisReasoningGenerationIssue[];
     };
 
+export type FullAnalysisFalseStartGenerationReasonCode =
+  | "NO_SUPPORTED_FALSE_START_EVIDENCE";
+
+export type FullAnalysisFalseStartGenerationResult = {
+  falseStart: FullAnalysisFalseStartSlot;
+  reasonCodes: FullAnalysisFalseStartGenerationReasonCode[];
+};
+
 export type InternalLinkCandidate = {
   href: string;
   label?: string;

--- a/scripts/check-content-kitchen-contract.ts
+++ b/scripts/check-content-kitchen-contract.ts
@@ -13,6 +13,7 @@ import {
   readContentKitchenDictionaryDiffs,
 } from "../lib/puzzles/content-kitchen/dictionary";
 import { generateFullAnalysisClueFits } from "../lib/puzzles/content-kitchen/clue-fit-generator";
+import { generateFullAnalysisFalseStart } from "../lib/puzzles/content-kitchen/false-start-generator";
 import { validateFullAnalysisSlotPlan } from "../lib/puzzles/content-kitchen/full-analysis-slots";
 import { hashInputSnapshot } from "../lib/puzzles/content-kitchen/identity";
 import { classifyFullAnalysisPuzzleType } from "../lib/puzzles/content-kitchen/puzzle-type-classifier";
@@ -821,6 +822,32 @@ function assertReasoningPatternGenerator(dictionaries: ContentKitchenDictionarie
   );
 }
 
+function assertFalseStartGenerator() {
+  const l1Input = makeSlotContractL1Input();
+  const generated = generateFullAnalysisFalseStart();
+
+  assert.deepEqual(
+    generated.falseStart,
+    { status: "omitted" },
+    "false-start generator should omit unsupported false starts instead of inventing one",
+  );
+  assert.deepEqual(
+    generated.reasonCodes,
+    ["NO_SUPPORTED_FALSE_START_EVIDENCE"],
+    "false-start generator should explain why the slot was omitted",
+  );
+
+  const generatedSlotPlan: FullAnalysisSlotPlanV0 = {
+    ...makeValidSlotPlan(),
+    falseStart: generated.falseStart,
+  };
+  assert.deepEqual(
+    validateFullAnalysisSlotPlan({ l1Input, slotPlan: generatedSlotPlan }),
+    [],
+    "omitted false-start output should satisfy the full-analysis slot contract",
+  );
+}
+
 async function main() {
   const fileNames = (await readdir(FIXTURE_DIR)).filter((fileName) => fileName.endsWith(".json")).sort();
   assert.ok(fileNames.length >= 6, "content kitchen should have at least 6 fixtures");
@@ -851,6 +878,7 @@ async function main() {
   assertPuzzleTypeClassifier(dictionaries);
   assertClueFitGenerator(dictionaries);
   assertReasoningPatternGenerator(dictionaries);
+  assertFalseStartGenerator();
   console.log(`content-kitchen contract fixtures passed (${fileNames.length} fixtures)`);
 }
 


### PR DESCRIPTION
## Summary
- add the PR8 false-start generator empty-state path
- return falseStart.status=omitted when no supported false-start evidence exists
- include a reason code so omitted false starts are explainable
- cover the generated false-start slot in the content-kitchen contract test

## Tests
- npm run test:content-kitchen
- npm run typecheck
- npm run lint
- npm run validate:data
- npm run build
- git diff --check