### PR TITLE
Add PR9 answer-first SLA clock

### DIFF
--- a/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
+++ b/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
@@ -2069,6 +2069,17 @@ Acceptance:
 - stale jobs cannot overwrite newer revisions
 - successful enrichment updates `dateModified` only when content substantively changes
 
+PR9 first implementation slice:
+
+- add a local answer-first SLA clock; do not create the durable queue yet
+- keep v0 answer-first pages `noindex + sitemap exclude` while they are still waiting for enrichment
+- return `normal_alert_due` after 30 minutes without a safe full-analysis upgrade
+- return `review_required` after 60 minutes without a safe full-analysis upgrade
+- return `thin_page_noindex_required` for future indexed answer-first pages older than 2 hours without a safe upgrade
+- return `high_priority_alert_due` after 6 hours unresolved
+- return `upgrade_ready` as soon as a safe full-analysis candidate exists
+- do not send Feishu messages in this slice; only return the alert level that a later notification layer can use
+
 ### PR10 — Review Artifact And Human Review
 
 Goal: make failed content actionable.

--- a/lib/puzzles/content-kitchen/answer-first-sla.ts
+++ b/lib/puzzles/content-kitchen/answer-first-sla.ts
@@ -1,0 +1,240 @@
+import type {
+  AnswerFirstSlaDecision,
+  AnswerFirstSlaNotificationLevel,
+  AnswerFirstSlaStatus,
+  ContentKitchenIssueCode,
+  ContentMode,
+  SiteIndexHealthGuard,
+  ValidationPolicies,
+} from "./types";
+
+export const DEFAULT_ANSWER_FIRST_SLA_CONFIG: SiteIndexHealthGuard = {
+  maxIndexedAnswerFirstRatio: 0,
+  targetFullAnalysisMinutes: 30,
+  firstAlertAfterMinutes: 30,
+  reviewAfterMinutes: 60,
+  thinPageAutoNoindexAfterMinutes: 120,
+  highPriorityAlertAfterHours: 6,
+  autoNoindexIfOverSLA: true,
+  excludeFromRecentIfNoindex: true,
+  notificationChannel: "feishu",
+};
+
+export type EvaluateAnswerFirstSlaInput = {
+  contentMode: ContentMode;
+  answerFirstPublishedAt: string;
+  now: string;
+  hasSafeFullAnalysisUpgrade?: boolean;
+  isIndexedAnswerFirst?: boolean;
+  config?: Partial<SiteIndexHealthGuard>;
+};
+
+const KEEP_CURRENT_POLICIES: ValidationPolicies = {
+  indexPolicy: "index",
+  sitemapPolicy: "include",
+  schemaPolicy: "article_only",
+  internalLinkPolicy: "normal",
+  requiredAction: "keep_current",
+};
+
+const ANSWER_FIRST_DEFAULT_POLICIES: ValidationPolicies = {
+  indexPolicy: "noindex",
+  sitemapPolicy: "exclude",
+  schemaPolicy: "none",
+  internalLinkPolicy: "hidden_from_recent",
+  requiredAction: "enrich",
+};
+
+const ANSWER_FIRST_UPGRADE_POLICIES: ValidationPolicies = {
+  indexPolicy: "noindex",
+  sitemapPolicy: "exclude",
+  schemaPolicy: "none",
+  internalLinkPolicy: "deemphasized",
+  requiredAction: "upgrade",
+};
+
+const ANSWER_FIRST_REVIEW_POLICIES: ValidationPolicies = {
+  indexPolicy: "review_required",
+  sitemapPolicy: "remove_on_next_build",
+  schemaPolicy: "none",
+  internalLinkPolicy: "hidden_from_recent",
+  requiredAction: "review",
+};
+
+const INDEXED_ANSWER_FIRST_DEGRADE_POLICIES: ValidationPolicies = {
+  indexPolicy: "noindex",
+  sitemapPolicy: "exclude",
+  schemaPolicy: "none",
+  internalLinkPolicy: "hidden_from_recent",
+  requiredAction: "degrade",
+  degradationActions: ["apply_noindex", "remove_from_sitemap", "hide_from_recent"],
+};
+
+function parseTimestamp(value: string, fieldPath: string): number {
+  const timestamp = Date.parse(value);
+  if (!Number.isFinite(timestamp)) {
+    throw new Error(`${fieldPath} must be a valid timestamp`);
+  }
+  return timestamp;
+}
+
+function addMinutes(timestamp: number, minutes: number): number {
+  return timestamp + minutes * 60_000;
+}
+
+function toIso(timestamp: number): string {
+  return new Date(timestamp).toISOString();
+}
+
+function notificationLevel(
+  status: AnswerFirstSlaStatus,
+  config: SiteIndexHealthGuard,
+): AnswerFirstSlaNotificationLevel {
+  if (config.notificationChannel === "none") {
+    return "none";
+  }
+
+  if (status === "high_priority_alert_due") {
+    return "high_priority";
+  }
+
+  if (status === "normal_alert_due") {
+    return "normal";
+  }
+
+  return "none";
+}
+
+function buildDecision(input: {
+  status: AnswerFirstSlaStatus;
+  publishedAt: number;
+  now: number;
+  config: SiteIndexHealthGuard;
+  issueCodes: ContentKitchenIssueCode[];
+  policies: ValidationPolicies;
+}): AnswerFirstSlaDecision {
+  const highPriorityMinutes = input.config.highPriorityAlertAfterHours * 60;
+
+  return {
+    status: input.status,
+    elapsedMinutes: Math.max(0, Math.floor((input.now - input.publishedAt) / 60_000)),
+    targetFullAnalysisAt: toIso(addMinutes(input.publishedAt, input.config.targetFullAnalysisMinutes)),
+    firstAlertAt: toIso(addMinutes(input.publishedAt, input.config.firstAlertAfterMinutes)),
+    reviewRequiredAt: toIso(addMinutes(input.publishedAt, input.config.reviewAfterMinutes)),
+    thinPageNoindexAt: toIso(addMinutes(input.publishedAt, input.config.thinPageAutoNoindexAfterMinutes)),
+    highPriorityAlertAt: toIso(addMinutes(input.publishedAt, highPriorityMinutes)),
+    notificationLevel: notificationLevel(input.status, input.config),
+    issueCodes: input.issueCodes,
+    policies: input.policies,
+  };
+}
+
+export function evaluateAnswerFirstSla(input: EvaluateAnswerFirstSlaInput): AnswerFirstSlaDecision {
+  const config: SiteIndexHealthGuard = {
+    ...DEFAULT_ANSWER_FIRST_SLA_CONFIG,
+    ...input.config,
+  };
+  const publishedAt = parseTimestamp(input.answerFirstPublishedAt, "answerFirstPublishedAt");
+  const now = parseTimestamp(input.now, "now");
+  const targetAt = addMinutes(publishedAt, config.targetFullAnalysisMinutes);
+  const firstAlertAt = addMinutes(publishedAt, config.firstAlertAfterMinutes);
+  const reviewAt = addMinutes(publishedAt, config.reviewAfterMinutes);
+  const thinNoindexAt = addMinutes(publishedAt, config.thinPageAutoNoindexAfterMinutes);
+  const highPriorityAt = addMinutes(publishedAt, config.highPriorityAlertAfterHours * 60);
+
+  if (input.contentMode !== "answer-first") {
+    return buildDecision({
+      status: "not_applicable",
+      publishedAt,
+      now,
+      config,
+      issueCodes: [],
+      policies: KEEP_CURRENT_POLICIES,
+    });
+  }
+
+  if (input.hasSafeFullAnalysisUpgrade) {
+    return buildDecision({
+      status: "upgrade_ready",
+      publishedAt,
+      now,
+      config,
+      issueCodes: [],
+      policies: ANSWER_FIRST_UPGRADE_POLICIES,
+    });
+  }
+
+  const issueCodes: ContentKitchenIssueCode[] = [];
+  if (now >= targetAt) {
+    issueCodes.push("ANSWER_FIRST_OVER_SLA");
+  }
+
+  const staleIndexedAnswerFirst =
+    Boolean(input.isIndexedAnswerFirst) &&
+    config.autoNoindexIfOverSLA &&
+    now >= thinNoindexAt;
+  if (staleIndexedAnswerFirst) {
+    issueCodes.push("INDEXED_ANSWER_FIRST_STALE");
+  }
+
+  if (now >= reviewAt) {
+    issueCodes.push("ANSWER_FIRST_REVIEW_REQUIRED");
+  }
+
+  if (now >= highPriorityAt) {
+    issueCodes.push("ANSWER_FIRST_HIGH_PRIORITY_ALERT");
+  }
+
+  if (now >= highPriorityAt) {
+    return buildDecision({
+      status: "high_priority_alert_due",
+      publishedAt,
+      now,
+      config,
+      issueCodes,
+      policies: staleIndexedAnswerFirst ? INDEXED_ANSWER_FIRST_DEGRADE_POLICIES : ANSWER_FIRST_REVIEW_POLICIES,
+    });
+  }
+
+  if (staleIndexedAnswerFirst) {
+    return buildDecision({
+      status: "thin_page_noindex_required",
+      publishedAt,
+      now,
+      config,
+      issueCodes,
+      policies: INDEXED_ANSWER_FIRST_DEGRADE_POLICIES,
+    });
+  }
+
+  if (now >= reviewAt) {
+    return buildDecision({
+      status: "review_required",
+      publishedAt,
+      now,
+      config,
+      issueCodes,
+      policies: ANSWER_FIRST_REVIEW_POLICIES,
+    });
+  }
+
+  if (now >= firstAlertAt) {
+    return buildDecision({
+      status: "normal_alert_due",
+      publishedAt,
+      now,
+      config,
+      issueCodes,
+      policies: ANSWER_FIRST_DEFAULT_POLICIES,
+    });
+  }
+
+  return buildDecision({
+    status: "within_sla",
+    publishedAt,
+    now,
+    config,
+    issueCodes,
+    policies: ANSWER_FIRST_DEFAULT_POLICIES,
+  });
+}

