### PR TITLE
Add PR9 enrichment job contract

### DIFF
--- a/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
+++ b/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
@@ -2080,6 +2080,15 @@ PR9 first implementation slice:
 - return `upgrade_ready` as soon as a safe full-analysis candidate exists
 - do not send Feishu messages in this slice; only return the alert level that a later notification layer can use
 
+PR9 second implementation slice:
+
+- add a local answer-first enrichment job contract; do not create durable storage or Worker scanning yet
+- include `idempotencyKey`, `inputSnapshotHash`, `sourceRevisionId`, `targetRevision`, queue state, attempt counters, backoff strategy, lock fields, SLA timestamps, and failure reason codes
+- make the idempotency key stable for one `puzzleId + targetRevision`
+- treat queued, running, and review-required jobs as active for duplicate prevention
+- block stale job results when the published source revision, input snapshot hash, or target revision no longer matches
+- keep this slice local-only; later PR9 slices can attach it to storage, locks, resume behavior, and notifications
+
 ### PR10 — Review Artifact And Human Review
 
 Goal: make failed content actionable.

--- a/lib/puzzles/content-kitchen/enrichment-job.ts
+++ b/lib/puzzles/content-kitchen/enrichment-job.ts
@@ -1,0 +1,134 @@
+import { DEFAULT_ANSWER_FIRST_SLA_CONFIG } from "./answer-first-sla";
+import { normalizeIdentityMatch, normalizeIdentityText } from "./identity";
+import type {
+  AnswerFirstEnrichmentJob,
+  EnrichmentJobState,
+  SiteIndexHealthGuard,
+} from "./types";
+
+export type CreateAnswerFirstEnrichmentJobInput = {
+  puzzleId: string;
+  sourceRevisionId: string;
+  targetRevision: string;
+  inputSnapshotHash: string;
+  answerFirstPublishedAt: string;
+  now: string;
+  maxAttempts?: number;
+  backoffStrategy?: AnswerFirstEnrichmentJob["backoffStrategy"];
+  config?: Partial<SiteIndexHealthGuard>;
+};
+
+export type CanApplyEnrichmentJobResultInput = {
+  job: AnswerFirstEnrichmentJob;
+  currentPublishedRevisionId: string;
+  currentInputSnapshotHash: string;
+  resultTargetRevision: string;
+};
+
+const ACTIVE_ENRICHMENT_JOB_STATES = new Set<EnrichmentJobState>([
+  "queued",
+  "running",
+  "review_required",
+]);
+
+function parseTimestamp(value: string, fieldPath: string): number {
+  const timestamp = Date.parse(value);
+  if (!Number.isFinite(timestamp)) {
+    throw new Error(`${fieldPath} must be a valid timestamp`);
+  }
+  return timestamp;
+}
+
+function addMinutes(timestamp: number, minutes: number): string {
+  return new Date(timestamp + minutes * 60_000).toISOString();
+}
+
+function safeId(value: string): string {
+  return normalizeIdentityMatch(value).replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "") || "unknown";
+}
+
+function requireText(value: string, fieldPath: string): string {
+  const normalized = normalizeIdentityText(value);
+  if (!normalized) {
+    throw new Error(`${fieldPath} is required`);
+  }
+  return normalized;
+}
+
+export function buildEnrichmentJobIdempotencyKey(input: Pick<
+  CreateAnswerFirstEnrichmentJobInput,
+  "puzzleId" | "targetRevision"
+>): string {
+  return `content-kitchen:answer-first-enrichment:${safeId(input.puzzleId)}:${safeId(input.targetRevision)}`;
+}
+
+export function createAnswerFirstEnrichmentJob(
+  input: CreateAnswerFirstEnrichmentJobInput,
+): AnswerFirstEnrichmentJob {
+  const puzzleId = requireText(input.puzzleId, "puzzleId");
+  const sourceRevisionId = requireText(input.sourceRevisionId, "sourceRevisionId");
+  const targetRevision = requireText(input.targetRevision, "targetRevision");
+  const inputSnapshotHash = requireText(input.inputSnapshotHash, "inputSnapshotHash");
+  const createdAt = new Date(parseTimestamp(input.now, "now")).toISOString();
+  const publishedAt = parseTimestamp(input.answerFirstPublishedAt, "answerFirstPublishedAt");
+  const config: SiteIndexHealthGuard = {
+    ...DEFAULT_ANSWER_FIRST_SLA_CONFIG,
+    ...input.config,
+  };
+  const highPriorityMinutes = config.highPriorityAlertAfterHours * 60;
+  const targetFullAnalysisAt = addMinutes(publishedAt, config.targetFullAnalysisMinutes);
+  const idempotencyKey = buildEnrichmentJobIdempotencyKey({ puzzleId, targetRevision });
+
+  return {
+    jobVersion: "answer-first-enrichment-job-v0",
+    jobId: `job-${safeId(puzzleId)}-${safeId(targetRevision)}`,
+    idempotencyKey,
+    puzzleId,
+    sourceRevisionId,
+    targetRevision,
+    inputSnapshotHash,
+    state: "queued",
+    createdAt,
+    updatedAt: createdAt,
+    nextAttemptAt: createdAt,
+    attemptCount: 0,
+    maxAttempts: input.maxAttempts ?? 3,
+    backoffStrategy: input.backoffStrategy ?? "exponential",
+    deadlineAt: targetFullAnalysisAt,
+    targetFullAnalysisAt,
+    firstAlertAt: addMinutes(publishedAt, config.firstAlertAfterMinutes),
+    reviewRequiredAt: addMinutes(publishedAt, config.reviewAfterMinutes),
+    thinPageNoindexAt: addMinutes(publishedAt, config.thinPageAutoNoindexAfterMinutes),
+    highPriorityAlertAt: addMinutes(publishedAt, highPriorityMinutes),
+    failureReasonCodes: [],
+  };
+}
+
+export function isActiveEnrichmentJob(job: Pick<AnswerFirstEnrichmentJob, "state">): boolean {
+  return ACTIVE_ENRICHMENT_JOB_STATES.has(job.state);
+}
+
+export function findActiveEnrichmentJobForTarget(
+  jobs: Pick<AnswerFirstEnrichmentJob, "puzzleId" | "targetRevision" | "state">[],
+  target: Pick<AnswerFirstEnrichmentJob, "puzzleId" | "targetRevision">,
+): Pick<AnswerFirstEnrichmentJob, "puzzleId" | "targetRevision" | "state"> | undefined {
+  const puzzleId = normalizeIdentityMatch(target.puzzleId);
+  const targetRevision = normalizeIdentityMatch(target.targetRevision);
+
+  return jobs.find((job) => {
+    return (
+      isActiveEnrichmentJob(job) &&
+      normalizeIdentityMatch(job.puzzleId) === puzzleId &&
+      normalizeIdentityMatch(job.targetRevision) === targetRevision
+    );
+  });
+}
+
+export function canApplyEnrichmentJobResult(input: CanApplyEnrichmentJobResultInput): boolean {
+  return (
+    input.job.state === "running" &&
+    normalizeIdentityText(input.currentPublishedRevisionId) === normalizeIdentityText(input.job.sourceRevisionId) &&
+    normalizeIdentityText(input.currentInputSnapshotHash) === normalizeIdentityText(input.job.inputSnapshotHash) &&
+    normalizeIdentityText(input.resultTargetRevision) === normalizeIdentityText(input.job.targetRevision)
+  );
+}

