### PR TITLE
Add PR9 enrichment queue scanner

### DIFF
--- a/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
+++ b/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
@@ -2099,6 +2099,16 @@ PR9 third implementation slice:
 - move jobs to `dead_letter` after `maxAttempts`
 - keep stale-result protection from the job contract unchanged
 
+PR9 fourth implementation slice:
+
+- add a local queue scanner; do not attach it to durable storage or Worker cron yet
+- return due queued jobs and running jobs whose locks have expired
+- skip queued jobs whose `nextAttemptAt` is still in the future
+- skip running jobs whose lock is still active
+- skip completed, review-required, and dead-letter jobs
+- skip jobs that have reached `maxAttempts`
+- support a batch limit and mark otherwise-runnable overflow jobs as `over_limit`
+
 ### PR10 — Review Artifact And Human Review
 
 Goal: make failed content actionable.

--- a/lib/puzzles/content-kitchen/enrichment-job.ts
+++ b/lib/puzzles/content-kitchen/enrichment-job.ts
@@ -44,6 +44,27 @@ export type CompleteAnswerFirstEnrichmentJobInput = {
   now: string;
 };
 
+export type EnrichmentQueueSkipReason =
+  | "not_due"
+  | "lock_active"
+  | "max_attempts_reached"
+  | "terminal_state"
+  | "over_limit";
+
+export type ScanAnswerFirstEnrichmentQueueInput = {
+  jobs: AnswerFirstEnrichmentJob[];
+  now: string;
+  limit?: number;
+};
+
+export type ScanAnswerFirstEnrichmentQueueResult = {
+  runnableJobs: AnswerFirstEnrichmentJob[];
+  skippedJobs: Array<{
+    job: AnswerFirstEnrichmentJob;
+    reason: EnrichmentQueueSkipReason;
+  }>;
+};
+
 const ACTIVE_ENRICHMENT_JOB_STATES = new Set<EnrichmentJobState>([
   "queued",
   "running",
@@ -174,19 +195,7 @@ export function canClaimAnswerFirstEnrichmentJob(
   job: AnswerFirstEnrichmentJob,
   now: string,
 ): boolean {
-  if (job.attemptCount >= job.maxAttempts) {
-    return false;
-  }
-
-  if (job.state === "queued") {
-    return parseTimestamp(job.nextAttemptAt, "nextAttemptAt") <= parseTimestamp(now, "now");
-  }
-
-  if (job.state === "running") {
-    return isEnrichmentJobLockExpired(job, now);
-  }
-
-  return false;
+  return getEnrichmentQueueSkipReason(job, now) === null;
 }
 
 export function claimAnswerFirstEnrichmentJob(
@@ -247,6 +256,55 @@ export function completeAnswerFirstEnrichmentJob(
     state: "completed",
     updatedAt: now,
     nextAttemptAt: now,
+  };
+}
+
+export function getEnrichmentQueueSkipReason(
+  job: AnswerFirstEnrichmentJob,
+  now: string,
+): EnrichmentQueueSkipReason | null {
+  if (job.state === "completed" || job.state === "dead_letter" || job.state === "review_required") {
+    return "terminal_state";
+  }
+
+  if (job.attemptCount >= job.maxAttempts) {
+    return "max_attempts_reached";
+  }
+
+  if (job.state === "queued") {
+    return parseTimestamp(job.nextAttemptAt, "nextAttemptAt") <= parseTimestamp(now, "now") ? null : "not_due";
+  }
+
+  if (job.state === "running") {
+    return isEnrichmentJobLockExpired(job, now) ? null : "lock_active";
+  }
+
+  return "terminal_state";
+}
+
+export function scanAnswerFirstEnrichmentQueue(
+  input: ScanAnswerFirstEnrichmentQueueInput,
+): ScanAnswerFirstEnrichmentQueueResult {
+  const runnableJobs: AnswerFirstEnrichmentJob[] = [];
+  const skippedJobs: ScanAnswerFirstEnrichmentQueueResult["skippedJobs"] = [];
+  const limit = input.limit ?? input.jobs.length;
+
+  for (const job of input.jobs) {
+    const reason = getEnrichmentQueueSkipReason(job, input.now);
+    if (!reason && runnableJobs.length < limit) {
+      runnableJobs.push(job);
+      continue;
+    }
+
+    skippedJobs.push({
+      job,
+      reason: reason ?? "over_limit",
+    });
+  }
+
+  return {
+    runnableJobs,
+    skippedJobs,
   };
 }
 

--- a/scripts/check-content-kitchen-contract.ts
+++ b/scripts/check-content-kitchen-contract.ts
@@ -24,8 +24,10 @@ import {
   createAnswerFirstEnrichmentJob,
   failAnswerFirstEnrichmentJob,
   findActiveEnrichmentJobForTarget,
+  getEnrichmentQueueSkipReason,
   isActiveEnrichmentJob,
   isEnrichmentJobLockExpired,
+  scanAnswerFirstEnrichmentQueue,
 } from "../lib/puzzles/content-kitchen/enrichment-job";
 import { generateFullAnalysisClueFits } from "../lib/puzzles/content-kitchen/clue-fit-generator";
 import { generateFullAnalysisFaqItems } from "../lib/puzzles/content-kitchen/faq-generator";
@@ -1607,6 +1609,143 @@ function assertAnswerFirstEnrichmentJobRetryAndLock() {
   );
 }
 
+function assertAnswerFirstEnrichmentQueueScan() {
+  const dueQueued = createAnswerFirstEnrichmentJob({
+    puzzleId: "pinpoint-902-2026-05-23",
+    sourceRevisionId: "rev-answer-first-902",
+    targetRevision: "rev-full-analysis-902",
+    inputSnapshotHash: "sha256:l1-902",
+    answerFirstPublishedAt: "2026-05-23T08:00:00.000Z",
+    now: "2026-05-23T08:05:00.000Z",
+  });
+  const futureQueued = {
+    ...createAnswerFirstEnrichmentJob({
+      puzzleId: "pinpoint-903-2026-05-23",
+      sourceRevisionId: "rev-answer-first-903",
+      targetRevision: "rev-full-analysis-903",
+      inputSnapshotHash: "sha256:l1-903",
+      answerFirstPublishedAt: "2026-05-23T08:00:00.000Z",
+      now: "2026-05-23T08:05:00.000Z",
+    }),
+    nextAttemptAt: "2026-05-23T08:30:00.000Z",
+  };
+  const runningLocked = {
+    ...createAnswerFirstEnrichmentJob({
+      puzzleId: "pinpoint-904-2026-05-23",
+      sourceRevisionId: "rev-answer-first-904",
+      targetRevision: "rev-full-analysis-904",
+      inputSnapshotHash: "sha256:l1-904",
+      answerFirstPublishedAt: "2026-05-23T08:00:00.000Z",
+      now: "2026-05-23T08:05:00.000Z",
+    }),
+    state: "running" as const,
+    attemptCount: 1,
+    lockedBy: "worker-a",
+    lockedUntil: "2026-05-23T08:25:00.000Z",
+  };
+  const runningExpired = {
+    ...runningLocked,
+    puzzleId: "pinpoint-905-2026-05-23",
+    targetRevision: "rev-full-analysis-905",
+    lockedUntil: "2026-05-23T08:09:00.000Z",
+  };
+  const completed = {
+    ...dueQueued,
+    puzzleId: "pinpoint-906-2026-05-23",
+    targetRevision: "rev-full-analysis-906",
+    state: "completed" as const,
+  };
+  const deadLetter = {
+    ...dueQueued,
+    puzzleId: "pinpoint-907-2026-05-23",
+    targetRevision: "rev-full-analysis-907",
+    state: "dead_letter" as const,
+  };
+  const maxAttemptsReached = {
+    ...dueQueued,
+    puzzleId: "pinpoint-908-2026-05-23",
+    targetRevision: "rev-full-analysis-908",
+    attemptCount: 3,
+    maxAttempts: 3,
+  };
+
+  assert.equal(
+    getEnrichmentQueueSkipReason(dueQueued, "2026-05-23T08:10:00.000Z"),
+    null,
+    "due queued jobs should be runnable",
+  );
+  assert.equal(
+    getEnrichmentQueueSkipReason(futureQueued, "2026-05-23T08:10:00.000Z"),
+    "not_due",
+    "future queued jobs should be skipped as not due",
+  );
+  assert.equal(
+    getEnrichmentQueueSkipReason(runningLocked, "2026-05-23T08:10:00.000Z"),
+    "lock_active",
+    "running jobs with a live lock should be skipped",
+  );
+  assert.equal(
+    getEnrichmentQueueSkipReason(completed, "2026-05-23T08:10:00.000Z"),
+    "terminal_state",
+    "completed jobs should be skipped as terminal",
+  );
+  assert.equal(
+    getEnrichmentQueueSkipReason(deadLetter, "2026-05-23T08:10:00.000Z"),
+    "terminal_state",
+    "dead-letter jobs should be skipped as terminal",
+  );
+  assert.equal(
+    getEnrichmentQueueSkipReason(maxAttemptsReached, "2026-05-23T08:10:00.000Z"),
+    "max_attempts_reached",
+    "jobs at max attempts should be skipped",
+  );
+
+  const scan = scanAnswerFirstEnrichmentQueue({
+    jobs: [
+      dueQueued,
+      futureQueued,
+      runningLocked,
+      runningExpired,
+      completed,
+      deadLetter,
+      maxAttemptsReached,
+    ],
+    now: "2026-05-23T08:10:00.000Z",
+  });
+  assert.deepEqual(
+    scan.runnableJobs.map((job) => job.puzzleId),
+    ["pinpoint-902-2026-05-23", "pinpoint-905-2026-05-23"],
+    "queue scan should return due queued jobs and expired-lock running jobs",
+  );
+  assert.deepEqual(
+    scan.skippedJobs.map((entry) => [entry.job.puzzleId, entry.reason]),
+    [
+      ["pinpoint-903-2026-05-23", "not_due"],
+      ["pinpoint-904-2026-05-23", "lock_active"],
+      ["pinpoint-906-2026-05-23", "terminal_state"],
+      ["pinpoint-907-2026-05-23", "terminal_state"],
+      ["pinpoint-908-2026-05-23", "max_attempts_reached"],
+    ],
+    "queue scan should keep clear skip reasons",
+  );
+
+  const limitedScan = scanAnswerFirstEnrichmentQueue({
+    jobs: [dueQueued, runningExpired],
+    now: "2026-05-23T08:10:00.000Z",
+    limit: 1,
+  });
+  assert.deepEqual(
+    limitedScan.runnableJobs.map((job) => job.puzzleId),
+    ["pinpoint-902-2026-05-23"],
+    "queue scan limit should cap runnable jobs",
+  );
+  assert.deepEqual(
+    limitedScan.skippedJobs.map((entry) => [entry.job.puzzleId, entry.reason]),
+    [["pinpoint-905-2026-05-23", "over_limit"]],
+    "queue scan should explain jobs skipped only because the batch limit was reached",
+  );
+}
+
 async function main() {
   const fileNames = (await readdir(FIXTURE_DIR)).filter((fileName) => fileName.endsWith(".json")).sort();
   assert.ok(fileNames.length >= 6, "content kitchen should have at least 6 fixtures");
@@ -1645,6 +1784,7 @@ async function main() {
   assertAnswerFirstSlaClock();
   assertAnswerFirstEnrichmentJobContract();
   assertAnswerFirstEnrichmentJobRetryAndLock();
+  assertAnswerFirstEnrichmentQueueScan();
   console.log(`content-kitchen contract fixtures passed (${fileNames.length} fixtures)`);
 }
 


### PR DESCRIPTION
## Summary
- add a local queue scanner for answer-first enrichment jobs
- return due queued jobs and expired-lock running jobs, with clear skip reasons for not-due, lock-active, terminal, max-attempt, and over-limit jobs
- cover scanner behavior in the content-kitchen contract test and document the PR9 fourth slice

## Tests
- npm run test:content-kitchen
- npm run typecheck
- npm run lint
- npm run validate:data
- npm run build
- git diff --check