### PR TITLE
Add PR8 FAQ generator

### DIFF
--- a/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
+++ b/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
@@ -1997,6 +1997,15 @@ PR8 fifth implementation slice:
 - do not generate `falseStart.status = "included"` until a later slice defines supported false-start evidence
 - do not connect this generator to live publishing or LLM generation yet
 
+PR8 sixth implementation slice:
+
+- add a local FAQ generator for `category_membership`
+- generate two to four FAQ items only after complete 5/5 clue-fit coverage exists
+- carry evidence refs from clue-fit rows into the FAQ items
+- fail when puzzle type is unsupported, answer category is missing, clue-fit coverage is incomplete, or evidence refs are missing
+- keep FAQ output structural only; rendered FAQ/schema checks still belong to validator and later public-page audits
+- do not connect this generator to live publishing or LLM generation yet
+
 ### PR9 — Answer-First Enrichment SLA
 
 Goal: make `answer-first` temporary.

--- a/lib/puzzles/content-kitchen/faq-generator.ts
+++ b/lib/puzzles/content-kitchen/faq-generator.ts
@@ -1,0 +1,157 @@
+import { normalizeIdentityMatch, normalizeIdentityText } from "./identity";
+import {
+  CONTENT_KITCHEN_CLUE_COUNT,
+  type FullAnalysisClueFitSlot,
+  type FullAnalysisFaqGenerationIssue,
+  type FullAnalysisFaqGenerationIssueCode,
+  type FullAnalysisFaqGenerationResult,
+  type FullAnalysisFaqSlot,
+  type FullAnalysisPuzzleTypeClassification,
+  type L1PuzzleInput,
+} from "./types";
+
+export type GenerateFullAnalysisFaqItemsInput = {
+  l1Input: L1PuzzleInput;
+  classification: FullAnalysisPuzzleTypeClassification;
+  clueFits: FullAnalysisClueFitSlot[];
+};
+
+function makeIssue(
+  issueCode: FullAnalysisFaqGenerationIssueCode,
+  fieldPath: string,
+  message: string,
+  suggestedAction: string,
+): FullAnalysisFaqGenerationIssue {
+  return {
+    issueCode,
+    fieldPath,
+    message,
+    suggestedAction,
+  };
+}
+
+function unique(values: string[]): string[] {
+  return [...new Set(values.map(normalizeIdentityText).filter(Boolean))];
+}
+
+function formatClueList(clueTexts: string[]): string {
+  if (clueTexts.length <= 2) {
+    return clueTexts.join(" and ");
+  }
+
+  return `${clueTexts.slice(0, -1).join(", ")}, and ${clueTexts[clueTexts.length - 1]}`;
+}
+
+function clueFitById(clueFits: FullAnalysisClueFitSlot[]): Map<string, FullAnalysisClueFitSlot> {
+  const byId = new Map<string, FullAnalysisClueFitSlot>();
+  for (const clueFit of clueFits) {
+    const clueId = normalizeIdentityMatch(clueFit.clueId);
+    if (clueId) {
+      byId.set(clueId, clueFit);
+    }
+  }
+  return byId;
+}
+
+export function generateFullAnalysisFaqItems(
+  input: GenerateFullAnalysisFaqItemsInput,
+): FullAnalysisFaqGenerationResult {
+  if (input.classification.puzzleType !== "category_membership") {
+    return {
+      ok: false,
+      faqItems: [],
+      issues: [
+        makeIssue(
+          "UNSUPPORTED_FAQ_PUZZLE_TYPE",
+          "classification.puzzleType",
+          "The local FAQ generator only supports category_membership in this PR8 slice.",
+          "Keep this candidate out of local FAQ generation until a later generator supports its puzzle type.",
+        ),
+      ],
+    };
+  }
+
+  const answerCategory = normalizeIdentityText(input.classification.answerCategory);
+  if (!answerCategory) {
+    return {
+      ok: false,
+      faqItems: [],
+      issues: [
+        makeIssue(
+          "MISSING_FAQ_ANSWER_CATEGORY",
+          "classification.answerCategory",
+          "Category-membership FAQ generation needs an answer category.",
+          "Run puzzle type classification before generating FAQ items.",
+        ),
+      ],
+    };
+  }
+
+  const issues: FullAnalysisFaqGenerationIssue[] = [];
+  const fitsById = clueFitById(input.clueFits);
+  const orderedFits = input.l1Input.clues.flatMap((clue) => {
+    const fit = fitsById.get(normalizeIdentityMatch(clue.clueId));
+    return fit ? [fit] : [];
+  });
+
+  if (input.clueFits.length !== CONTENT_KITCHEN_CLUE_COUNT || orderedFits.length !== CONTENT_KITCHEN_CLUE_COUNT) {
+    issues.push(
+      makeIssue(
+        "INCOMPLETE_FAQ_CLUE_FIT_COVERAGE",
+        "clueFits",
+        "FAQ generation needs exactly five clue-fit slots, one per L1 clue.",
+        "Generate complete 5/5 clue-fit coverage before FAQ items.",
+      ),
+    );
+  }
+
+  for (let index = 0; index < orderedFits.length; index += 1) {
+    const fit = orderedFits[index];
+    if (!Array.isArray(fit.evidenceRefs) || fit.evidenceRefs.length === 0 || fit.evidenceRefs.some((ref) => !normalizeIdentityText(ref))) {
+      issues.push(
+        makeIssue(
+          "MISSING_FAQ_EVIDENCE_REF",
+          `clueFits[${index}].evidenceRefs`,
+          "FAQ generation needs evidence refs from every clue-fit slot.",
+          "Attach evidence refs to every clue-fit slot before FAQ generation.",
+        ),
+      );
+    }
+  }
+
+  if (issues.length > 0) {
+    return {
+      ok: false,
+      faqItems: [],
+      issues,
+    };
+  }
+
+  const clueTexts = input.l1Input.clues.map((clue) => normalizeIdentityText(clue.text));
+  const allEvidenceRefs = unique(orderedFits.flatMap((fit) => fit.evidenceRefs));
+  const firstFit = orderedFits[0];
+  const firstClueText = normalizeIdentityText(firstFit.clueText) || clueTexts[0];
+
+  const faqItems: FullAnalysisFaqSlot[] = [
+    {
+      question: "What is the Pinpoint answer?",
+      answer: `The answer is ${answerCategory}.`,
+      evidenceRefs: allEvidenceRefs,
+    },
+    {
+      question: `Why does ${firstClueText} fit ${answerCategory}?`,
+      answer: `Reviewed dictionary evidence links ${firstClueText} to ${answerCategory}.`,
+      evidenceRefs: firstFit.evidenceRefs,
+    },
+    {
+      question: `How do the clues confirm ${answerCategory}?`,
+      answer: `${formatClueList(clueTexts)} all match ${answerCategory}, so the five clues point to the same answer category.`,
+      evidenceRefs: allEvidenceRefs,
+    },
+  ];
+
+  return {
+    ok: true,
+    faqItems,
+  };
+}

