### PR TITLE
Add PR9 enrichment worker file store

### DIFF
--- a/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
+++ b/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
@@ -2140,6 +2140,13 @@ PR9 eighth implementation slice:
 - expose the runner through an npm script for local inspection
 - keep the dry run read-only; do not mutate the input file or attach it to production storage, Worker cron, or Feishu notifications yet
 
+PR9 ninth implementation slice:
+
+- add a local JSON file store for dry-run worker ticks
+- allow the dry-run runner to write updated job state to a separate output JSON file
+- keep the input file read-only and preserve non-runnable jobs in the output
+- keep this local-only; do not attach it to production storage, Worker cron, or Feishu notifications yet
+
 ### PR10 — Review Artifact And Human Review
 
 Goal: make failed content actionable.

--- a/scripts/check-content-kitchen-contract.ts
+++ b/scripts/check-content-kitchen-contract.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
-import { readdir, readFile } from "node:fs/promises";
+import { mkdtemp, readdir, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
@@ -53,9 +54,11 @@ import {
 } from "../lib/puzzles/content-kitchen/issue-registry";
 import { buildReviewArtifactV0, shouldCreateReviewArtifact } from "../lib/puzzles/content-kitchen/review-artifact";
 import { validateCandidate } from "../lib/puzzles/content-kitchen/validate-candidate";
+import { ENRICHMENT_WORKER_FILE_STORE_OUTPUT_VERSION } from "./content-kitchen-enrichment-file-store";
 import {
   ENRICHMENT_WORKER_DRY_RUN_RESULT_VERSION,
   runAnswerFirstEnrichmentWorkerJsonDryRun,
+  runAnswerFirstEnrichmentWorkerJsonDryRunToFile,
   type AnswerFirstEnrichmentWorkerDryRunInput,
 } from "./run-content-kitchen-enrichment-worker-dry-run";
 import type {
@@ -2073,7 +2076,8 @@ async function assertAnswerFirstEnrichmentJobStoreAdapter() {
 }
 
 async function assertAnswerFirstEnrichmentWorkerJsonDryRun() {
-  const raw = await readFile(resolve(EXAMPLE_DIR, "enrichment-worker-dry-run.input.json"), "utf8");
+  const examplePath = resolve(EXAMPLE_DIR, "enrichment-worker-dry-run.input.json");
+  const raw = await readFile(examplePath, "utf8");
   const input = JSON.parse(raw) as AnswerFirstEnrichmentWorkerDryRunInput;
   const result = await runAnswerFirstEnrichmentWorkerJsonDryRun(input);
 
@@ -2146,6 +2150,56 @@ async function assertAnswerFirstEnrichmentWorkerJsonDryRun() {
     ),
     "package.json should expose the content-kitchen enrichment dry-run script",
   );
+
+  const tmpDir = await mkdtemp(resolve(tmpdir(), "content-kitchen-worker-"));
+  try {
+    const outputPath = resolve(tmpDir, "worker-output.json");
+    const fileResult = await runAnswerFirstEnrichmentWorkerJsonDryRunToFile({
+      input,
+      inputPath: examplePath,
+      outputPath,
+    });
+    const output = JSON.parse(await readFile(outputPath, "utf8")) as {
+      schemaVersion: string;
+      sourcePath: string;
+      writtenAt: string;
+      jobs: Array<{ puzzleId: string; state: string; lockedBy?: string; failureReasonCodes: string[] }>;
+    };
+
+    assert.equal(
+      fileResult.outputPath,
+      outputPath,
+      "worker dry-run file mode should report the output path",
+    );
+    assert.equal(
+      output.schemaVersion,
+      ENRICHMENT_WORKER_FILE_STORE_OUTPUT_VERSION,
+      "worker dry-run file output schema version should be stable",
+    );
+    assert.equal(output.sourcePath, examplePath, "worker dry-run file output should record the source path");
+    assert.equal(output.writtenAt, input.now, "worker dry-run file output should use the dry-run timestamp");
+    assert.deepEqual(
+      output.jobs.map((job) => [job.puzzleId, job.state, job.lockedBy, job.failureReasonCodes]),
+      [
+        ["pinpoint-916-2026-05-23", "running", "worker-dry-run", []],
+        ["pinpoint-917-2026-05-23", "queued", undefined, []],
+        [
+          "pinpoint-918-2026-05-23",
+          "review_required",
+          undefined,
+          ["ANSWER_FIRST_OVER_SLA", "ANSWER_FIRST_REVIEW_REQUIRED"],
+        ],
+      ],
+      "worker dry-run file output should persist updated job states",
+    );
+    assert.equal(
+      await readFile(examplePath, "utf8"),
+      raw,
+      "worker dry-run file mode should not mutate the input file",
+    );
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
 }
 
 async function main() {

--- a/scripts/content-kitchen-enrichment-file-store.ts
+++ b/scripts/content-kitchen-enrichment-file-store.ts
@@ -1,0 +1,91 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import type { AnswerFirstEnrichmentJobStore } from "../lib/puzzles/content-kitchen/enrichment-job-store";
+import type { AnswerFirstEnrichmentJob } from "../lib/puzzles/content-kitchen/types";
+
+export const ENRICHMENT_WORKER_FILE_STORE_OUTPUT_VERSION =
+  "content-kitchen-enrichment-worker-file-store-output-v0";
+
+export type AnswerFirstEnrichmentWorkerFileStoreOutput = {
+  schemaVersion: typeof ENRICHMENT_WORKER_FILE_STORE_OUTPUT_VERSION;
+  sourcePath: string;
+  writtenAt: string;
+  jobs: AnswerFirstEnrichmentJob[];
+};
+
+function cloneAnswerFirstEnrichmentJob(job: AnswerFirstEnrichmentJob): AnswerFirstEnrichmentJob {
+  return {
+    ...job,
+    failureReasonCodes: [...job.failureReasonCodes],
+  };
+}
+
+function parseJobsFile(value: unknown, fieldPath: string): AnswerFirstEnrichmentJob[] {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${fieldPath} must be an object`);
+  }
+
+  const jobs = (value as { jobs?: unknown }).jobs;
+  if (!Array.isArray(jobs)) {
+    throw new Error(`${fieldPath}.jobs must be an array`);
+  }
+
+  return jobs.map((job) => cloneAnswerFirstEnrichmentJob(job as AnswerFirstEnrichmentJob));
+}
+
+export function mergeAnswerFirstEnrichmentJobsById(
+  existingJobs: AnswerFirstEnrichmentJob[],
+  updatedJobs: AnswerFirstEnrichmentJob[],
+): AnswerFirstEnrichmentJob[] {
+  const updatedByJobId = new Map(updatedJobs.map((job) => [job.jobId, cloneAnswerFirstEnrichmentJob(job)]));
+  const merged: AnswerFirstEnrichmentJob[] = [];
+  const seenJobIds = new Set<string>();
+
+  for (const job of existingJobs) {
+    const updated = updatedByJobId.get(job.jobId);
+    merged.push(updated ?? cloneAnswerFirstEnrichmentJob(job));
+    seenJobIds.add(job.jobId);
+  }
+
+  for (const job of updatedJobs) {
+    if (!seenJobIds.has(job.jobId)) {
+      merged.push(cloneAnswerFirstEnrichmentJob(job));
+    }
+  }
+
+  return merged;
+}
+
+export type JsonFileAnswerFirstEnrichmentJobStoreInput = {
+  inputPath: string;
+  outputPath: string;
+  writtenAt: string;
+};
+
+export function createJsonFileAnswerFirstEnrichmentJobStore(
+  input: JsonFileAnswerFirstEnrichmentJobStoreInput,
+): AnswerFirstEnrichmentJobStore {
+  const inputPath = resolve(input.inputPath);
+  const outputPath = resolve(input.outputPath);
+  let loadedJobs: AnswerFirstEnrichmentJob[] | null = null;
+
+  return {
+    async listAnswerFirstEnrichmentJobs() {
+      const raw = await readFile(inputPath, "utf8");
+      loadedJobs = parseJobsFile(JSON.parse(raw), "input").map(cloneAnswerFirstEnrichmentJob);
+      return loadedJobs.map(cloneAnswerFirstEnrichmentJob);
+    },
+    async upsertAnswerFirstEnrichmentJobs(jobs) {
+      const baseJobs = loadedJobs ?? [];
+      const output: AnswerFirstEnrichmentWorkerFileStoreOutput = {
+        schemaVersion: ENRICHMENT_WORKER_FILE_STORE_OUTPUT_VERSION,
+        sourcePath: inputPath,
+        writtenAt: new Date(Date.parse(input.writtenAt)).toISOString(),
+        jobs: mergeAnswerFirstEnrichmentJobsById(baseJobs, jobs),
+      };
+
+      await mkdir(dirname(outputPath), { recursive: true });
+      await writeFile(outputPath, `${JSON.stringify(output, null, 2)}\n`, "utf8");
+    },
+  };
+}

--- a/scripts/run-content-kitchen-enrichment-worker-dry-run.ts
+++ b/scripts/run-content-kitchen-enrichment-worker-dry-run.ts
@@ -6,6 +6,7 @@ import {
   runAnswerFirstEnrichmentWorkerTickFromStore,
 } from "../lib/puzzles/content-kitchen/enrichment-job-store";
 import type { AnswerFirstEnrichmentJob } from "../lib/puzzles/content-kitchen/types";
+import { createJsonFileAnswerFirstEnrichmentJobStore } from "./content-kitchen-enrichment-file-store";
 
 export const ENRICHMENT_WORKER_DRY_RUN_INPUT_VERSION = "content-kitchen-enrichment-worker-dry-run-v0";
 export const ENRICHMENT_WORKER_DRY_RUN_RESULT_VERSION = "content-kitchen-enrichment-worker-dry-run-result-v0";
@@ -45,6 +46,7 @@ export type AnswerFirstEnrichmentWorkerDryRunResult = {
     skippedJobs: number;
     stateAdvancements: number;
   };
+  outputPath?: string;
   claimedJobs: AnswerFirstEnrichmentWorkerDryRunJobSummary[];
   skippedJobs: Array<{
     job: AnswerFirstEnrichmentWorkerDryRunJobSummary;
@@ -60,6 +62,7 @@ export type AnswerFirstEnrichmentWorkerDryRunResult = {
 
 type ParsedArgs = {
   inputPath: string;
+  outputPath?: string;
   pretty: boolean;
 };
 
@@ -146,40 +149,67 @@ export async function runAnswerFirstEnrichmentWorkerJsonDryRun(
   });
   const outputJobs = store.snapshot();
 
+  return buildDryRunResult({
+    input,
+    outputJobs,
+    claimedJobs: tick.claimedJobs,
+    skippedJobs: tick.skippedJobs,
+    stateAdvancements: tick.stateAdvancements,
+  });
+}
+
+type BuildDryRunResultInput = {
+  input: AnswerFirstEnrichmentWorkerDryRunInput;
+  outputJobs: AnswerFirstEnrichmentJob[];
+  outputPath?: string;
+  claimedJobs: Awaited<ReturnType<typeof runAnswerFirstEnrichmentWorkerTickFromStore>>["claimedJobs"];
+  skippedJobs: Awaited<ReturnType<typeof runAnswerFirstEnrichmentWorkerTickFromStore>>["skippedJobs"];
+  stateAdvancements: Awaited<ReturnType<typeof runAnswerFirstEnrichmentWorkerTickFromStore>>["stateAdvancements"];
+};
+
+function buildDryRunResult(input: BuildDryRunResultInput): AnswerFirstEnrichmentWorkerDryRunResult {
   return {
     schemaVersion: ENRICHMENT_WORKER_DRY_RUN_RESULT_VERSION,
     dryRun: true,
-    now: input.now,
-    workerId: input.workerId,
+    now: input.input.now,
+    workerId: input.input.workerId,
     summary: {
-      inputJobs: input.jobs.length,
-      outputJobs: outputJobs.length,
-      claimedJobs: tick.claimedJobs.length,
-      skippedJobs: tick.skippedJobs.length,
-      stateAdvancements: tick.stateAdvancements.filter((result) => result.transition !== "unchanged").length,
+      inputJobs: input.input.jobs.length,
+      outputJobs: input.outputJobs.length,
+      claimedJobs: input.claimedJobs.length,
+      skippedJobs: input.skippedJobs.length,
+      stateAdvancements: input.stateAdvancements.filter((result) => result.transition !== "unchanged").length,
     },
-    claimedJobs: tick.claimedJobs.map(summarizeJob),
-    skippedJobs: tick.skippedJobs.map((entry) => ({
+    outputPath: input.outputPath,
+    claimedJobs: input.claimedJobs.map(summarizeJob),
+    skippedJobs: input.skippedJobs.map((entry) => ({
       job: summarizeJob(entry.job),
       reason: entry.reason,
     })),
-    stateAdvancements: tick.stateAdvancements.map((result) => ({
+    stateAdvancements: input.stateAdvancements.map((result) => ({
       job: summarizeJob(result.job),
       transition: result.transition,
       issueCodesAdded: [...result.issueCodesAdded],
     })),
-    outputJobs,
+    outputJobs: input.outputJobs,
   };
 }
 
 function parseArgs(argv: string[]): ParsedArgs {
   let inputPath = "";
+  let outputPath: string | undefined;
   let pretty = true;
 
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
     if (arg === "--input") {
-      inputPath = argv[index + 1] ?? "";
+      inputPath = readArgValue(argv, index, "--input");
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--output") {
+      outputPath = resolve(readArgValue(argv, index, "--output"));
       index += 1;
       continue;
     }
@@ -196,7 +226,7 @@ function parseArgs(argv: string[]): ParsedArgs {
 
     if (arg === "--help" || arg === "-h") {
       throw new Error(
-        "Usage: npm run content-kitchen:enrichment-dry-run -- --input <path> [--pretty|--compact]",
+        "Usage: npm run content-kitchen:enrichment-dry-run -- --input <path> [--output <path>] [--pretty|--compact]",
       );
     }
 
@@ -209,16 +239,60 @@ function parseArgs(argv: string[]): ParsedArgs {
 
   return {
     inputPath: resolve(inputPath),
+    outputPath,
     pretty,
   };
+}
+
+function readArgValue(argv: string[], index: number, name: string): string {
+  const value = argv[index + 1];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${name} requires a value`);
+  }
+
+  return value;
 }
 
 export async function runCli(argv: string[] = process.argv.slice(2)): Promise<void> {
   const args = parseArgs(argv);
   const raw = await readFile(args.inputPath, "utf8");
   const input = parseDryRunInput(JSON.parse(raw));
-  const result = await runAnswerFirstEnrichmentWorkerJsonDryRun(input);
+  const result = args.outputPath
+    ? await runAnswerFirstEnrichmentWorkerJsonDryRunToFile({
+      input,
+      inputPath: args.inputPath,
+      outputPath: args.outputPath,
+    })
+    : await runAnswerFirstEnrichmentWorkerJsonDryRun(input);
   console.log(JSON.stringify(result, null, args.pretty ? 2 : 0));
+}
+
+export async function runAnswerFirstEnrichmentWorkerJsonDryRunToFile(input: {
+  input: AnswerFirstEnrichmentWorkerDryRunInput;
+  inputPath: string;
+  outputPath: string;
+}): Promise<AnswerFirstEnrichmentWorkerDryRunResult> {
+  const store = createJsonFileAnswerFirstEnrichmentJobStore({
+    inputPath: input.inputPath,
+    outputPath: input.outputPath,
+    writtenAt: input.input.now,
+  });
+  const tick = await runAnswerFirstEnrichmentWorkerTickFromStore({
+    store,
+    now: input.input.now,
+    workerId: input.input.workerId,
+    limit: input.input.limit,
+    lockMinutes: input.input.lockMinutes,
+  });
+
+  return buildDryRunResult({
+    input: input.input,
+    outputPath: input.outputPath,
+    outputJobs: tick.updatedJobs,
+    claimedJobs: tick.claimedJobs,
+    skippedJobs: tick.skippedJobs,
+    stateAdvancements: tick.stateAdvancements,
+  });
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {


### PR DESCRIPTION
## Summary
- add a local JSON file store for enrichment worker dry runs
- support --output in the enrichment dry-run command so updated job states can be written to a separate JSON file
- keep input files read-only and preserve skipped/non-runnable jobs in output
- document the PR9 ninth implementation slice

## Checks
- npm run content-kitchen:enrichment-dry-run -- --input lib/puzzles/content-kitchen/examples/enrichment-worker-dry-run.input.json --output <tmp>/worker-output.json --compact
- npm run test:content-kitchen
- npm run typecheck
- git diff --check
- npm run lint
- npm run validate:data
- npm run build