### PR TITLE
Add PR8 deterministic assembler

### DIFF
--- a/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
+++ b/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
@@ -2006,6 +2006,15 @@ PR8 sixth implementation slice:
 - keep FAQ output structural only; rendered FAQ/schema checks still belong to validator and later public-page audits
 - do not connect this generator to live publishing or LLM generation yet
 
+PR8 seventh implementation slice:
+
+- add a deterministic assembler for `full-analysis-slot-plan-v0`
+- combine puzzle classification, clue-fit rows, reasoning, false-start, and FAQ slots without changing their content
+- immediately run the full-analysis slot contract validator on the assembled plan
+- fail when answer category is missing or assembled slots do not pass the slot contract
+- return slot-level validation issues with assembly failures for debugging/repair
+- do not connect this assembler to live publishing or LLM generation yet
+
 ### PR9 — Answer-First Enrichment SLA
 
 Goal: make `answer-first` temporary.

--- a/lib/puzzles/content-kitchen/full-analysis-assembler.ts
+++ b/lib/puzzles/content-kitchen/full-analysis-assembler.ts
@@ -1,0 +1,94 @@
+import { validateFullAnalysisSlotPlan } from "./full-analysis-slots";
+import { normalizeIdentityText } from "./identity";
+import type {
+  FullAnalysisAssemblyIssue,
+  FullAnalysisAssemblyIssueCode,
+  FullAnalysisAssemblyResult,
+  FullAnalysisClueFitSlot,
+  FullAnalysisFalseStartSlot,
+  FullAnalysisFaqSlot,
+  FullAnalysisPuzzleTypeClassification,
+  FullAnalysisReasoning,
+  FullAnalysisSlotPlanV0,
+  L1PuzzleInput,
+} from "./types";
+
+export type AssembleFullAnalysisSlotPlanInput = {
+  l1Input: L1PuzzleInput;
+  classification: FullAnalysisPuzzleTypeClassification;
+  clueFits: FullAnalysisClueFitSlot[];
+  reasoning: FullAnalysisReasoning;
+  falseStart: FullAnalysisFalseStartSlot;
+  faqItems: FullAnalysisFaqSlot[];
+};
+
+function makeIssue(
+  issueCode: FullAnalysisAssemblyIssueCode,
+  fieldPath: string,
+  message: string,
+  suggestedAction: string,
+): FullAnalysisAssemblyIssue {
+  return {
+    issueCode,
+    fieldPath,
+    message,
+    suggestedAction,
+  };
+}
+
+export function assembleFullAnalysisSlotPlan(
+  input: AssembleFullAnalysisSlotPlanInput,
+): FullAnalysisAssemblyResult {
+  const answerCategory = normalizeIdentityText(input.classification.answerCategory);
+  const slotPlan: FullAnalysisSlotPlanV0 = {
+    slotVersion: "full-analysis-slot-plan-v0",
+    puzzleType: input.classification.puzzleType,
+    ...(answerCategory ? { answerCategory } : {}),
+    clueFits: input.clueFits,
+    reasoning: input.reasoning,
+    falseStart: input.falseStart,
+    faqItems: input.faqItems,
+  };
+  const issues: FullAnalysisAssemblyIssue[] = [];
+
+  if (!answerCategory) {
+    issues.push(
+      makeIssue(
+        "MISSING_ASSEMBLY_ANSWER_CATEGORY",
+        "classification.answerCategory",
+        "Full-analysis assembly needs an answer category.",
+        "Run puzzle type classification before assembling the slot plan.",
+      ),
+    );
+  }
+
+  const slotIssues = validateFullAnalysisSlotPlan({
+    l1Input: input.l1Input,
+    slotPlan,
+  });
+
+  if (slotIssues.length > 0) {
+    issues.push(
+      makeIssue(
+        "INVALID_ASSEMBLED_SLOT_PLAN",
+        "slotPlan",
+        "Assembled full-analysis slot plan did not pass the slot contract.",
+        "Fix the upstream slots before assembling.",
+      ),
+    );
+  }
+
+  if (issues.length > 0) {
+    return {
+      ok: false,
+      slotPlan,
+      issues,
+      slotIssues,
+    };
+  }
+
+  return {
+    ok: true,
+    slotPlan,
+  };
+}

