### PR TITLE
Add PR8 local repair loop

### DIFF
--- a/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
+++ b/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
@@ -2015,6 +2015,15 @@ PR8 seventh implementation slice:
 - return slot-level validation issues with assembly failures for debugging/repair
 - do not connect this assembler to live publishing or LLM generation yet
 
+PR8 eighth implementation slice:
+
+- add a local repair loop planner for full-analysis generation failures
+- collect generator, assembly, and slot-contract issues into deduped repair actions
+- keep answer and L1 clue data immutable; repair actions only target classification, dictionaries, clue-fit slots, reasoning, FAQ, false-start, or assembly
+- mark missing reviewed dictionary facts as not auto-repairable
+- keep local structural issues auto-repairable by rerunning the relevant local generator and assembler
+- do not connect this repair planner to live publishing or LLM generation yet
+
 ### PR9 — Answer-First Enrichment SLA
 
 Goal: make `answer-first` temporary.

--- a/lib/puzzles/content-kitchen/local-repair-loop.ts
+++ b/lib/puzzles/content-kitchen/local-repair-loop.ts
@@ -1,0 +1,236 @@
+import { normalizeIdentityText } from "./identity";
+import type {
+  FullAnalysisRepairAction,
+  FullAnalysisRepairActionCode,
+  FullAnalysisRepairPlan,
+} from "./types";
+
+export type RepairableIssue = {
+  issueCode: string;
+  fieldPath?: string;
+  suggestedAction?: string;
+};
+
+export type BuildFullAnalysisRepairPlanInput = {
+  issues: RepairableIssue[];
+};
+
+type ActionTemplate = {
+  actionCode: FullAnalysisRepairActionCode;
+  target: string;
+  reason: string;
+  canAutoRepair: boolean;
+};
+
+const ISSUE_REPAIR_ACTIONS: Record<string, ActionTemplate> = {
+  MISSING_ANSWER_CATEGORY: {
+    actionCode: "rerun_puzzle_type_classifier",
+    target: "classification.answerCategory",
+    reason: "Answer category is missing before clue-fit generation.",
+    canAutoRepair: true,
+  },
+  MISSING_ASSEMBLY_ANSWER_CATEGORY: {
+    actionCode: "rerun_puzzle_type_classifier",
+    target: "classification.answerCategory",
+    reason: "Answer category is missing before assembly.",
+    canAutoRepair: true,
+  },
+  MISSING_FAQ_ANSWER_CATEGORY: {
+    actionCode: "rerun_puzzle_type_classifier",
+    target: "classification.answerCategory",
+    reason: "Answer category is missing before FAQ generation.",
+    canAutoRepair: true,
+  },
+  MISSING_REASONING_ANSWER_CATEGORY: {
+    actionCode: "rerun_puzzle_type_classifier",
+    target: "classification.answerCategory",
+    reason: "Answer category is missing before reasoning generation.",
+    canAutoRepair: true,
+  },
+  UNSUPPORTED_PUZZLE_TYPE: {
+    actionCode: "rerun_puzzle_type_classifier",
+    target: "classification.puzzleType",
+    reason: "The local clue-fit generator does not support this puzzle type.",
+    canAutoRepair: false,
+  },
+  UNSUPPORTED_REASONING_PUZZLE_TYPE: {
+    actionCode: "rerun_puzzle_type_classifier",
+    target: "classification.puzzleType",
+    reason: "The local reasoning generator does not support this puzzle type.",
+    canAutoRepair: false,
+  },
+  UNSUPPORTED_FAQ_PUZZLE_TYPE: {
+    actionCode: "rerun_puzzle_type_classifier",
+    target: "classification.puzzleType",
+    reason: "The local FAQ generator does not support this puzzle type.",
+    canAutoRepair: false,
+  },
+  MISSING_REVIEWED_DICTIONARIES: {
+    actionCode: "load_reviewed_dictionaries",
+    target: "dictionaries",
+    reason: "Reviewed dictionaries are required for local generation.",
+    canAutoRepair: true,
+  },
+  MISSING_REVIEWED_CATEGORY_MEMBER: {
+    actionCode: "repair_dictionary_coverage",
+    target: "dictionaries.categoryMembership",
+    reason: "A clue/category pair is missing from reviewed dictionary coverage.",
+    canAutoRepair: false,
+  },
+  INCOMPLETE_CLUE_FIT_COVERAGE: {
+    actionCode: "regenerate_clue_fits",
+    target: "clueFits",
+    reason: "Clue-fit generation did not produce complete 5/5 coverage.",
+    canAutoRepair: true,
+  },
+  MISSING_SLOT_CLUE_FIT: {
+    actionCode: "regenerate_clue_fits",
+    target: "clueFits",
+    reason: "The slot contract is missing one or more clue-fit rows.",
+    canAutoRepair: true,
+  },
+  DUPLICATE_SLOT_CLUE_FIT: {
+    actionCode: "regenerate_clue_fits",
+    target: "clueFits",
+    reason: "The slot contract found duplicate clue-fit rows.",
+    canAutoRepair: true,
+  },
+  UNKNOWN_SLOT_CLUE: {
+    actionCode: "regenerate_clue_fits",
+    target: "clueFits",
+    reason: "A clue-fit row points to an unknown L1 clue.",
+    canAutoRepair: true,
+  },
+  MISSING_SLOT_EVIDENCE_REF: {
+    actionCode: "regenerate_clue_fits",
+    target: "clueFits",
+    reason: "One or more clue-fit rows are missing evidence refs.",
+    canAutoRepair: true,
+  },
+  INVALID_SLOT_PLAN_VERSION: {
+    actionCode: "rerun_assembler",
+    target: "slotPlan",
+    reason: "The slot plan version is invalid.",
+    canAutoRepair: true,
+  },
+  MISSING_SLOT_PUZZLE_TYPE: {
+    actionCode: "rerun_puzzle_type_classifier",
+    target: "classification.puzzleType",
+    reason: "The slot plan is missing puzzle type classification.",
+    canAutoRepair: true,
+  },
+  INCOMPLETE_REASONING_CLUE_FIT_COVERAGE: {
+    actionCode: "regenerate_clue_fits",
+    target: "clueFits",
+    reason: "Reasoning needs complete clue-fit coverage first.",
+    canAutoRepair: true,
+  },
+  MISSING_REASONING_EVIDENCE_REF: {
+    actionCode: "regenerate_clue_fits",
+    target: "clueFits",
+    reason: "Reasoning needs clue-fit evidence refs first.",
+    canAutoRepair: true,
+  },
+  MISSING_REASONING_PATTERN: {
+    actionCode: "regenerate_reasoning",
+    target: "reasoning",
+    reason: "The slot contract is missing reasoning.",
+    canAutoRepair: true,
+  },
+  UNSUPPORTED_REASONING_PATTERN: {
+    actionCode: "regenerate_reasoning",
+    target: "reasoning",
+    reason: "The slot contract found unsupported reasoning.",
+    canAutoRepair: true,
+  },
+  INCOMPLETE_FAQ_CLUE_FIT_COVERAGE: {
+    actionCode: "regenerate_clue_fits",
+    target: "clueFits",
+    reason: "FAQ generation needs complete clue-fit coverage first.",
+    canAutoRepair: true,
+  },
+  MISSING_FAQ_EVIDENCE_REF: {
+    actionCode: "regenerate_clue_fits",
+    target: "clueFits",
+    reason: "FAQ generation needs clue-fit evidence refs first.",
+    canAutoRepair: true,
+  },
+  MISSING_SLOT_FAQ: {
+    actionCode: "regenerate_faq",
+    target: "faqItems",
+    reason: "The slot contract is missing valid FAQ items.",
+    canAutoRepair: true,
+  },
+  INVALID_FALSE_START_SLOT: {
+    actionCode: "keep_false_start_omitted",
+    target: "falseStart",
+    reason: "Unsupported false starts should stay omitted.",
+    canAutoRepair: true,
+  },
+  INVALID_ASSEMBLED_SLOT_PLAN: {
+    actionCode: "rerun_assembler",
+    target: "slotPlan",
+    reason: "The assembled slot plan must be rebuilt after upstream fixes.",
+    canAutoRepair: true,
+  },
+};
+
+function fallbackAction(issue: RepairableIssue): FullAnalysisRepairAction {
+  const issueCode = normalizeIdentityText(issue.issueCode) || "UNKNOWN";
+  return {
+    actionCode: "rerun_assembler",
+    target: "slotPlan",
+    reason: normalizeIdentityText(issue.suggestedAction) || "Rerun assembly after fixing this issue.",
+    issueCodes: [issueCode],
+  };
+}
+
+function actionKey(action: FullAnalysisRepairAction): string {
+  return `${action.actionCode}:${action.target}`;
+}
+
+export function buildFullAnalysisRepairPlan(input: BuildFullAnalysisRepairPlanInput): FullAnalysisRepairPlan {
+  const actionsByKey = new Map<string, FullAnalysisRepairAction>();
+  let canAutoRepair = true;
+
+  for (const issue of input.issues) {
+    const issueCode = normalizeIdentityText(issue.issueCode);
+    if (!issueCode) {
+      continue;
+    }
+
+    const template = ISSUE_REPAIR_ACTIONS[issueCode];
+    const action = template
+      ? {
+          actionCode: template.actionCode,
+          target: template.target,
+          reason: template.reason,
+          issueCodes: [issueCode],
+        }
+      : fallbackAction(issue);
+
+    if (template && !template.canAutoRepair) {
+      canAutoRepair = false;
+    }
+
+    if (!template) {
+      canAutoRepair = false;
+    }
+
+    const key = actionKey(action);
+    const existing = actionsByKey.get(key);
+    if (existing) {
+      actionsByKey.set(key, {
+        ...existing,
+        issueCodes: [...new Set([...existing.issueCodes, ...action.issueCodes])],
+      });
+    } else {
+      actionsByKey.set(key, action);
+    }
+  }
+
+  return {
+    canAutoRepair,
+    actions: [...actionsByKey.values()],
+  };
+}

