### PR TITLE
Add PR8 local pipeline smoke

### DIFF
--- a/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
+++ b/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
@@ -2024,6 +2024,14 @@ PR8 eighth implementation slice:
 - keep local structural issues auto-repairable by rerunning the relevant local generator and assembler
 - do not connect this repair planner to live publishing or LLM generation yet
 
+PR8 ninth implementation slice:
+
+- add a local full-analysis pipeline entrypoint that runs classification, clue-fit generation, reasoning, false-start handling, FAQ generation, assembly, and repair planning in order
+- return a complete slot plan only when every local step passes
+- stop early with a repair plan when reviewed dictionaries are missing, puzzle type is unsupported, a generator fails, or assembly fails
+- keep the pipeline local-only and deterministic; do not connect it to live publishing, background queues, external search, or LLM generation yet
+- cover the happy path, missing dictionary path, and unsupported puzzle type path in the content-kitchen contract test
+
 ### PR9 — Answer-First Enrichment SLA
 
 Goal: make `answer-first` temporary.

--- a/lib/puzzles/content-kitchen/full-analysis-local-pipeline.ts
+++ b/lib/puzzles/content-kitchen/full-analysis-local-pipeline.ts
@@ -1,0 +1,182 @@
+import { generateFullAnalysisClueFits } from "./clue-fit-generator";
+import { generateFullAnalysisFaqItems } from "./faq-generator";
+import { generateFullAnalysisFalseStart } from "./false-start-generator";
+import { assembleFullAnalysisSlotPlan } from "./full-analysis-assembler";
+import { buildFullAnalysisRepairPlan, type RepairableIssue } from "./local-repair-loop";
+import { classifyFullAnalysisPuzzleType } from "./puzzle-type-classifier";
+import { generateFullAnalysisReasoning } from "./reasoning-generator";
+import type {
+  ContentKitchenDictionaries,
+  FullAnalysisAssemblyResult,
+  FullAnalysisClueFitGenerationResult,
+  FullAnalysisFalseStartGenerationResult,
+  FullAnalysisFaqGenerationResult,
+  FullAnalysisPuzzleTypeClassification,
+  FullAnalysisReasoningGenerationResult,
+  FullAnalysisRepairPlan,
+  L1PuzzleInput,
+} from "./types";
+
+export type GenerateFullAnalysisLocalPipelineInput = {
+  l1Input: L1PuzzleInput;
+  dictionaries?: ContentKitchenDictionaries;
+  answerCategoryHint?: string;
+  evidenceIdPrefix?: string;
+};
+
+export type FullAnalysisLocalPipelineFailureStage =
+  | "clue_fits"
+  | "reasoning"
+  | "faq"
+  | "assembly";
+
+export type FullAnalysisLocalPipelineResult =
+  | {
+      ok: true;
+      stage: "complete";
+      classification: FullAnalysisPuzzleTypeClassification;
+      clueFitResult: Extract<FullAnalysisClueFitGenerationResult, { ok: true }>;
+      reasoningResult: Extract<FullAnalysisReasoningGenerationResult, { ok: true }>;
+      falseStartResult: FullAnalysisFalseStartGenerationResult;
+      faqResult: Extract<FullAnalysisFaqGenerationResult, { ok: true }>;
+      assemblyResult: Extract<FullAnalysisAssemblyResult, { ok: true }>;
+      repairPlan: FullAnalysisRepairPlan;
+    }
+  | {
+      ok: false;
+      stage: FullAnalysisLocalPipelineFailureStage;
+      classification: FullAnalysisPuzzleTypeClassification;
+      clueFitResult?: FullAnalysisClueFitGenerationResult;
+      reasoningResult?: FullAnalysisReasoningGenerationResult;
+      falseStartResult?: FullAnalysisFalseStartGenerationResult;
+      faqResult?: FullAnalysisFaqGenerationResult;
+      assemblyResult?: FullAnalysisAssemblyResult;
+      issues: RepairableIssue[];
+      repairPlan: FullAnalysisRepairPlan;
+    };
+
+function makeRepairPlan(issues: RepairableIssue[]): FullAnalysisRepairPlan {
+  return buildFullAnalysisRepairPlan({ issues });
+}
+
+export function generateFullAnalysisLocalPipeline(
+  input: GenerateFullAnalysisLocalPipelineInput,
+): FullAnalysisLocalPipelineResult {
+  const classification = classifyFullAnalysisPuzzleType({
+    l1Input: input.l1Input,
+    dictionaries: input.dictionaries,
+    answerCategoryHint: input.answerCategoryHint,
+  });
+
+  if (!input.dictionaries) {
+    const issues: RepairableIssue[] = [
+      {
+        issueCode: "MISSING_REVIEWED_DICTIONARIES",
+        fieldPath: "dictionaries",
+        suggestedAction: "Load reviewed dictionaries before local full-analysis generation.",
+      },
+    ];
+
+    return {
+      ok: false,
+      stage: "clue_fits",
+      classification,
+      issues,
+      repairPlan: makeRepairPlan(issues),
+    };
+  }
+
+  const clueFitResult = generateFullAnalysisClueFits({
+    l1Input: input.l1Input,
+    classification,
+    dictionaries: input.dictionaries,
+    evidenceIdPrefix: input.evidenceIdPrefix,
+  });
+
+  if (!clueFitResult.ok) {
+    return {
+      ok: false,
+      stage: "clue_fits",
+      classification,
+      clueFitResult,
+      issues: clueFitResult.issues,
+      repairPlan: makeRepairPlan(clueFitResult.issues),
+    };
+  }
+
+  const reasoningResult = generateFullAnalysisReasoning({
+    l1Input: input.l1Input,
+    classification,
+    clueFits: clueFitResult.clueFits,
+  });
+
+  if (!reasoningResult.ok) {
+    return {
+      ok: false,
+      stage: "reasoning",
+      classification,
+      clueFitResult,
+      reasoningResult,
+      issues: reasoningResult.issues,
+      repairPlan: makeRepairPlan(reasoningResult.issues),
+    };
+  }
+
+  const falseStartResult = generateFullAnalysisFalseStart();
+  const faqResult = generateFullAnalysisFaqItems({
+    l1Input: input.l1Input,
+    classification,
+    clueFits: clueFitResult.clueFits,
+  });
+
+  if (!faqResult.ok) {
+    return {
+      ok: false,
+      stage: "faq",
+      classification,
+      clueFitResult,
+      reasoningResult,
+      falseStartResult,
+      faqResult,
+      issues: faqResult.issues,
+      repairPlan: makeRepairPlan(faqResult.issues),
+    };
+  }
+
+  const assemblyResult = assembleFullAnalysisSlotPlan({
+    l1Input: input.l1Input,
+    classification,
+    clueFits: clueFitResult.clueFits,
+    reasoning: reasoningResult.reasoning,
+    falseStart: falseStartResult.falseStart,
+    faqItems: faqResult.faqItems,
+  });
+
+  if (!assemblyResult.ok) {
+    const issues = [...assemblyResult.issues, ...assemblyResult.slotIssues];
+    return {
+      ok: false,
+      stage: "assembly",
+      classification,
+      clueFitResult,
+      reasoningResult,
+      falseStartResult,
+      faqResult,
+      assemblyResult,
+      issues,
+      repairPlan: makeRepairPlan(issues),
+    };
+  }
+
+  return {
+    ok: true,
+    stage: "complete",
+    classification,
+    clueFitResult,
+    reasoningResult,
+    falseStartResult,
+    faqResult,
+    assemblyResult,
+    repairPlan: makeRepairPlan([]),
+  };
+}

