### PR TITLE
Add PR9 enrichment state advancement

### DIFF
--- a/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
+++ b/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
@@ -2109,6 +2109,16 @@ PR9 fourth implementation slice:
 - skip jobs that have reached `maxAttempts`
 - support a batch limit and mark otherwise-runnable overflow jobs as `over_limit`
 
+PR9 fifth implementation slice:
+
+- add a local job state advancer; do not attach it to durable storage, Worker cron, or Feishu notifications yet
+- keep fresh jobs unchanged before the 30-minute target
+- mark jobs past 30 minutes with `ANSWER_FIRST_OVER_SLA` while preserving the current queue state
+- move unresolved jobs past 60 minutes to `review_required` and clear locks
+- move unresolved jobs past 6 hours to `dead_letter` and set `deadLetterAt`
+- preserve completed and already-dead-letter jobs unchanged
+- return the issue codes newly added by the advancement step so later artifacts/notifications can explain the change
+
 ### PR10 — Review Artifact And Human Review
 
 Goal: make failed content actionable.

--- a/lib/puzzles/content-kitchen/enrichment-job.ts
+++ b/lib/puzzles/content-kitchen/enrichment-job.ts
@@ -44,6 +44,23 @@ export type CompleteAnswerFirstEnrichmentJobInput = {
   now: string;
 };
 
+export type AdvanceAnswerFirstEnrichmentJobStateInput = {
+  job: AnswerFirstEnrichmentJob;
+  now: string;
+};
+
+export type EnrichmentJobStateAdvanceTransition =
+  | "unchanged"
+  | "marked_over_sla"
+  | "review_required"
+  | "dead_letter";
+
+export type AdvanceAnswerFirstEnrichmentJobStateResult = {
+  job: AnswerFirstEnrichmentJob;
+  transition: EnrichmentJobStateAdvanceTransition;
+  issueCodesAdded: ContentKitchenIssueCode[];
+};
+
 export type EnrichmentQueueSkipReason =
   | "not_due"
   | "lock_active"
@@ -112,6 +129,24 @@ function mergeFailureReasonCodes(
   incoming: ContentKitchenIssueCode[],
 ): ContentKitchenIssueCode[] {
   return [...new Set([...existing, ...incoming])];
+}
+
+function addedFailureReasonCodes(
+  before: ContentKitchenIssueCode[],
+  after: ContentKitchenIssueCode[],
+): ContentKitchenIssueCode[] {
+  const beforeSet = new Set(before);
+  return after.filter((issueCode) => !beforeSet.has(issueCode));
+}
+
+function withFailureReasonCodes(
+  job: AnswerFirstEnrichmentJob,
+  issueCodes: ContentKitchenIssueCode[],
+): AnswerFirstEnrichmentJob {
+  return {
+    ...job,
+    failureReasonCodes: mergeFailureReasonCodes(job.failureReasonCodes, issueCodes),
+  };
 }
 
 export function calculateEnrichmentRetryDelayMinutes(
@@ -256,6 +291,80 @@ export function completeAnswerFirstEnrichmentJob(
     state: "completed",
     updatedAt: now,
     nextAttemptAt: now,
+  };
+}
+
+export function advanceAnswerFirstEnrichmentJobState(
+  input: AdvanceAnswerFirstEnrichmentJobStateInput,
+): AdvanceAnswerFirstEnrichmentJobStateResult {
+  const now = parseTimestamp(input.now, "now");
+  const nowIso = new Date(now).toISOString();
+
+  if (input.job.state === "completed" || input.job.state === "dead_letter") {
+    return {
+      job: input.job,
+      transition: "unchanged",
+      issueCodesAdded: [],
+    };
+  }
+
+  if (parseTimestamp(input.job.highPriorityAlertAt, "highPriorityAlertAt") <= now) {
+    const withReasons = withFailureReasonCodes(input.job, [
+      "ANSWER_FIRST_OVER_SLA",
+      "ANSWER_FIRST_REVIEW_REQUIRED",
+      "ANSWER_FIRST_HIGH_PRIORITY_ALERT",
+    ]);
+    const advanced = {
+      ...clearLock(withReasons),
+      state: "dead_letter" as const,
+      updatedAt: nowIso,
+      nextAttemptAt: nowIso,
+      deadLetterAt: nowIso,
+    };
+
+    return {
+      job: advanced,
+      transition: "dead_letter",
+      issueCodesAdded: addedFailureReasonCodes(input.job.failureReasonCodes, advanced.failureReasonCodes),
+    };
+  }
+
+  if (parseTimestamp(input.job.reviewRequiredAt, "reviewRequiredAt") <= now) {
+    const withReasons = withFailureReasonCodes(input.job, [
+      "ANSWER_FIRST_OVER_SLA",
+      "ANSWER_FIRST_REVIEW_REQUIRED",
+    ]);
+    const advanced = {
+      ...clearLock(withReasons),
+      state: "review_required" as const,
+      updatedAt: nowIso,
+      nextAttemptAt: nowIso,
+    };
+
+    return {
+      job: advanced,
+      transition: "review_required",
+      issueCodesAdded: addedFailureReasonCodes(input.job.failureReasonCodes, advanced.failureReasonCodes),
+    };
+  }
+
+  if (parseTimestamp(input.job.targetFullAnalysisAt, "targetFullAnalysisAt") <= now) {
+    const advanced = {
+      ...withFailureReasonCodes(input.job, ["ANSWER_FIRST_OVER_SLA"]),
+      updatedAt: nowIso,
+    };
+
+    return {
+      job: advanced,
+      transition: "marked_over_sla",
+      issueCodesAdded: addedFailureReasonCodes(input.job.failureReasonCodes, advanced.failureReasonCodes),
+    };
+  }
+
+  return {
+    job: input.job,
+    transition: "unchanged",
+    issueCodesAdded: [],
   };
 }
 