--- a/lib/puzzles/content-kitchen/types.ts
+++ b/lib/puzzles/content-kitchen/types.ts
@@ -477,6 +477,28 @@ export type FullAnalysisAssemblyResult =
       slotIssues: FullAnalysisSlotIssue[];
     };
 
+export type FullAnalysisRepairActionCode =
+  | "rerun_puzzle_type_classifier"
+  | "load_reviewed_dictionaries"
+  | "repair_dictionary_coverage"
+  | "regenerate_clue_fits"
+  | "regenerate_reasoning"
+  | "regenerate_faq"
+  | "keep_false_start_omitted"
+  | "rerun_assembler";
+
+export type FullAnalysisRepairAction = {
+  actionCode: FullAnalysisRepairActionCode;
+  target: string;
+  reason: string;
+  issueCodes: string[];
+};
+
+export type FullAnalysisRepairPlan = {
+  canAutoRepair: boolean;
+  actions: FullAnalysisRepairAction[];
+};
+
 export type InternalLinkCandidate = {
   href: string;
   label?: string;

--- a/scripts/check-content-kitchen-contract.ts
+++ b/scripts/check-content-kitchen-contract.ts
@@ -18,6 +18,7 @@ import { generateFullAnalysisFalseStart } from "../lib/puzzles/content-kitchen/f
 import { assembleFullAnalysisSlotPlan } from "../lib/puzzles/content-kitchen/full-analysis-assembler";
 import { validateFullAnalysisSlotPlan } from "../lib/puzzles/content-kitchen/full-analysis-slots";
 import { hashInputSnapshot } from "../lib/puzzles/content-kitchen/identity";
+import { buildFullAnalysisRepairPlan } from "../lib/puzzles/content-kitchen/local-repair-loop";
 import { classifyFullAnalysisPuzzleType } from "../lib/puzzles/content-kitchen/puzzle-type-classifier";
 import { generateFullAnalysisReasoning } from "../lib/puzzles/content-kitchen/reasoning-generator";
 import {
@@ -1057,6 +1058,150 @@ function assertDeterministicAssembler(dictionaries: ContentKitchenDictionaries) 
   );
 }
 