--- a/lib/puzzles/content-kitchen/types.ts
+++ b/lib/puzzles/content-kitchen/types.ts
@@ -543,6 +543,42 @@ export type AnswerFirstSlaDecision = {
   policies: ValidationPolicies;
 };
 
+export type EnrichmentJobState =
+  | "queued"
+  | "running"
+  | "review_required"
+  | "dead_letter"
+  | "completed";
+
+export type EnrichmentBackoffStrategy = "fixed" | "exponential";
+
+export type AnswerFirstEnrichmentJob = {
+  jobVersion: "answer-first-enrichment-job-v0";
+  jobId: string;
+  idempotencyKey: string;
+  puzzleId: string;
+  sourceRevisionId: string;
+  targetRevision: string;
+  inputSnapshotHash: string;
+  state: EnrichmentJobState;
+  createdAt: string;
+  updatedAt: string;
+  nextAttemptAt: string;
+  attemptCount: number;
+  maxAttempts: number;
+  backoffStrategy: EnrichmentBackoffStrategy;
+  deadlineAt: string;
+  targetFullAnalysisAt: string;
+  firstAlertAt: string;
+  reviewRequiredAt: string;
+  thinPageNoindexAt: string;
+  highPriorityAlertAt: string;
+  lockedBy?: string;
+  lockedUntil?: string;
+  failureReasonCodes: ContentKitchenIssueCode[];
+  deadLetterAt?: string;
+};
+
 export type InternalLinkCandidate = {
   href: string;
   label?: string;

--- a/scripts/check-content-kitchen-contract.ts
+++ b/scripts/check-content-kitchen-contract.ts
@@ -16,6 +16,12 @@ import {
   readContentKitchenDictionaries,
   readContentKitchenDictionaryDiffs,
 } from "../lib/puzzles/content-kitchen/dictionary";
+import {
+  canApplyEnrichmentJobResult,
+  createAnswerFirstEnrichmentJob,
+  findActiveEnrichmentJobForTarget,
+  isActiveEnrichmentJob,
+} from "../lib/puzzles/content-kitchen/enrichment-job";
 import { generateFullAnalysisClueFits } from "../lib/puzzles/content-kitchen/clue-fit-generator";
 import { generateFullAnalysisFaqItems } from "../lib/puzzles/content-kitchen/faq-generator";
 import { generateFullAnalysisFalseStart } from "../lib/puzzles/content-kitchen/false-start-generator";
@@ -1386,6 +1392,95 @@ function assertAnswerFirstSlaClock() {
   assert.equal(notApplicable.policies.requiredAction, "keep_current", "full-analysis pages should keep current content");
 }
 
+function assertAnswerFirstEnrichmentJobContract() {
+  const job = createAnswerFirstEnrichmentJob({
+    puzzleId: "pinpoint-900-2026-05-23",
+    sourceRevisionId: "rev-answer-first-900",
+    targetRevision: "rev-full-analysis-900",
+    inputSnapshotHash: "sha256:l1-900",
+    answerFirstPublishedAt: "2026-05-23T08:00:00.000Z",
+    now: "2026-05-23T08:05:00.000Z",
+  });
+
+  assert.equal(job.jobVersion, "answer-first-enrichment-job-v0", "enrichment job version should be stable");
+  assert.equal(
+    job.idempotencyKey,
+    "content-kitchen:answer-first-enrichment:pinpoint-900-2026-05-23:rev-full-analysis-900",
+    "enrichment job idempotency key should be stable for puzzleId + targetRevision",
+  );
+  assert.equal(job.state, "queued", "new enrichment jobs should start queued");
+  assert.equal(job.nextAttemptAt, "2026-05-23T08:05:00.000Z", "new enrichment jobs should be immediately runnable");
+  assert.equal(job.attemptCount, 0, "new enrichment jobs should start with zero attempts");
+  assert.equal(job.maxAttempts, 3, "new enrichment jobs should default to three attempts");
+  assert.equal(job.backoffStrategy, "exponential", "new enrichment jobs should default to exponential backoff");
+  assert.equal(job.deadlineAt, "2026-05-23T08:30:00.000Z", "deadline should match target full-analysis time");
+  assert.equal(job.targetFullAnalysisAt, "2026-05-23T08:30:00.000Z", "target full-analysis time should be 30 minutes");
+  assert.equal(job.firstAlertAt, "2026-05-23T08:30:00.000Z", "first alert should be 30 minutes");
+  assert.equal(job.reviewRequiredAt, "2026-05-23T09:00:00.000Z", "review should be required after 60 minutes");
+  assert.equal(job.thinPageNoindexAt, "2026-05-23T10:00:00.000Z", "thin indexed fallback should be after 2 hours");
+  assert.equal(job.highPriorityAlertAt, "2026-05-23T14:00:00.000Z", "high priority alert should be after 6 hours");
+  assert.deepEqual(job.failureReasonCodes, [], "new enrichment jobs should not start with failure reasons");
+
+  assert.equal(isActiveEnrichmentJob(job), true, "queued enrichment jobs should count as active");
+  assert.equal(
+    isActiveEnrichmentJob({ ...job, state: "completed" }),
+    false,
+    "completed enrichment jobs should not count as active",
+  );
+  assert.equal(
+    Boolean(findActiveEnrichmentJobForTarget([{ ...job, state: "completed" }, job], job)),
+    true,
+    "active job lookup should find queued jobs for the same puzzleId + targetRevision",
+  );
+  assert.equal(
+    findActiveEnrichmentJobForTarget([{ ...job, state: "completed" }], job),
+    undefined,
+    "active job lookup should ignore completed jobs",
+  );
+
+  const runningJob = { ...job, state: "running" as const };
+  assert.equal(
+    canApplyEnrichmentJobResult({
+      job: runningJob,
+      currentPublishedRevisionId: "rev-answer-first-900",
+      currentInputSnapshotHash: "sha256:l1-900",
+      resultTargetRevision: "rev-full-analysis-900",
+    }),
+    true,
+    "running jobs should apply when source revision, input hash, and target revision still match",
+  );
+  assert.equal(
+    canApplyEnrichmentJobResult({
+      job: runningJob,
+      currentPublishedRevisionId: "rev-newer-answer-first-900",
+      currentInputSnapshotHash: "sha256:l1-900",
+      resultTargetRevision: "rev-full-analysis-900",
+    }),
+    false,
+    "stale jobs should not overwrite a newer published revision",
+  );
+  assert.equal(
+    canApplyEnrichmentJobResult({
+      job: runningJob,
+      currentPublishedRevisionId: "rev-answer-first-900",
+      currentInputSnapshotHash: "sha256:new-l1-900",
+      resultTargetRevision: "rev-full-analysis-900",
+    }),
+    false,
+    "stale jobs should not overwrite content generated from newer L1 input",
+  );
+  assert.equal(
+    canApplyEnrichmentJobResult({
+      job: runningJob,
+      currentPublishedRevisionId: "rev-answer-first-900",
+      currentInputSnapshotHash: "sha256:l1-900",
+      resultTargetRevision: "rev-other-full-analysis-900",
+    }),
+    false,
+    "stale jobs should not apply a result for a different target revision",
+  );
+}
+
 async function main() {
   const fileNames = (await readdir(FIXTURE_DIR)).filter((fileName) => fileName.endsWith(".json")).sort();
   assert.ok(fileNames.length >= 6, "content kitchen should have at least 6 fixtures");
@@ -1422,6 +1517,7 @@ async function main() {
   assertLocalRepairLoop(dictionaries);
   assertLocalPipelineSmoke(dictionaries);
   assertAnswerFirstSlaClock();
+  assertAnswerFirstEnrichmentJobContract();
   console.log(`content-kitchen contract fixtures passed (${fileNames.length} fixtures)`);
 }
 


### PR DESCRIPTION
## Summary
- add a local answer-first enrichment job contract with stable idempotency, attempt, lock, SLA, and failure fields
- add helpers to find active jobs for one puzzleId + targetRevision and block stale job results
- document the PR9 second slice and cover the job contract in content-kitchen tests

## Tests
- npm run test:content-kitchen
- npm run typecheck
- npm run lint
- npm run validate:data
- npm run build
- git diff --check