--- a/scripts/check-content-kitchen-contract.ts
+++ b/scripts/check-content-kitchen-contract.ts
@@ -16,6 +16,7 @@ import { generateFullAnalysisClueFits } from "../lib/puzzles/content-kitchen/clu
 import { generateFullAnalysisFaqItems } from "../lib/puzzles/content-kitchen/faq-generator";
 import { generateFullAnalysisFalseStart } from "../lib/puzzles/content-kitchen/false-start-generator";
 import { assembleFullAnalysisSlotPlan } from "../lib/puzzles/content-kitchen/full-analysis-assembler";
+import { generateFullAnalysisLocalPipeline } from "../lib/puzzles/content-kitchen/full-analysis-local-pipeline";
 import { validateFullAnalysisSlotPlan } from "../lib/puzzles/content-kitchen/full-analysis-slots";
 import { hashInputSnapshot } from "../lib/puzzles/content-kitchen/identity";
 import { buildFullAnalysisRepairPlan } from "../lib/puzzles/content-kitchen/local-repair-loop";
@@ -1202,6 +1203,81 @@ function assertLocalRepairLoop(dictionaries: ContentKitchenDictionaries) {
   );
 }
 
+function assertLocalPipelineSmoke(dictionaries: ContentKitchenDictionaries) {
+  const l1Input = makeSlotContractL1Input();
+  const generated = generateFullAnalysisLocalPipeline({
+    l1Input,
+    dictionaries,
+    evidenceIdPrefix: "pipeline",
+  });
+
+  assert.equal(generated.ok, true, "local pipeline should produce a full-analysis slot plan");
+  if (!generated.ok) {
+    throw new Error("expected local pipeline to pass");
+  }
+  assert.equal(generated.stage, "complete", "local pipeline should report complete stage on success");
+  assert.equal(generated.classification.puzzleType, "category_membership", "local pipeline should classify the puzzle");
+  assert.equal(generated.clueFitResult.clueFits.length, 5, "local pipeline should produce five clue fits");
+  assert.equal(generated.clueFitResult.evidenceRecords.length, 5, "local pipeline should produce five evidence records");
+  assert.equal(generated.reasoningResult.reasoning.pattern, "cumulative_confirmation", "local pipeline should produce reasoning");
+  assert.equal(generated.falseStartResult.falseStart.status, "omitted", "local pipeline should omit unsupported false starts");
+  assert.equal(generated.faqResult.faqItems.length, 3, "local pipeline should produce stable FAQ items");
+  assert.deepEqual(
+    validateFullAnalysisSlotPlan({ l1Input, slotPlan: generated.assemblyResult.slotPlan }),
+    [],
+    "local pipeline output should satisfy the full-analysis slot contract",
+  );
+  assert.deepEqual(generated.repairPlan.actions, [], "successful local pipeline should not request repairs");
+
+  const missingDictionaries = generateFullAnalysisLocalPipeline({
+    l1Input,
+  });
+  assert.equal(missingDictionaries.ok, false, "local pipeline should fail clearly without dictionaries");
+  if (missingDictionaries.ok) {
+    throw new Error("expected missing-dictionary local pipeline to fail");
+  }
+  assert.equal(missingDictionaries.stage, "clue_fits", "missing dictionaries should stop before clue-fit generation");
+  assert.deepEqual(
+    missingDictionaries.issues.map((issue) => issue.issueCode),
+    ["MISSING_REVIEWED_DICTIONARIES"],
+    "missing dictionaries should return a direct issue code",
+  );
+  assert.equal(
+    missingDictionaries.repairPlan.actions[0]?.actionCode,
+    "load_reviewed_dictionaries",
+    "missing dictionaries should route to dictionary loading",
+  );
+
+  const unsupported = generateFullAnalysisLocalPipeline({
+    l1Input: {
+      ...l1Input,
+      answer: "Unknown category",
+      clues: [
+        { clueId: "clue-1", text: "Bass", position: 1 },
+        { clueId: "clue-2", text: "Alpha", position: 2 },
+        { clueId: "clue-3", text: "Bravo", position: 3 },
+        { clueId: "clue-4", text: "Charlie", position: 4 },
+        { clueId: "clue-5", text: "Delta", position: 5 },
+      ],
+    },
+    dictionaries,
+  });
+  assert.equal(unsupported.ok, false, "local pipeline should fail unsupported puzzle types");
+  if (unsupported.ok) {
+    throw new Error("expected unsupported local pipeline to fail");
+  }
+  assert.equal(unsupported.stage, "clue_fits", "unsupported puzzle type should stop at clue fits");
+  assert.ok(
+    unsupported.issues.some((issue) => issue.issueCode === "UNSUPPORTED_PUZZLE_TYPE"),
+    "unsupported puzzle type should report a clear issue",
+  );
+  assert.equal(
+    unsupported.repairPlan.canAutoRepair,
+    false,
+    "unsupported puzzle type should not be marked auto-repairable",
+  );
+}
+
 async function main() {
   const fileNames = (await readdir(FIXTURE_DIR)).filter((fileName) => fileName.endsWith(".json")).sort();
   assert.ok(fileNames.length >= 6, "content kitchen should have at least 6 fixtures");
@@ -1236,6 +1312,7 @@ async function main() {
   assertFaqGenerator(dictionaries);
   assertDeterministicAssembler(dictionaries);
   assertLocalRepairLoop(dictionaries);
+  assertLocalPipelineSmoke(dictionaries);
   console.log(`content-kitchen contract fixtures passed (${fileNames.length} fixtures)`);
 }
 


### PR DESCRIPTION
## Summary
- add a local full-analysis pipeline entrypoint that runs classification, clue fits, reasoning, false-start handling, FAQ, assembly, and repair planning
- stop early with a repair plan when dictionaries are missing, puzzle type is unsupported, a generator fails, or assembly fails
- add content-kitchen contract coverage for the happy path, missing dictionary path, and unsupported puzzle type path

## Tests
- npm run test:content-kitchen
- npm run typecheck
- npm run lint
- npm run validate:data
- npm run build
- git diff --check