### PR TITLE
Add PR9 enrichment job retry locks

### DIFF
--- a/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
+++ b/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
@@ -2089,6 +2089,16 @@ PR9 second implementation slice:
 - block stale job results when the published source revision, input snapshot hash, or target revision no longer matches
 - keep this slice local-only; later PR9 slices can attach it to storage, locks, resume behavior, and notifications
 
+PR9 third implementation slice:
+
+- add local job claim, lock expiry, retry, completion, and dead-letter helpers; do not attach them to Worker scanning yet
+- allow queued jobs to be claimed only when `nextAttemptAt` has arrived
+- allow running jobs to be claimed by another worker only after `lockedUntil` expires
+- increment `attemptCount` on each claim and clear locks after failure or completion
+- schedule retry delays from the configured backoff strategy
+- move jobs to `dead_letter` after `maxAttempts`
+- keep stale-result protection from the job contract unchanged
+
 ### PR10 — Review Artifact And Human Review
 
 Goal: make failed content actionable.

--- a/lib/puzzles/content-kitchen/enrichment-job.ts
+++ b/lib/puzzles/content-kitchen/enrichment-job.ts
@@ -2,6 +2,7 @@ import { DEFAULT_ANSWER_FIRST_SLA_CONFIG } from "./answer-first-sla";
 import { normalizeIdentityMatch, normalizeIdentityText } from "./identity";
 import type {
   AnswerFirstEnrichmentJob,
+  ContentKitchenIssueCode,
   EnrichmentJobState,
   SiteIndexHealthGuard,
 } from "./types";
@@ -25,11 +26,32 @@ export type CanApplyEnrichmentJobResultInput = {
   resultTargetRevision: string;
 };
 
+export type ClaimAnswerFirstEnrichmentJobInput = {
+  job: AnswerFirstEnrichmentJob;
+  workerId: string;
+  now: string;
+  lockMinutes?: number;
+};
+
+export type FailAnswerFirstEnrichmentJobInput = {
+  job: AnswerFirstEnrichmentJob;
+  now: string;
+  failureReasonCodes: ContentKitchenIssueCode[];
+};
+
+export type CompleteAnswerFirstEnrichmentJobInput = {
+  job: AnswerFirstEnrichmentJob;
+  now: string;
+};
+
 const ACTIVE_ENRICHMENT_JOB_STATES = new Set<EnrichmentJobState>([
   "queued",
   "running",
   "review_required",
 ]);
+const DEFAULT_ENRICHMENT_LOCK_MINUTES = 15;
+const BASE_RETRY_DELAY_MINUTES = 5;
+const MAX_RETRY_DELAY_MINUTES = 60;
 
 function parseTimestamp(value: string, fieldPath: string): number {
   const timestamp = Date.parse(value);
@@ -43,6 +65,10 @@ function addMinutes(timestamp: number, minutes: number): string {
   return new Date(timestamp + minutes * 60_000).toISOString();
 }
 
+function addMinutesNumber(timestamp: number, minutes: number): number {
+  return timestamp + minutes * 60_000;
+}
+
 function safeId(value: string): string {
   return normalizeIdentityMatch(value).replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "") || "unknown";
 }
@@ -53,6 +79,31 @@ function requireText(value: string, fieldPath: string): string {
     throw new Error(`${fieldPath} is required`);
   }
   return normalized;
