### PR TITLE
Add PR9 enrichment job store adapter

### DIFF
--- a/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
+++ b/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
@@ -2126,6 +2126,13 @@ PR9 sixth implementation slice:
 - claim jobs only after state advancement so review/dead-letter transitions happen before work is picked up
 - keep this slice local-only; do not attach it to durable storage, Worker cron, or Feishu notifications yet
 
+PR9 seventh implementation slice:
+
+- add a local job store interface so worker ticks can load jobs and write updated jobs through one boundary
+- include an in-memory store for contract tests and local dry runs only
+- make the store return cloned job objects so tests do not accidentally mutate persisted state
+- keep the final durable backend undecided; do not attach this slice to production storage, Worker cron, or Feishu notifications yet
+
 ### PR10 — Review Artifact And Human Review
 
 Goal: make failed content actionable.

--- a/lib/puzzles/content-kitchen/enrichment-job-store.ts
+++ b/lib/puzzles/content-kitchen/enrichment-job-store.ts
@@ -1,0 +1,71 @@
+import {
+  runAnswerFirstEnrichmentWorkerTick,
+  type RunAnswerFirstEnrichmentWorkerTickInput,
+  type RunAnswerFirstEnrichmentWorkerTickResult,
+} from "./enrichment-job";
+import type { AnswerFirstEnrichmentJob } from "./types";
+
+export type AnswerFirstEnrichmentJobStore = {
+  listAnswerFirstEnrichmentJobs: () => Promise<AnswerFirstEnrichmentJob[]>;
+  upsertAnswerFirstEnrichmentJobs: (jobs: AnswerFirstEnrichmentJob[]) => Promise<void>;
+};
+
+export type InMemoryAnswerFirstEnrichmentJobStore = AnswerFirstEnrichmentJobStore & {
+  snapshot: () => AnswerFirstEnrichmentJob[];
+};
+
+export type RunAnswerFirstEnrichmentWorkerTickFromStoreInput = Omit<
+  RunAnswerFirstEnrichmentWorkerTickInput,
+  "jobs"
+> & {
+  store: AnswerFirstEnrichmentJobStore;
+};
+
+function cloneAnswerFirstEnrichmentJob(job: AnswerFirstEnrichmentJob): AnswerFirstEnrichmentJob {
+  return {
+    ...job,
+    failureReasonCodes: [...job.failureReasonCodes],
+  };
+}
+
+export function createInMemoryAnswerFirstEnrichmentJobStore(
+  initialJobs: AnswerFirstEnrichmentJob[] = [],
+): InMemoryAnswerFirstEnrichmentJobStore {
+  const jobsById = new Map<string, AnswerFirstEnrichmentJob>();
+
+  for (const job of initialJobs) {
+    jobsById.set(job.jobId, cloneAnswerFirstEnrichmentJob(job));
+  }
+
+  const snapshot = (): AnswerFirstEnrichmentJob[] => {
+    return [...jobsById.values()].map(cloneAnswerFirstEnrichmentJob);
+  };
+
+  return {
+    async listAnswerFirstEnrichmentJobs() {
+      return snapshot();
+    },
+    async upsertAnswerFirstEnrichmentJobs(jobs) {
+      for (const job of jobs) {
+        jobsById.set(job.jobId, cloneAnswerFirstEnrichmentJob(job));
+      }
+    },
+    snapshot,
+  };
+}
+
+export async function runAnswerFirstEnrichmentWorkerTickFromStore(
+  input: RunAnswerFirstEnrichmentWorkerTickFromStoreInput,
+): Promise<RunAnswerFirstEnrichmentWorkerTickResult> {
+  const jobs = await input.store.listAnswerFirstEnrichmentJobs();
+  const tick = runAnswerFirstEnrichmentWorkerTick({
+    jobs,
+    now: input.now,
+    workerId: input.workerId,
+    limit: input.limit,
+    lockMinutes: input.lockMinutes,
+  });
+
+  await input.store.upsertAnswerFirstEnrichmentJobs(tick.updatedJobs);
+  return tick;
+}

--- a/scripts/check-content-kitchen-contract.ts
+++ b/scripts/check-content-kitchen-contract.ts
@@ -31,6 +31,10 @@ import {
   runAnswerFirstEnrichmentWorkerTick,
   scanAnswerFirstEnrichmentQueue,
 } from "../lib/puzzles/content-kitchen/enrichment-job";
+import {
+  createInMemoryAnswerFirstEnrichmentJobStore,
+  runAnswerFirstEnrichmentWorkerTickFromStore,
+} from "../lib/puzzles/content-kitchen/enrichment-job-store";
 import { generateFullAnalysisClueFits } from "../lib/puzzles/content-kitchen/clue-fit-generator";
 import { generateFullAnalysisFaqItems } from "../lib/puzzles/content-kitchen/faq-generator";
 import { generateFullAnalysisFalseStart } from "../lib/puzzles/content-kitchen/false-start-generator";
@@ -1966,6 +1970,102 @@ function assertAnswerFirstEnrichmentWorkerTick() {
   );
 }
 