--- a/lib/puzzles/content-kitchen/types.ts
+++ b/lib/puzzles/content-kitchen/types.ts
@@ -454,6 +454,29 @@ export type FullAnalysisFaqGenerationResult =
       issues: FullAnalysisFaqGenerationIssue[];
     };
 
+export type FullAnalysisAssemblyIssueCode =
+  | "MISSING_ASSEMBLY_ANSWER_CATEGORY"
+  | "INVALID_ASSEMBLED_SLOT_PLAN";
+
+export type FullAnalysisAssemblyIssue = {
+  issueCode: FullAnalysisAssemblyIssueCode;
+  fieldPath: string;
+  message: string;
+  suggestedAction: string;
+};
+
+export type FullAnalysisAssemblyResult =
+  | {
+      ok: true;
+      slotPlan: FullAnalysisSlotPlanV0;
+    }
+  | {
+      ok: false;
+      slotPlan: Partial<FullAnalysisSlotPlanV0>;
+      issues: FullAnalysisAssemblyIssue[];
+      slotIssues: FullAnalysisSlotIssue[];
+    };
+
 export type InternalLinkCandidate = {
   href: string;
   label?: string;

--- a/scripts/check-content-kitchen-contract.ts
+++ b/scripts/check-content-kitchen-contract.ts
@@ -15,6 +15,7 @@ import {
 import { generateFullAnalysisClueFits } from "../lib/puzzles/content-kitchen/clue-fit-generator";
 import { generateFullAnalysisFaqItems } from "../lib/puzzles/content-kitchen/faq-generator";
 import { generateFullAnalysisFalseStart } from "../lib/puzzles/content-kitchen/false-start-generator";
+import { assembleFullAnalysisSlotPlan } from "../lib/puzzles/content-kitchen/full-analysis-assembler";
 import { validateFullAnalysisSlotPlan } from "../lib/puzzles/content-kitchen/full-analysis-slots";
 import { hashInputSnapshot } from "../lib/puzzles/content-kitchen/identity";
 import { classifyFullAnalysisPuzzleType } from "../lib/puzzles/content-kitchen/puzzle-type-classifier";
@@ -953,6 +954,109 @@ function assertFaqGenerator(dictionaries: ContentKitchenDictionaries) {
   );
 }
 
+function assertDeterministicAssembler(dictionaries: ContentKitchenDictionaries) {
+  const l1Input = makeSlotContractL1Input();
+  const classification = classifyFullAnalysisPuzzleType({
+    l1Input,
+    dictionaries,
+  });
+  const generatedFits = generateFullAnalysisClueFits({
+    l1Input,
+    classification,
+    dictionaries,
+    evidenceIdPrefix: "slot",
+  });
+  assert.equal(generatedFits.ok, true, "assembler setup should produce clue fits");
+  if (!generatedFits.ok) {
+    throw new Error("expected clue-fit generation to pass before assembly");
+  }
+
+  const generatedReasoning = generateFullAnalysisReasoning({
+    l1Input,
+    classification,
+    clueFits: generatedFits.clueFits,
+  });
+  assert.equal(generatedReasoning.ok, true, "assembler setup should produce reasoning");
+  if (!generatedReasoning.ok) {
+    throw new Error("expected reasoning generation to pass before assembly");
+  }
+
+  const generatedFalseStart = generateFullAnalysisFalseStart();
+  const generatedFaq = generateFullAnalysisFaqItems({
+    l1Input,
+    classification,
+    clueFits: generatedFits.clueFits,
+  });
+  assert.equal(generatedFaq.ok, true, "assembler setup should produce FAQ items");
+  if (!generatedFaq.ok) {
+    throw new Error("expected FAQ generation to pass before assembly");
+  }
+
+  const assembled = assembleFullAnalysisSlotPlan({
+    l1Input,
+    classification,
+    clueFits: generatedFits.clueFits,
+    reasoning: generatedReasoning.reasoning,
+    falseStart: generatedFalseStart.falseStart,
+    faqItems: generatedFaq.faqItems,
+  });
+  assert.equal(assembled.ok, true, "assembler should produce a valid full-analysis slot plan");
+  if (!assembled.ok) {
+    throw new Error("expected assembly to pass");
+  }
+  assert.equal(assembled.slotPlan.slotVersion, "full-analysis-slot-plan-v0", "assembler should set slot plan version");
+  assert.equal(assembled.slotPlan.puzzleType, "category_membership", "assembler should preserve puzzle type");
+  assert.equal(assembled.slotPlan.answerCategory, "Types of guitar", "assembler should preserve answer category");
+  assert.equal(assembled.slotPlan.clueFits.length, 5, "assembler should preserve five clue fits");
+  assert.equal(assembled.slotPlan.faqItems.length, 3, "assembler should preserve generated FAQ items");
+  assert.deepEqual(
+    validateFullAnalysisSlotPlan({ l1Input, slotPlan: assembled.slotPlan }),
+    [],
+    "assembled slot plan should satisfy the full-analysis slot contract",
+  );
+
+  const missingCategory = assembleFullAnalysisSlotPlan({
+    l1Input,
+    classification: {
+      ...classification,
+      answerCategory: undefined,
+    },
+    clueFits: generatedFits.clueFits,
+    reasoning: generatedReasoning.reasoning,
+    falseStart: generatedFalseStart.falseStart,
+    faqItems: generatedFaq.faqItems,
+  });
+  assert.equal(missingCategory.ok, false, "assembler should fail without answer category");
+  if (missingCategory.ok) {
+    throw new Error("expected missing-category assembly to fail");
+  }
+  assert.ok(
+    missingCategory.issues.some((issue) => issue.issueCode === "MISSING_ASSEMBLY_ANSWER_CATEGORY"),
+    "missing-category assembly should return a clear issue code",
+  );
+
+  const invalidPlan = assembleFullAnalysisSlotPlan({
+    l1Input,
+    classification,
+    clueFits: generatedFits.clueFits.slice(0, 4),
+    reasoning: generatedReasoning.reasoning,
+    falseStart: generatedFalseStart.falseStart,
+    faqItems: generatedFaq.faqItems,
+  });
+  assert.equal(invalidPlan.ok, false, "assembler should fail when upstream slots break the slot contract");
+  if (invalidPlan.ok) {
+    throw new Error("expected invalid assembly to fail");
+  }
+  assert.ok(
+    invalidPlan.issues.some((issue) => issue.issueCode === "INVALID_ASSEMBLED_SLOT_PLAN"),
+    "invalid assembly should return a clear assembly issue code",
+  );
+  assert.ok(
+    invalidPlan.slotIssues.some((issue) => issue.issueCode === "MISSING_SLOT_CLUE_FIT"),
+    "invalid assembly should return slot contract issues for debugging",
+  );
+}
+
 async function main() {
   const fileNames = (await readdir(FIXTURE_DIR)).filter((fileName) => fileName.endsWith(".json")).sort();
   assert.ok(fileNames.length >= 6, "content kitchen should have at least 6 fixtures");
@@ -985,6 +1089,7 @@ async function main() {
   assertReasoningPatternGenerator(dictionaries);
   assertFalseStartGenerator();
   assertFaqGenerator(dictionaries);
+  assertDeterministicAssembler(dictionaries);
   console.log(`content-kitchen contract fixtures passed (${fileNames.length} fixtures)`);
 }
 


### PR DESCRIPTION
## Summary
- add a deterministic assembler for full-analysis-slot-plan-v0
- combine classification, clue-fit rows, reasoning, false-start, and FAQ slots without changing their content
- run the full-analysis slot validator immediately after assembly
- return assembly issues and slot-level issues for debugging/repair

## Tests
- npm run test:content-kitchen
- npm run typecheck
- npm run lint
- npm run validate:data
- npm run build
- git diff --check