--- a/scripts/check-content-kitchen-contract.ts
+++ b/scripts/check-content-kitchen-contract.ts
@@ -17,6 +17,7 @@ import {
   readContentKitchenDictionaryDiffs,
 } from "../lib/puzzles/content-kitchen/dictionary";
 import {
+  advanceAnswerFirstEnrichmentJobState,
   canApplyEnrichmentJobResult,
   canClaimAnswerFirstEnrichmentJob,
   claimAnswerFirstEnrichmentJob,
@@ -1746,6 +1747,97 @@ function assertAnswerFirstEnrichmentQueueScan() {
   );
 }
 
+function assertAnswerFirstEnrichmentStateAdvance() {
+  const job = createAnswerFirstEnrichmentJob({
+    puzzleId: "pinpoint-909-2026-05-23",
+    sourceRevisionId: "rev-answer-first-909",
+    targetRevision: "rev-full-analysis-909",
+    inputSnapshotHash: "sha256:l1-909",
+    answerFirstPublishedAt: "2026-05-23T08:00:00.000Z",
+    now: "2026-05-23T08:05:00.000Z",
+  });
+
+  const fresh = advanceAnswerFirstEnrichmentJobState({
+    job,
+    now: "2026-05-23T08:29:00.000Z",
+  });
+  assert.equal(fresh.transition, "unchanged", "fresh jobs should not advance");
+  assert.equal(fresh.job.state, "queued", "fresh jobs should stay queued");
+  assert.deepEqual(fresh.issueCodesAdded, [], "fresh jobs should not add issue codes");
+
+  const overSla = advanceAnswerFirstEnrichmentJobState({
+    job,
+    now: "2026-05-23T08:31:00.000Z",
+  });
+  assert.equal(overSla.transition, "marked_over_sla", "jobs past 30 minutes should be marked over SLA");
+  assert.equal(overSla.job.state, "queued", "over-SLA jobs should keep their current queue state before review time");
+  assert.equal(overSla.job.updatedAt, "2026-05-23T08:31:00.000Z", "over-SLA jobs should update updatedAt");
+  assert.deepEqual(overSla.issueCodesAdded, ["ANSWER_FIRST_OVER_SLA"], "over-SLA jobs should add one issue code");
+  assert.deepEqual(overSla.job.failureReasonCodes, ["ANSWER_FIRST_OVER_SLA"], "over-SLA jobs should keep failure reasons");
+
+  const runningJob = {
+    ...job,
+    state: "running" as const,
+    attemptCount: 1,
+    lockedBy: "worker-a",
+    lockedUntil: "2026-05-23T09:10:00.000Z",
+  };
+  const reviewRequired = advanceAnswerFirstEnrichmentJobState({
+    job: runningJob,
+    now: "2026-05-23T09:01:00.000Z",
+  });
+  assert.equal(reviewRequired.transition, "review_required", "jobs past 60 minutes should enter review");
+  assert.equal(reviewRequired.job.state, "review_required", "review-stage jobs should use review_required state");
+  assert.equal(reviewRequired.job.lockedBy, undefined, "review-stage jobs should clear lockedBy");
+  assert.equal(reviewRequired.job.lockedUntil, undefined, "review-stage jobs should clear lockedUntil");
+  assert.deepEqual(
+    reviewRequired.job.failureReasonCodes,
+    ["ANSWER_FIRST_OVER_SLA", "ANSWER_FIRST_REVIEW_REQUIRED"],
+    "review-stage jobs should keep over-SLA and review reason codes",
+  );
+  assert.deepEqual(
+    reviewRequired.issueCodesAdded,
+    ["ANSWER_FIRST_OVER_SLA", "ANSWER_FIRST_REVIEW_REQUIRED"],
+    "review-stage jobs should report newly added issue codes",
+  );
+
+  const highPriority = advanceAnswerFirstEnrichmentJobState({
+    job: reviewRequired.job,
+    now: "2026-05-23T14:01:00.000Z",
+  });
+  assert.equal(highPriority.transition, "dead_letter", "jobs past six hours should enter dead letter");
+  assert.equal(highPriority.job.state, "dead_letter", "six-hour unresolved jobs should use dead_letter state");
+  assert.equal(highPriority.job.deadLetterAt, "2026-05-23T14:01:00.000Z", "dead-letter jobs should set deadLetterAt");
+  assert.deepEqual(
+    highPriority.job.failureReasonCodes,
+    ["ANSWER_FIRST_OVER_SLA", "ANSWER_FIRST_REVIEW_REQUIRED", "ANSWER_FIRST_HIGH_PRIORITY_ALERT"],
+    "dead-letter jobs should keep all SLA reason codes",
+  );
+  assert.deepEqual(
+    highPriority.issueCodesAdded,
+    ["ANSWER_FIRST_HIGH_PRIORITY_ALERT"],
+    "dead-letter transition should report only newly added issue codes",
+  );
+
+  const completed = completeAnswerFirstEnrichmentJob({
+    job,
+    now: "2026-05-23T08:20:00.000Z",
+  });
+  const completedAdvance = advanceAnswerFirstEnrichmentJobState({
+    job: completed,
+    now: "2026-05-23T14:01:00.000Z",
+  });
+  assert.equal(completedAdvance.transition, "unchanged", "completed jobs should not be advanced by SLA");
+  assert.equal(completedAdvance.job.state, "completed", "completed jobs should stay completed");
+
+  const deadLetterAdvance = advanceAnswerFirstEnrichmentJobState({
+    job: highPriority.job,
+    now: "2026-05-23T15:00:00.000Z",
+  });
+  assert.equal(deadLetterAdvance.transition, "unchanged", "dead-letter jobs should not be advanced again");
+  assert.equal(deadLetterAdvance.job.deadLetterAt, "2026-05-23T14:01:00.000Z", "deadLetterAt should stay stable");
+}
+
 async function main() {
   const fileNames = (await readdir(FIXTURE_DIR)).filter((fileName) => fileName.endsWith(".json")).sort();
   assert.ok(fileNames.length >= 6, "content kitchen should have at least 6 fixtures");
@@ -1785,6 +1877,7 @@ async function main() {
   assertAnswerFirstEnrichmentJobContract();
   assertAnswerFirstEnrichmentJobRetryAndLock();
   assertAnswerFirstEnrichmentQueueScan();
+  assertAnswerFirstEnrichmentStateAdvance();
   console.log(`content-kitchen contract fixtures passed (${fileNames.length} fixtures)`);
 }
 


### PR DESCRIPTION
## Summary
- add a local state advancer for answer-first enrichment jobs
- mark jobs over SLA after 30 minutes, move unresolved jobs to review after 60 minutes, and move six-hour unresolved jobs to dead letter
- preserve completed and already-dead-letter jobs, clear locks during review/dead-letter transitions, and report newly added issue codes

## Tests
- npm run test:content-kitchen
- npm run typecheck
- npm run lint
- npm run validate:data
- npm run build
- git diff --check