### PR TITLE
Add PR9 enrichment worker tick

### DIFF
--- a/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
+++ b/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
@@ -2119,6 +2119,13 @@ PR9 fifth implementation slice:
 - preserve completed and already-dead-letter jobs unchanged
 - return the issue codes newly added by the advancement step so later artifacts/notifications can explain the change
 
+PR9 sixth implementation slice:
+
+- add a local worker tick that advances job states, scans the queue, and claims runnable jobs in one deterministic pass
+- return updated jobs, claimed jobs, skipped jobs, and state advancement summaries
+- claim jobs only after state advancement so review/dead-letter transitions happen before work is picked up
+- keep this slice local-only; do not attach it to durable storage, Worker cron, or Feishu notifications yet
+
 ### PR10 — Review Artifact And Human Review
 
 Goal: make failed content actionable.

--- a/lib/puzzles/content-kitchen/enrichment-job.ts
+++ b/lib/puzzles/content-kitchen/enrichment-job.ts
@@ -82,6 +82,21 @@ export type ScanAnswerFirstEnrichmentQueueResult = {
   }>;
 };
 
+export type RunAnswerFirstEnrichmentWorkerTickInput = {
+  jobs: AnswerFirstEnrichmentJob[];
+  now: string;
+  workerId: string;
+  limit?: number;
+  lockMinutes?: number;
+};
+
+export type RunAnswerFirstEnrichmentWorkerTickResult = {
+  updatedJobs: AnswerFirstEnrichmentJob[];
+  claimedJobs: AnswerFirstEnrichmentJob[];
+  skippedJobs: ScanAnswerFirstEnrichmentQueueResult["skippedJobs"];
+  stateAdvancements: AdvanceAnswerFirstEnrichmentJobStateResult[];
+};
+
 const ACTIVE_ENRICHMENT_JOB_STATES = new Set<EnrichmentJobState>([
   "queued",
   "running",
@@ -414,6 +429,45 @@ export function scanAnswerFirstEnrichmentQueue(
   return {
     runnableJobs,
     skippedJobs,
+  };
+}
+
+export function runAnswerFirstEnrichmentWorkerTick(
+  input: RunAnswerFirstEnrichmentWorkerTickInput,
+): RunAnswerFirstEnrichmentWorkerTickResult {
+  const workerId = requireText(input.workerId, "workerId");
+  const stateAdvancements = input.jobs.map((job) => advanceAnswerFirstEnrichmentJobState({
+    job,
+    now: input.now,
+  }));
+  const advancedJobs = stateAdvancements.map((result) => result.job);
+  const scan = scanAnswerFirstEnrichmentQueue({
+    jobs: advancedJobs,
+    now: input.now,
+    limit: input.limit,
+  });
+  const claimedJobs: AnswerFirstEnrichmentJob[] = [];
+  const claimedByJobId = new Map<string, AnswerFirstEnrichmentJob>();
+
+  for (const job of scan.runnableJobs) {
+    const claimed = claimAnswerFirstEnrichmentJob({
+      job,
+      now: input.now,
+      workerId,
+      lockMinutes: input.lockMinutes,
+    });
+
+    if (claimed) {
+      claimedJobs.push(claimed);
+      claimedByJobId.set(job.jobId, claimed);
+    }
+  }
+
+  return {
+    updatedJobs: advancedJobs.map((job) => claimedByJobId.get(job.jobId) ?? job),
+    claimedJobs,
+    skippedJobs: scan.skippedJobs,
+    stateAdvancements,
   };
 }
 

--- a/scripts/check-content-kitchen-contract.ts
+++ b/scripts/check-content-kitchen-contract.ts
@@ -28,6 +28,7 @@ import {
   getEnrichmentQueueSkipReason,
   isActiveEnrichmentJob,
   isEnrichmentJobLockExpired,
+  runAnswerFirstEnrichmentWorkerTick,
   scanAnswerFirstEnrichmentQueue,
 } from "../lib/puzzles/content-kitchen/enrichment-job";
 import { generateFullAnalysisClueFits } from "../lib/puzzles/content-kitchen/clue-fit-generator";
@@ -1838,6 +1839,133 @@ function assertAnswerFirstEnrichmentStateAdvance() {
   assert.equal(deadLetterAdvance.job.deadLetterAt, "2026-05-23T14:01:00.000Z", "deadLetterAt should stay stable");
 }
 
+function assertAnswerFirstEnrichmentWorkerTick() {
+  const dueQueued = createAnswerFirstEnrichmentJob({
+    puzzleId: "pinpoint-910-2026-05-23",
+    sourceRevisionId: "rev-answer-first-910",
+    targetRevision: "rev-full-analysis-910",
+    inputSnapshotHash: "sha256:l1-910",
+    answerFirstPublishedAt: "2026-05-23T08:45:00.000Z",
+    now: "2026-05-23T08:55:00.000Z",
+  });
+  const futureQueued = {
+    ...createAnswerFirstEnrichmentJob({
+      puzzleId: "pinpoint-911-2026-05-23",
+      sourceRevisionId: "rev-answer-first-911",
+      targetRevision: "rev-full-analysis-911",
+      inputSnapshotHash: "sha256:l1-911",
+      answerFirstPublishedAt: "2026-05-23T08:45:00.000Z",
+      now: "2026-05-23T08:55:00.000Z",
+    }),
+    nextAttemptAt: "2026-05-23T09:30:00.000Z",
+  };
+  const reviewDue = createAnswerFirstEnrichmentJob({
+    puzzleId: "pinpoint-912-2026-05-23",
+    sourceRevisionId: "rev-answer-first-912",
+    targetRevision: "rev-full-analysis-912",
+    inputSnapshotHash: "sha256:l1-912",
+    answerFirstPublishedAt: "2026-05-23T08:00:00.000Z",
+    now: "2026-05-23T08:05:00.000Z",
+  });
+  const expiredRunning = {
+    ...createAnswerFirstEnrichmentJob({
+      puzzleId: "pinpoint-913-2026-05-23",
+      sourceRevisionId: "rev-answer-first-913",
+      targetRevision: "rev-full-analysis-913",
+      inputSnapshotHash: "sha256:l1-913",
+      answerFirstPublishedAt: "2026-05-23T08:45:00.000Z",
+      now: "2026-05-23T08:55:00.000Z",
+    }),
+    state: "running" as const,
+    attemptCount: 1,
+    lockedBy: "worker-old",
+    lockedUntil: "2026-05-23T09:00:00.000Z",
+  };
+
+  const tick = runAnswerFirstEnrichmentWorkerTick({
+    jobs: [dueQueued, futureQueued, reviewDue, expiredRunning],
+    now: "2026-05-23T09:01:00.000Z",
+    workerId: "worker-tick",
+    lockMinutes: 10,
+    limit: 2,
+  });
+
+  assert.deepEqual(
+    tick.claimedJobs.map((job) => job.puzzleId),
+    ["pinpoint-910-2026-05-23", "pinpoint-913-2026-05-23"],
+    "worker tick should claim due queued jobs and expired-lock running jobs",
+  );
+  assert.deepEqual(
+    tick.claimedJobs.map((job) => [job.state, job.lockedBy, job.lockedUntil]),
+    [
+      ["running", "worker-tick", "2026-05-23T09:11:00.000Z"],
+      ["running", "worker-tick", "2026-05-23T09:11:00.000Z"],
+    ],
+    "worker tick should lock claimed jobs for the requested worker",
+  );
+  assert.deepEqual(
+    tick.claimedJobs.map((job) => [job.puzzleId, job.attemptCount]),
+    [
+      ["pinpoint-910-2026-05-23", 1],
+      ["pinpoint-913-2026-05-23", 2],
+    ],
+    "worker tick should increment attempts when claiming jobs",
+  );
+  assert.deepEqual(
+    tick.skippedJobs.map((entry) => [entry.job.puzzleId, entry.reason]),
+    [
+      ["pinpoint-911-2026-05-23", "not_due"],
+      ["pinpoint-912-2026-05-23", "terminal_state"],
+    ],
+    "worker tick should report skipped jobs after state advancement",
+  );
+  assert.deepEqual(
+    tick.stateAdvancements.map((result) => [result.job.puzzleId, result.transition]),
+    [
+      ["pinpoint-910-2026-05-23", "unchanged"],
+      ["pinpoint-911-2026-05-23", "unchanged"],
+      ["pinpoint-912-2026-05-23", "review_required"],
+      ["pinpoint-913-2026-05-23", "unchanged"],
+    ],
+    "worker tick should advance states before scanning the queue",
+  );
+
+  const updatedByPuzzleId = new Map(tick.updatedJobs.map((job) => [job.puzzleId, job]));
+  assert.equal(
+    updatedByPuzzleId.get("pinpoint-912-2026-05-23")?.state,
+    "review_required",
+    "worker tick should keep review-required advancement in updated jobs",
+  );
+  assert.equal(
+    updatedByPuzzleId.get("pinpoint-912-2026-05-23")?.lockedBy,
+    undefined,
+    "worker tick should clear locks for review-required jobs",
+  );
+  assert.equal(
+    updatedByPuzzleId.get("pinpoint-910-2026-05-23")?.lockedBy,
+    "worker-tick",
+    "worker tick should return claimed queued jobs in updated jobs",
+  );
+
+  const limitedTick = runAnswerFirstEnrichmentWorkerTick({
+    jobs: [dueQueued, expiredRunning],
+    now: "2026-05-23T09:01:00.000Z",
+    workerId: "worker-tick",
+    lockMinutes: 10,
+    limit: 1,
+  });
+  assert.deepEqual(
+    limitedTick.claimedJobs.map((job) => job.puzzleId),
+    ["pinpoint-910-2026-05-23"],
+    "worker tick limit should cap claimed jobs",
+  );
+  assert.deepEqual(
+    limitedTick.skippedJobs.map((entry) => [entry.job.puzzleId, entry.reason]),
+    [["pinpoint-913-2026-05-23", "over_limit"]],
+    "worker tick should keep over-limit skip reasons from the queue scanner",
+  );
+}
+
 async function main() {
   const fileNames = (await readdir(FIXTURE_DIR)).filter((fileName) => fileName.endsWith(".json")).sort();
   assert.ok(fileNames.length >= 6, "content kitchen should have at least 6 fixtures");
@@ -1878,6 +2006,7 @@ async function main() {
   assertAnswerFirstEnrichmentJobRetryAndLock();
   assertAnswerFirstEnrichmentQueueScan();
   assertAnswerFirstEnrichmentStateAdvance();
+  assertAnswerFirstEnrichmentWorkerTick();
   console.log(`content-kitchen contract fixtures passed (${fileNames.length} fixtures)`);
 }
 


### PR DESCRIPTION
## Summary
- add a local answer-first enrichment worker tick that advances job state, scans the queue, and claims runnable jobs
- return updated jobs, claimed jobs, skipped jobs, and state advancement summaries
- document the PR9 sixth implementation slice

## Checks
- npm run test:content-kitchen
- npm run typecheck
- git diff --check
- npm run lint
- npm run validate:data
- npm run build