+function assertLocalRepairLoop(dictionaries: ContentKitchenDictionaries) {
+  const l1Input = makeSlotContractL1Input();
+  const classification = classifyFullAnalysisPuzzleType({
+    l1Input,
+    dictionaries,
+  });
+  const generatedFits = generateFullAnalysisClueFits({
+    l1Input,
+    classification,
+    dictionaries,
+    evidenceIdPrefix: "slot",
+  });
+  assert.equal(generatedFits.ok, true, "repair loop setup should produce clue fits");
+  if (!generatedFits.ok) {
+    throw new Error("expected clue-fit generation to pass before repair loop checks");
+  }
+
+  const generatedReasoning = generateFullAnalysisReasoning({
+    l1Input,
+    classification,
+    clueFits: generatedFits.clueFits,
+  });
+  assert.equal(generatedReasoning.ok, true, "repair loop setup should produce reasoning");
+  if (!generatedReasoning.ok) {
+    throw new Error("expected reasoning generation to pass before repair loop checks");
+  }
+
+  const generatedFalseStart = generateFullAnalysisFalseStart();
+  const generatedFaq = generateFullAnalysisFaqItems({
+    l1Input,
+    classification,
+    clueFits: generatedFits.clueFits,
+  });
+  assert.equal(generatedFaq.ok, true, "repair loop setup should produce FAQ items");
+  if (!generatedFaq.ok) {
+    throw new Error("expected FAQ generation to pass before repair loop checks");
+  }
+
+  const invalidPlan = assembleFullAnalysisSlotPlan({
+    l1Input,
+    classification,
+    clueFits: generatedFits.clueFits.slice(0, 4),
+    reasoning: generatedReasoning.reasoning,
+    falseStart: generatedFalseStart.falseStart,
+    faqItems: generatedFaq.faqItems,
+  });
+  assert.equal(invalidPlan.ok, false, "repair loop fixture should start from failed assembly");
+  if (invalidPlan.ok) {
+    throw new Error("expected invalid assembly to fail before repair loop checks");
+  }
+
+  const plan = buildFullAnalysisRepairPlan({
+    issues: [...invalidPlan.issues, ...invalidPlan.slotIssues],
+  });
+  assert.equal(plan.canAutoRepair, true, "repair loop should auto-repair local slot omissions");
+  assert.ok(
+    plan.actions.some((action) => {
+      return action.actionCode === "regenerate_clue_fits" && action.issueCodes.includes("MISSING_SLOT_CLUE_FIT");
+    }),
+    "repair loop should ask for clue-fit regeneration when clue rows are missing",
+  );
+  assert.ok(
+    plan.actions.some((action) => {
+      return action.actionCode === "rerun_assembler" && action.issueCodes.includes("INVALID_ASSEMBLED_SLOT_PLAN");
+    }),
+    "repair loop should ask for assembler rerun after upstream fixes",
+  );
+
+  const dictionaryCoveragePlan = buildFullAnalysisRepairPlan({
+    issues: [
+      {
+        issueCode: "MISSING_REVIEWED_CATEGORY_MEMBER",
+        fieldPath: "l1Input.clues[4]",
+        suggestedAction: "Add reviewed dictionary coverage.",
+      },
+      {
+        issueCode: "INCOMPLETE_CLUE_FIT_COVERAGE",
+        fieldPath: "clueFits",
+        suggestedAction: "Regenerate clue fits after coverage is complete.",
+      },
+    ],
+  });
+  assert.equal(
+    dictionaryCoveragePlan.canAutoRepair,
+    false,
+    "repair loop should not auto-repair missing reviewed dictionary facts",
+  );
+  assert.ok(
+    dictionaryCoveragePlan.actions.some((action) => action.actionCode === "repair_dictionary_coverage"),
+    "repair loop should route missing dictionary facts to dictionary repair",
+  );
+  assert.ok(
+    dictionaryCoveragePlan.actions.some((action) => action.actionCode === "regenerate_clue_fits"),
+    "repair loop should still request clue-fit regeneration after dictionary repair",
+  );
+
+  const deduped = buildFullAnalysisRepairPlan({
+    issues: [
+      { issueCode: "MISSING_SLOT_CLUE_FIT", fieldPath: "slotPlan.clueFits" },
+      { issueCode: "MISSING_SLOT_EVIDENCE_REF", fieldPath: "slotPlan.clueFits[0].evidenceRefs" },
+      { issueCode: "INCOMPLETE_REASONING_CLUE_FIT_COVERAGE", fieldPath: "clueFits" },
+    ],
+  });
+  assert.equal(
+    deduped.actions.filter((action) => action.actionCode === "regenerate_clue_fits").length,
+    1,
+    "repair loop should dedupe repeated clue-fit repair actions",
+  );
+  assert.deepEqual(
+    deduped.actions.find((action) => action.actionCode === "regenerate_clue_fits")?.issueCodes.sort(),
+    ["INCOMPLETE_REASONING_CLUE_FIT_COVERAGE", "MISSING_SLOT_CLUE_FIT", "MISSING_SLOT_EVIDENCE_REF"].sort(),
+    "deduped repair action should keep all source issue codes",
+  );
+
+  const unsupportedTypePlan = buildFullAnalysisRepairPlan({
+    issues: [
+      { issueCode: "UNSUPPORTED_PUZZLE_TYPE", fieldPath: "classification.puzzleType" },
+      { issueCode: "UNSUPPORTED_FAQ_PUZZLE_TYPE", fieldPath: "classification.puzzleType" },
+    ],
+  });
+  assert.equal(
+    unsupportedTypePlan.canAutoRepair,
+    false,
+    "repair loop should not auto-repair unsupported puzzle types",
+  );
+  assert.deepEqual(
+    unsupportedTypePlan.actions.find((action) => action.actionCode === "rerun_puzzle_type_classifier")?.issueCodes.sort(),
+    ["UNSUPPORTED_FAQ_PUZZLE_TYPE", "UNSUPPORTED_PUZZLE_TYPE"].sort(),
+    "unsupported type repair should dedupe classification reruns",
+  );
+
+  const unknownIssuePlan = buildFullAnalysisRepairPlan({
+    issues: [
+      { issueCode: "SOME_FUTURE_ISSUE", fieldPath: "l1Input.answer", suggestedAction: "Future issue." },
+    ],
+  });
+  assert.equal(unknownIssuePlan.canAutoRepair, false, "repair loop should not auto-repair unknown future issues");
+  assert.equal(
+    unknownIssuePlan.actions[0]?.target,
+    "slotPlan",
+    "unknown issue fallback should not suggest changing L1 answer or clues",
+  );
+}
+
 async function main() {
   const fileNames = (await readdir(FIXTURE_DIR)).filter((fileName) => fileName.endsWith(".json")).sort();
   assert.ok(fileNames.length >= 6, "content kitchen should have at least 6 fixtures");
@@ -1090,6 +1235,7 @@ async function main() {
   assertFalseStartGenerator();
   assertFaqGenerator(dictionaries);
   assertDeterministicAssembler(dictionaries);
+  assertLocalRepairLoop(dictionaries);
   console.log(`content-kitchen contract fixtures passed (${fileNames.length} fixtures)`);
 }
 


### PR DESCRIPTION
## Summary
- add a local repair planner for PR8 full-analysis generation failures
- dedupe generator, assembly, and slot-contract issues into repair actions
- keep answer and L1 clue data immutable by only targeting classification, dictionaries, slots, and assembly
- mark missing reviewed dictionary facts and unsupported puzzle types as not auto-repairable

## Tests
- npm run test:content-kitchen
- npm run typecheck
- npm run lint
- npm run validate:data
- npm run build
- git diff --check