+}
+
+function clearLock(job: AnswerFirstEnrichmentJob): AnswerFirstEnrichmentJob {
+  const { lockedBy: _lockedBy, lockedUntil: _lockedUntil, ...rest } = job;
+  return rest;
+}
+
+function mergeFailureReasonCodes(
+  existing: ContentKitchenIssueCode[],
+  incoming: ContentKitchenIssueCode[],
+): ContentKitchenIssueCode[] {
+  return [...new Set([...existing, ...incoming])];
+}
+
+export function calculateEnrichmentRetryDelayMinutes(
+  job: Pick<AnswerFirstEnrichmentJob, "attemptCount" | "backoffStrategy">,
+): number {
+  if (job.backoffStrategy === "fixed") {
+    return BASE_RETRY_DELAY_MINUTES;
+  }
+
+  return Math.min(
+    MAX_RETRY_DELAY_MINUTES,
+    BASE_RETRY_DELAY_MINUTES * 2 ** Math.max(0, job.attemptCount - 1),
+  );
 }
 
 export function buildEnrichmentJobIdempotencyKey(input: Pick<
@@ -106,6 +157,97 @@ export function createAnswerFirstEnrichmentJob(
 
 export function isActiveEnrichmentJob(job: Pick<AnswerFirstEnrichmentJob, "state">): boolean {
   return ACTIVE_ENRICHMENT_JOB_STATES.has(job.state);
+}
+
+export function isEnrichmentJobLockExpired(
+  job: Pick<AnswerFirstEnrichmentJob, "lockedUntil">,
+  now: string,
+): boolean {
+  if (!job.lockedUntil) {
+    return true;
+  }
+
+  return parseTimestamp(job.lockedUntil, "lockedUntil") <= parseTimestamp(now, "now");
+}
+
+export function canClaimAnswerFirstEnrichmentJob(
+  job: AnswerFirstEnrichmentJob,
+  now: string,
+): boolean {
+  if (job.attemptCount >= job.maxAttempts) {
+    return false;
+  }
+
+  if (job.state === "queued") {
+    return parseTimestamp(job.nextAttemptAt, "nextAttemptAt") <= parseTimestamp(now, "now");
+  }
+
+  if (job.state === "running") {
+    return isEnrichmentJobLockExpired(job, now);
+  }
+
+  return false;
+}
+
+export function claimAnswerFirstEnrichmentJob(
+  input: ClaimAnswerFirstEnrichmentJobInput,
+): AnswerFirstEnrichmentJob | null {
+  if (!canClaimAnswerFirstEnrichmentJob(input.job, input.now)) {
+    return null;
+  }
+
+  const now = parseTimestamp(input.now, "now");
+  const workerId = requireText(input.workerId, "workerId");
+  const lockMinutes = input.lockMinutes ?? DEFAULT_ENRICHMENT_LOCK_MINUTES;
+
+  return {
+    ...input.job,
+    state: "running",
+    updatedAt: new Date(now).toISOString(),
+    nextAttemptAt: new Date(now).toISOString(),
+    attemptCount: input.job.attemptCount + 1,
+    lockedBy: workerId,
+    lockedUntil: new Date(addMinutesNumber(now, lockMinutes)).toISOString(),
+  };
+}
+
+export function failAnswerFirstEnrichmentJob(
+  input: FailAnswerFirstEnrichmentJobInput,
+): AnswerFirstEnrichmentJob {
+  const now = parseTimestamp(input.now, "now");
+  const failed = {
+    ...clearLock(input.job),
+    updatedAt: new Date(now).toISOString(),
+    failureReasonCodes: mergeFailureReasonCodes(input.job.failureReasonCodes, input.failureReasonCodes),
+  };
+
+  if (input.job.attemptCount >= input.job.maxAttempts) {
+    return {
+      ...failed,
+      state: "dead_letter",
+      nextAttemptAt: new Date(now).toISOString(),
+      deadLetterAt: new Date(now).toISOString(),
+    };
+  }
+
+  const delayMinutes = calculateEnrichmentRetryDelayMinutes(input.job);
+  return {
+    ...failed,
+    state: "queued",
+    nextAttemptAt: new Date(addMinutesNumber(now, delayMinutes)).toISOString(),
+  };
+}
+
+export function completeAnswerFirstEnrichmentJob(
+  input: CompleteAnswerFirstEnrichmentJobInput,
+): AnswerFirstEnrichmentJob {
+  const now = new Date(parseTimestamp(input.now, "now")).toISOString();
+  return {
+    ...clearLock(input.job),
+    state: "completed",
+    updatedAt: now,
+    nextAttemptAt: now,
+  };
 }
 
 export function findActiveEnrichmentJobForTarget(

--- a/scripts/check-content-kitchen-contract.ts
+++ b/scripts/check-content-kitchen-contract.ts
@@ -18,9 +18,14 @@ import {
 } from "../lib/puzzles/content-kitchen/dictionary";
 import {
   canApplyEnrichmentJobResult,
+  canClaimAnswerFirstEnrichmentJob,
+  claimAnswerFirstEnrichmentJob,
+  completeAnswerFirstEnrichmentJob,
   createAnswerFirstEnrichmentJob,
+  failAnswerFirstEnrichmentJob,
   findActiveEnrichmentJobForTarget,
   isActiveEnrichmentJob,
+  isEnrichmentJobLockExpired,
 } from "../lib/puzzles/content-kitchen/enrichment-job";
 import { generateFullAnalysisClueFits } from "../lib/puzzles/content-kitchen/clue-fit-generator";
 import { generateFullAnalysisFaqItems } from "../lib/puzzles/content-kitchen/faq-generator";
@@ -1481,6 +1486,127 @@ function assertAnswerFirstEnrichmentJobContract() {
   );
 }
 
+function assertAnswerFirstEnrichmentJobRetryAndLock() {
+  const job = createAnswerFirstEnrichmentJob({
+    puzzleId: "pinpoint-901-2026-05-23",
+    sourceRevisionId: "rev-answer-first-901",
+    targetRevision: "rev-full-analysis-901",
+    inputSnapshotHash: "sha256:l1-901",
+    answerFirstPublishedAt: "2026-05-23T08:00:00.000Z",
+    now: "2026-05-23T08:05:00.000Z",
+    maxAttempts: 2,
+  });
+
+  assert.equal(
+    canClaimAnswerFirstEnrichmentJob(job, "2026-05-23T08:04:59.000Z"),
+    false,
+    "jobs should not be claimable before nextAttemptAt",
+  );
+  assert.equal(
+    canClaimAnswerFirstEnrichmentJob(job, "2026-05-23T08:05:00.000Z"),
+    true,
+    "queued jobs should be claimable at nextAttemptAt",
+  );
+
+  const firstClaim = claimAnswerFirstEnrichmentJob({
+    job,
+    workerId: "worker-a",
+    now: "2026-05-23T08:05:00.000Z",
+  });
+  assert.ok(firstClaim, "claiming a due queued job should return a running job");
+  assert.equal(firstClaim.state, "running", "claimed jobs should move to running");
+  assert.equal(firstClaim.attemptCount, 1, "claiming a job should increment attempt count");
+  assert.equal(firstClaim.lockedBy, "worker-a", "claimed jobs should store the worker id");
+  assert.equal(firstClaim.lockedUntil, "2026-05-23T08:20:00.000Z", "claimed jobs should default to a 15 minute lock");
+  assert.equal(
+    isEnrichmentJobLockExpired(firstClaim, "2026-05-23T08:19:59.000Z"),
+    false,
+    "fresh locks should not be expired",
+  );
+  assert.equal(
+    isEnrichmentJobLockExpired(firstClaim, "2026-05-23T08:20:00.000Z"),
+    true,
+    "locks should expire at lockedUntil",
+  );
+  assert.equal(
+    claimAnswerFirstEnrichmentJob({
+      job: firstClaim,
+      workerId: "worker-b",
+      now: "2026-05-23T08:10:00.000Z",
+    }),
+    null,
+    "running jobs with a live lock should not be claimed by another worker",
+  );
+
+  const failedOnce = failAnswerFirstEnrichmentJob({
+    job: firstClaim,
+    now: "2026-05-23T08:06:00.000Z",
+    failureReasonCodes: ["ANSWER_FIRST_OVER_SLA"],
+  });
+  assert.equal(failedOnce.state, "queued", "failed jobs with attempts remaining should return to queued");
+  assert.equal(failedOnce.nextAttemptAt, "2026-05-23T08:11:00.000Z", "first exponential retry should wait 5 minutes");
+  assert.equal(failedOnce.lockedBy, undefined, "failed jobs should clear lockedBy");
+  assert.equal(failedOnce.lockedUntil, undefined, "failed jobs should clear lockedUntil");
+  assert.deepEqual(failedOnce.failureReasonCodes, ["ANSWER_FIRST_OVER_SLA"], "failed jobs should keep reason codes");
+
+  const secondClaim = claimAnswerFirstEnrichmentJob({
+    job: failedOnce,
+    workerId: "worker-b",
+    now: "2026-05-23T08:11:00.000Z",
+  });
+  assert.ok(secondClaim, "retryable jobs should be claimable at their next attempt time");
+  assert.equal(secondClaim.attemptCount, 2, "second claim should increment attempt count again");
+
+  const deadLetter = failAnswerFirstEnrichmentJob({
+    job: secondClaim,
+    now: "2026-05-23T08:12:00.000Z",
+    failureReasonCodes: ["ANSWER_FIRST_REVIEW_REQUIRED", "ANSWER_FIRST_OVER_SLA"],
+  });
+  assert.equal(deadLetter.state, "dead_letter", "jobs should enter dead letter after max attempts");
+  assert.equal(deadLetter.deadLetterAt, "2026-05-23T08:12:00.000Z", "dead-letter jobs should store deadLetterAt");
+  assert.equal(deadLetter.nextAttemptAt, "2026-05-23T08:12:00.000Z", "dead-letter jobs should not schedule another retry");
+  assert.deepEqual(
+    deadLetter.failureReasonCodes,
+    ["ANSWER_FIRST_OVER_SLA", "ANSWER_FIRST_REVIEW_REQUIRED"],
+    "dead-letter jobs should dedupe failure reason codes",
+  );
+  assert.equal(
+    canClaimAnswerFirstEnrichmentJob(deadLetter, "2026-05-23T08:13:00.000Z"),
+    false,
+    "dead-letter jobs should not be claimable",
+  );
+
+  const expiredClaim = claimAnswerFirstEnrichmentJob({
+    job: {
+      ...job,
+      state: "running",
+      attemptCount: 1,
+      lockedBy: "worker-a",
+      lockedUntil: "2026-05-23T08:20:00.000Z",
+    },
+    workerId: "worker-b",
+    now: "2026-05-23T08:21:00.000Z",
+    lockMinutes: 10,
+  });
+  assert.ok(expiredClaim, "running jobs with expired locks should be claimable");
+  assert.equal(expiredClaim.lockedBy, "worker-b", "expired locks should be replaced by the new worker");
+  assert.equal(expiredClaim.lockedUntil, "2026-05-23T08:31:00.000Z", "custom lock minutes should be applied");
+  assert.equal(expiredClaim.attemptCount, 2, "expired-lock claims should count as a new attempt");
+
+  const completed = completeAnswerFirstEnrichmentJob({
+    job: expiredClaim,
+    now: "2026-05-23T08:22:00.000Z",
+  });
+  assert.equal(completed.state, "completed", "completed jobs should move to completed");
+  assert.equal(completed.lockedBy, undefined, "completed jobs should clear lockedBy");
+  assert.equal(completed.lockedUntil, undefined, "completed jobs should clear lockedUntil");
+  assert.equal(
+    canClaimAnswerFirstEnrichmentJob(completed, "2026-05-23T08:23:00.000Z"),
+    false,
+    "completed jobs should not be claimable",
+  );
+}
+
 async function main() {
   const fileNames = (await readdir(FIXTURE_DIR)).filter((fileName) => fileName.endsWith(".json")).sort();
   assert.ok(fileNames.length >= 6, "content kitchen should have at least 6 fixtures");
@@ -1518,6 +1644,7 @@ async function main() {
   assertLocalPipelineSmoke(dictionaries);
   assertAnswerFirstSlaClock();
   assertAnswerFirstEnrichmentJobContract();
+  assertAnswerFirstEnrichmentJobRetryAndLock();
   console.log(`content-kitchen contract fixtures passed (${fileNames.length} fixtures)`);
 }
 


### PR DESCRIPTION
## Summary
- add local claim, lock expiry, failure retry, completion, and dead-letter helpers for answer-first enrichment jobs
- keep queued jobs gated by nextAttemptAt and running jobs gated by lockedUntil
- cover retry scheduling, lock clearing, expired-lock claiming, completion, and max-attempt dead-letter behavior in content-kitchen tests

## Tests
- npm run test:content-kitchen
- npm run typecheck
- npm run lint
- npm run validate:data
- npm run build
- git diff --check