--- a/lib/puzzles/content-kitchen/types.ts
+++ b/lib/puzzles/content-kitchen/types.ts
@@ -430,6 +430,30 @@ export type FullAnalysisFalseStartGenerationResult = {
   reasonCodes: FullAnalysisFalseStartGenerationReasonCode[];
 };
 
+export type FullAnalysisFaqGenerationIssueCode =
+  | "UNSUPPORTED_FAQ_PUZZLE_TYPE"
+  | "MISSING_FAQ_ANSWER_CATEGORY"
+  | "INCOMPLETE_FAQ_CLUE_FIT_COVERAGE"
+  | "MISSING_FAQ_EVIDENCE_REF";
+
+export type FullAnalysisFaqGenerationIssue = {
+  issueCode: FullAnalysisFaqGenerationIssueCode;
+  fieldPath: string;
+  message: string;
+  suggestedAction: string;
+};
+
+export type FullAnalysisFaqGenerationResult =
+  | {
+      ok: true;
+      faqItems: FullAnalysisFaqSlot[];
+    }
+  | {
+      ok: false;
+      faqItems: FullAnalysisFaqSlot[];
+      issues: FullAnalysisFaqGenerationIssue[];
+    };
+
 export type InternalLinkCandidate = {
   href: string;
   label?: string;

--- a/scripts/check-content-kitchen-contract.ts
+++ b/scripts/check-content-kitchen-contract.ts
@@ -13,6 +13,7 @@ import {
   readContentKitchenDictionaryDiffs,
 } from "../lib/puzzles/content-kitchen/dictionary";
 import { generateFullAnalysisClueFits } from "../lib/puzzles/content-kitchen/clue-fit-generator";
+import { generateFullAnalysisFaqItems } from "../lib/puzzles/content-kitchen/faq-generator";
 import { generateFullAnalysisFalseStart } from "../lib/puzzles/content-kitchen/false-start-generator";
 import { validateFullAnalysisSlotPlan } from "../lib/puzzles/content-kitchen/full-analysis-slots";
 import { hashInputSnapshot } from "../lib/puzzles/content-kitchen/identity";
@@ -848,6 +849,110 @@ function assertFalseStartGenerator() {
   );
 }
 