+async function assertAnswerFirstEnrichmentJobStoreAdapter() {
+  const dueQueued = createAnswerFirstEnrichmentJob({
+    puzzleId: "pinpoint-914-2026-05-23",
+    sourceRevisionId: "rev-answer-first-914",
+    targetRevision: "rev-full-analysis-914",
+    inputSnapshotHash: "sha256:l1-914",
+    answerFirstPublishedAt: "2026-05-23T08:45:00.000Z",
+    now: "2026-05-23T08:55:00.000Z",
+  });
+  const reviewDue = createAnswerFirstEnrichmentJob({
+    puzzleId: "pinpoint-915-2026-05-23",
+    sourceRevisionId: "rev-answer-first-915",
+    targetRevision: "rev-full-analysis-915",
+    inputSnapshotHash: "sha256:l1-915",
+    answerFirstPublishedAt: "2026-05-23T08:00:00.000Z",
+    now: "2026-05-23T08:05:00.000Z",
+  });
+  const store = createInMemoryAnswerFirstEnrichmentJobStore([dueQueued, reviewDue]);
+
+  const loaded = await store.listAnswerFirstEnrichmentJobs();
+  loaded[0].state = "dead_letter";
+  loaded[0].failureReasonCodes.push("ANSWER_FIRST_HIGH_PRIORITY_ALERT");
+
+  const unchangedSnapshot = store.snapshot();
+  assert.equal(
+    unchangedSnapshot[0].state,
+    "queued",
+    "in-memory job store should return cloned jobs from list",
+  );
+  assert.deepEqual(
+    unchangedSnapshot[0].failureReasonCodes,
+    [],
+    "in-memory job store should protect stored failure reasons from caller mutation",
+  );
+
+  const tick = await runAnswerFirstEnrichmentWorkerTickFromStore({
+    store,
+    now: "2026-05-23T09:01:00.000Z",
+    workerId: "worker-store",
+    lockMinutes: 12,
+  });
+
+  assert.deepEqual(
+    tick.claimedJobs.map((job) => job.puzzleId),
+    ["pinpoint-914-2026-05-23"],
+    "store-backed worker tick should claim due jobs loaded from the store",
+  );
+  assert.deepEqual(
+    tick.skippedJobs.map((entry) => [entry.job.puzzleId, entry.reason]),
+    [["pinpoint-915-2026-05-23", "terminal_state"]],
+    "store-backed worker tick should skip jobs moved to review during advancement",
+  );
+
+  const storedAfterTick = store.snapshot();
+  const storedByPuzzleId = new Map(storedAfterTick.map((job) => [job.puzzleId, job]));
+  assert.equal(
+    storedByPuzzleId.get("pinpoint-914-2026-05-23")?.state,
+    "running",
+    "store-backed worker tick should write claimed jobs back to the store",
+  );
+  assert.equal(
+    storedByPuzzleId.get("pinpoint-914-2026-05-23")?.lockedBy,
+    "worker-store",
+    "store-backed worker tick should persist the worker lock",
+  );
+  assert.equal(
+    storedByPuzzleId.get("pinpoint-914-2026-05-23")?.lockedUntil,
+    "2026-05-23T09:13:00.000Z",
+    "store-backed worker tick should persist the requested lock window",
+  );
+  assert.equal(
+    storedByPuzzleId.get("pinpoint-915-2026-05-23")?.state,
+    "review_required",
+    "store-backed worker tick should write review-required advancement back to the store",
+  );
+  assert.deepEqual(
+    storedByPuzzleId.get("pinpoint-915-2026-05-23")?.failureReasonCodes,
+    ["ANSWER_FIRST_OVER_SLA", "ANSWER_FIRST_REVIEW_REQUIRED"],
+    "store-backed worker tick should persist SLA issue codes from state advancement",
+  );
+
+  const replacement = completeAnswerFirstEnrichmentJob({
+    job: storedByPuzzleId.get("pinpoint-914-2026-05-23")!,
+    now: "2026-05-23T09:20:00.000Z",
+  });
+  await store.upsertAnswerFirstEnrichmentJobs([replacement]);
+  assert.deepEqual(
+    store.snapshot().map((job) => [job.puzzleId, job.state]),
+    [
+      ["pinpoint-914-2026-05-23", "completed"],
+      ["pinpoint-915-2026-05-23", "review_required"],
+    ],
+    "in-memory job store should replace jobs by jobId without duplicating them",
+  );
+}
+
 async function main() {
   const fileNames = (await readdir(FIXTURE_DIR)).filter((fileName) => fileName.endsWith(".json")).sort();
   assert.ok(fileNames.length >= 6, "content kitchen should have at least 6 fixtures");
@@ -2007,6 +2107,7 @@ async function main() {
   assertAnswerFirstEnrichmentQueueScan();
   assertAnswerFirstEnrichmentStateAdvance();
   assertAnswerFirstEnrichmentWorkerTick();
+  await assertAnswerFirstEnrichmentJobStoreAdapter();
   console.log(`content-kitchen contract fixtures passed (${fileNames.length} fixtures)`);
 }
 


### PR DESCRIPTION
## Summary
- add a local answer-first enrichment job store interface
- add an in-memory store for contract tests and local dry runs
- add a store-backed worker tick helper that loads jobs, runs the local tick, and writes updated jobs back
- document the PR9 seventh implementation slice

## Checks
- npm run test:content-kitchen
- npm run typecheck
- git diff --check
- npm run lint
- npm run validate:data
- npm run build