--- a/lib/puzzles/content-kitchen/issue-registry.ts
+++ b/lib/puzzles/content-kitchen/issue-registry.ts
@@ -185,6 +185,38 @@ export const CONTENT_KITCHEN_ISSUE_REGISTRY: IssueCodeDefinition[] = [
     defaultRequiredAction: "review",
     description: "A candidate has an unresolved evidence conflict.",
   },
+  {
+    code: "ANSWER_FIRST_OVER_SLA",
+    phaseOwner: "PR9",
+    defaultSeverity: "P1",
+    defaultOutcome: "requires_review",
+    defaultRequiredAction: "enrich",
+    description: "An answer-first page missed its target full-analysis upgrade time.",
+  },
+  {
+    code: "ANSWER_FIRST_REVIEW_REQUIRED",
+    phaseOwner: "PR9",
+    defaultSeverity: "P1",
+    defaultOutcome: "requires_review",
+    defaultRequiredAction: "review",
+    description: "An unresolved answer-first page is old enough to require human review.",
+  },
+  {
+    code: "INDEXED_ANSWER_FIRST_STALE",
+    phaseOwner: "PR9",
+    defaultSeverity: "P1",
+    defaultOutcome: "requires_review",
+    defaultRequiredAction: "degrade",
+    description: "A future indexed answer-first page stayed unresolved long enough to require noindex fallback.",
+  },
+  {
+    code: "ANSWER_FIRST_HIGH_PRIORITY_ALERT",
+    phaseOwner: "PR9",
+    defaultSeverity: "P1",
+    defaultOutcome: "requires_review",
+    defaultRequiredAction: "review",
+    description: "An answer-first page is still unresolved at the high-priority alert deadline.",
+  },
 ];
 
 export const CONTENT_KITCHEN_ISSUE_DEFINITIONS = new Map<ContentKitchenIssueCode, IssueCodeDefinition>(

--- a/lib/puzzles/content-kitchen/types.ts
+++ b/lib/puzzles/content-kitchen/types.ts
@@ -10,8 +10,8 @@ export type ValidationOutcome =
   | "block_publish";
 
 export type IndexPolicy = "index" | "noindex" | "review_required" | "block_publish";
-export type SitemapPolicy = "include" | "exclude" | "include_after_audit";
-export type SchemaPolicy = "none" | "article_only";
+export type SitemapPolicy = "include" | "exclude" | "remove_on_next_build" | "include_after_audit";
+export type SchemaPolicy = "none" | "article_only" | "faq_allowed" | "block_schema";
 export type InternalLinkPolicy = "normal" | "deemphasized" | "hidden_from_recent";
 
 export type RequiredAction =
@@ -19,8 +19,12 @@ export type RequiredAction =
   | "enrich"
   | "review"
   | "block_publish"
+  | "upgrade"
+  | "rollback"
   | "degrade"
-  | "create_fix_task";
+  | "create_fix_task"
+  | "dead_letter"
+  | "keep_current";
 
 export type DegradationAction =
   | "remove_faq_schema"
@@ -52,7 +56,11 @@ export type ContentKitchenIssueCode =
   | "L4_ONLY_EVIDENCE"
   | "FULL_ANALYSIS_WITH_LOW_CONFIDENCE"
   | "PROHIBITED_EVIDENCE_SOURCE"
-  | "EVIDENCE_SOURCE_CONFLICT";
+  | "EVIDENCE_SOURCE_CONFLICT"
+  | "ANSWER_FIRST_OVER_SLA"
+  | "ANSWER_FIRST_REVIEW_REQUIRED"
+  | "INDEXED_ANSWER_FIRST_STALE"
+  | "ANSWER_FIRST_HIGH_PRIORITY_ALERT";
 
 export type Pr6aIssueCode = ContentKitchenIssueCode;
 
@@ -499,6 +507,42 @@ export type FullAnalysisRepairPlan = {
   actions: FullAnalysisRepairAction[];
 };
 
+export type SiteIndexHealthGuard = {
+  maxIndexedAnswerFirstRatio: number;
+  targetFullAnalysisMinutes: number;
+  firstAlertAfterMinutes: number;
+  reviewAfterMinutes: number;
+  thinPageAutoNoindexAfterMinutes: number;
+  highPriorityAlertAfterHours: number;
+  autoNoindexIfOverSLA: boolean;
+  excludeFromRecentIfNoindex: boolean;
+  notificationChannel: "feishu" | "none" | "custom";
+};
+
+export type AnswerFirstSlaStatus =
+  | "not_applicable"
+  | "within_sla"
+  | "upgrade_ready"
+  | "normal_alert_due"
+  | "review_required"
+  | "thin_page_noindex_required"
+  | "high_priority_alert_due";
+
+export type AnswerFirstSlaNotificationLevel = "none" | "normal" | "high_priority";
+
+export type AnswerFirstSlaDecision = {
+  status: AnswerFirstSlaStatus;
+  elapsedMinutes: number;
+  targetFullAnalysisAt: string;
+  firstAlertAt: string;
+  reviewRequiredAt: string;
+  thinPageNoindexAt: string;
+  highPriorityAlertAt: string;
+  notificationLevel: AnswerFirstSlaNotificationLevel;
+  issueCodes: ContentKitchenIssueCode[];
+  policies: ValidationPolicies;
+};
+
 export type InternalLinkCandidate = {
   href: string;
   label?: string;
@@ -565,6 +609,7 @@ export type IssuePhaseOwner =
   | "PR6C"
   | "PR7"
   | "PR8"
+  | "PR9"
   | "PR10"
   | "PR11";
 

--- a/scripts/check-content-kitchen-contract.ts
+++ b/scripts/check-content-kitchen-contract.ts
@@ -3,6 +3,10 @@ import { readdir, readFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
+  DEFAULT_ANSWER_FIRST_SLA_CONFIG,
+  evaluateAnswerFirstSla,
+} from "../lib/puzzles/content-kitchen/answer-first-sla";
+import {
   buildCategoryMembershipEvidenceRecords,
   buildPublishedEvidenceUsageRecords,
   dictionaryDiffRequiresReviewArtifacts,
@@ -1278,6 +1282,110 @@ function assertLocalPipelineSmoke(dictionaries: ContentKitchenDictionaries) {
   );
 }
 
+function assertAnswerFirstSlaClock() {
+  const publishedAt = "2026-05-23T08:00:00.000Z";
+  const baseInput = {
+    contentMode: "answer-first" as const,
+    answerFirstPublishedAt: publishedAt,
+  };
+
+  assert.equal(
+    DEFAULT_ANSWER_FIRST_SLA_CONFIG.targetFullAnalysisMinutes,
+    30,
+    "answer-first SLA should target full-analysis within 30 minutes",
+  );
+
+  const withinSla = evaluateAnswerFirstSla({
+    ...baseInput,
+    now: "2026-05-23T08:29:00.000Z",
+  });
+  assert.equal(withinSla.status, "within_sla", "fresh answer-first pages should stay within SLA");
+  assert.equal(withinSla.notificationLevel, "none", "fresh answer-first pages should not alert");
+  assert.deepEqual(withinSla.issueCodes, [], "fresh answer-first pages should not have SLA issue codes");
+  assert.equal(withinSla.policies.indexPolicy, "noindex", "v0 answer-first should remain noindex");
+  assert.equal(withinSla.policies.sitemapPolicy, "exclude", "v0 answer-first should stay out of sitemap");
+  assert.equal(withinSla.policies.requiredAction, "enrich", "fresh answer-first pages should still target enrichment");
+
+  const alertDue = evaluateAnswerFirstSla({
+    ...baseInput,
+    now: "2026-05-23T08:31:00.000Z",
+  });
+  assert.equal(alertDue.status, "normal_alert_due", "answer-first pages past 30 minutes should alert");
+  assert.equal(alertDue.notificationLevel, "normal", "30-minute SLA misses should use normal alert level");
+  assert.deepEqual(alertDue.issueCodes, ["ANSWER_FIRST_OVER_SLA"], "30-minute SLA misses should keep one issue code");
+
+  const reviewRequired = evaluateAnswerFirstSla({
+    ...baseInput,
+    now: "2026-05-23T09:01:00.000Z",
+  });
+  assert.equal(reviewRequired.status, "review_required", "answer-first pages past 60 minutes should enter review");
+  assert.equal(reviewRequired.policies.indexPolicy, "review_required", "review-stage answer-first should require review");
+  assert.equal(
+    reviewRequired.policies.sitemapPolicy,
+    "remove_on_next_build",
+    "review-stage answer-first should be removed from sitemap on the next build",
+  );
+  assert.equal(reviewRequired.policies.requiredAction, "review", "review-stage answer-first should require review");
+  assert.deepEqual(
+    reviewRequired.issueCodes,
+    ["ANSWER_FIRST_OVER_SLA", "ANSWER_FIRST_REVIEW_REQUIRED"],
+    "review-stage answer-first should report over-SLA and review issue codes",
+  );
+
+  const indexedStale = evaluateAnswerFirstSla({
+    ...baseInput,
+    now: "2026-05-23T10:01:00.000Z",
+    isIndexedAnswerFirst: true,
+  });
+  assert.equal(
+    indexedStale.status,
+    "thin_page_noindex_required",
+    "future indexed answer-first pages older than two hours should fall back to noindex",
+  );
+  assert.equal(indexedStale.policies.requiredAction, "degrade", "stale indexed answer-first pages should degrade");
+  assert.deepEqual(
+    indexedStale.policies.degradationActions,
+    ["apply_noindex", "remove_from_sitemap", "hide_from_recent"],
+    "stale indexed answer-first pages should reduce SEO and recent-link exposure",
+  );
+  assert.ok(
+    indexedStale.issueCodes.includes("INDEXED_ANSWER_FIRST_STALE"),
+    "stale indexed answer-first pages should report the indexed stale issue",
+  );
+
+  const highPriority = evaluateAnswerFirstSla({
+    ...baseInput,
+    now: "2026-05-23T14:01:00.000Z",
+  });
+  assert.equal(
+    highPriority.status,
+    "high_priority_alert_due",
+    "unresolved answer-first pages past six hours should need high-priority alert",
+  );
+  assert.equal(highPriority.notificationLevel, "high_priority", "six-hour unresolved pages should use high priority");
+  assert.ok(
+    highPriority.issueCodes.includes("ANSWER_FIRST_HIGH_PRIORITY_ALERT"),
+    "six-hour unresolved pages should report the high-priority issue",
+  );
+
+  const upgradeReady = evaluateAnswerFirstSla({
+    ...baseInput,
+    now: "2026-05-23T08:10:00.000Z",
+    hasSafeFullAnalysisUpgrade: true,
+  });
+  assert.equal(upgradeReady.status, "upgrade_ready", "safe full-analysis candidates should be upgraded immediately");
+  assert.equal(upgradeReady.policies.requiredAction, "upgrade", "safe full-analysis candidates should request upgrade");
+  assert.deepEqual(upgradeReady.issueCodes, [], "safe full-analysis candidates should not carry SLA issue codes");
+
+  const notApplicable = evaluateAnswerFirstSla({
+    contentMode: "full-analysis",
+    answerFirstPublishedAt: publishedAt,
+    now: "2026-05-23T14:01:00.000Z",
+  });
+  assert.equal(notApplicable.status, "not_applicable", "full-analysis pages should not use answer-first SLA handling");
+  assert.equal(notApplicable.policies.requiredAction, "keep_current", "full-analysis pages should keep current content");
+}
+
 async function main() {
   const fileNames = (await readdir(FIXTURE_DIR)).filter((fileName) => fileName.endsWith(".json")).sort();
   assert.ok(fileNames.length >= 6, "content kitchen should have at least 6 fixtures");
@@ -1313,6 +1421,7 @@ async function main() {
   assertDeterministicAssembler(dictionaries);
   assertLocalRepairLoop(dictionaries);
   assertLocalPipelineSmoke(dictionaries);
+  assertAnswerFirstSlaClock();
   console.log(`content-kitchen contract fixtures passed (${fileNames.length} fixtures)`);
 }
 


### PR DESCRIPTION
## Summary
- add a local answer-first SLA clock for PR9 enrichment timing decisions
- return normal alert, review, future indexed noindex fallback, high-priority alert, and upgrade-ready decisions without sending notifications or changing production behavior
- register PR9 answer-first SLA issue codes and cover the clock in the content-kitchen contract test

## Tests
- npm run test:content-kitchen
- npm run typecheck
- npm run lint
- npm run validate:data
- npm run build
- git diff --check