+function assertFaqGenerator(dictionaries: ContentKitchenDictionaries) {
+  const l1Input = makeSlotContractL1Input();
+  const classification = classifyFullAnalysisPuzzleType({
+    l1Input,
+    dictionaries,
+  });
+  const generatedFits = generateFullAnalysisClueFits({
+    l1Input,
+    classification,
+    dictionaries,
+    evidenceIdPrefix: "slot",
+  });
+  assert.equal(generatedFits.ok, true, "FAQ generator setup should produce clue fits");
+  if (!generatedFits.ok) {
+    throw new Error("expected clue-fit generation to pass before FAQ generation");
+  }
+
+  const generatedFaq = generateFullAnalysisFaqItems({
+    l1Input,
+    classification,
+    clueFits: generatedFits.clueFits,
+  });
+  assert.equal(generatedFaq.ok, true, "FAQ generator should produce FAQ items for complete clue fits");
+  if (!generatedFaq.ok) {
+    throw new Error("expected FAQ generation to pass");
+  }
+  assert.equal(generatedFaq.faqItems.length, 3, "FAQ generator should produce three stable FAQ items");
+  assert.ok(
+    generatedFaq.faqItems.every((faqItem) => faqItem.question.trim() && faqItem.answer.includes("Types of guitar")),
+    "generated FAQ items should have specific question and answer text",
+  );
+  assert.ok(
+    generatedFaq.faqItems.every((faqItem) => Array.isArray(faqItem.evidenceRefs) && faqItem.evidenceRefs.length > 0),
+    "generated FAQ items should carry evidence refs",
+  );
+
+  const generatedSlotPlan: FullAnalysisSlotPlanV0 = {
+    ...makeValidSlotPlan(),
+    clueFits: generatedFits.clueFits,
+    faqItems: generatedFaq.faqItems,
+  };
+  assert.deepEqual(
+    validateFullAnalysisSlotPlan({ l1Input, slotPlan: generatedSlotPlan }),
+    [],
+    "generated FAQ items should satisfy the full-analysis slot contract",
+  );
+
+  const unsupported = generateFullAnalysisFaqItems({
+    l1Input,
+    classification: {
+      ...classification,
+      puzzleType: "unknown",
+      answerCategory: undefined,
+    },
+    clueFits: generatedFits.clueFits,
+  });
+  assert.equal(unsupported.ok, false, "unknown puzzle type should not generate FAQ items");
+  if (unsupported.ok) {
+    throw new Error("expected unsupported FAQ generation to fail");
+  }
+  assert.deepEqual(
+    unsupported.issues.map((issue) => issue.issueCode),
+    ["UNSUPPORTED_FAQ_PUZZLE_TYPE"],
+    "unsupported FAQ generation should return a clear issue code",
+  );
+
+  const incomplete = generateFullAnalysisFaqItems({
+    l1Input,
+    classification,
+    clueFits: generatedFits.clueFits.slice(0, 4),
+  });
+  assert.equal(incomplete.ok, false, "incomplete clue fits should not generate FAQ items");
+  if (incomplete.ok) {
+    throw new Error("expected incomplete FAQ generation to fail");
+  }
+  assert.ok(
+    incomplete.issues.some((issue) => issue.issueCode === "INCOMPLETE_FAQ_CLUE_FIT_COVERAGE"),
+    "incomplete FAQ generation should report incomplete clue-fit coverage",
+  );
+
+  const missingEvidence = generateFullAnalysisFaqItems({
+    l1Input,
+    classification,
+    clueFits: generatedFits.clueFits.map((fit, index) => {
+      if (index === 0) {
+        return {
+          ...fit,
+          evidenceRefs: [],
+        };
+      }
+
+      return fit;
+    }),
+  });
+  assert.equal(missingEvidence.ok, false, "missing evidence refs should not generate FAQ items");
+  if (missingEvidence.ok) {
+    throw new Error("expected missing-evidence FAQ generation to fail");
+  }
+  assert.ok(
+    missingEvidence.issues.some((issue) => issue.issueCode === "MISSING_FAQ_EVIDENCE_REF"),
+    "missing-evidence FAQ generation should report missing evidence refs",
+  );
+}
+
 async function main() {
   const fileNames = (await readdir(FIXTURE_DIR)).filter((fileName) => fileName.endsWith(".json")).sort();
   assert.ok(fileNames.length >= 6, "content kitchen should have at least 6 fixtures");
@@ -879,6 +984,7 @@ async function main() {
   assertClueFitGenerator(dictionaries);
   assertReasoningPatternGenerator(dictionaries);
   assertFalseStartGenerator();
+  assertFaqGenerator(dictionaries);
   console.log(`content-kitchen contract fixtures passed (${fileNames.length} fixtures)`);
 }
 


### PR DESCRIPTION
## Summary
- add a local category_membership FAQ generator
- generate three FAQ items only after complete 5/5 clue-fit coverage
- carry clue-fit evidence refs into FAQ items
- keep unsupported, missing-category, incomplete coverage, and missing-evidence paths as explicit failures

## Tests
- npm run test:content-kitchen
- npm run typecheck
- npm run lint
- npm run validate:data
- npm run build
- git diff --check