### PR TITLE
Add PR9 enrichment worker resume dry run

### DIFF
--- a/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
+++ b/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
@@ -2147,6 +2147,13 @@ PR9 ninth implementation slice:
 - keep the input file read-only and preserve non-runnable jobs in the output
 - keep this local-only; do not attach it to production storage, Worker cron, or Feishu notifications yet
 
+PR9 tenth implementation slice:
+
+- allow the dry-run runner to use a file-store output JSON as the next input
+- support command-line overrides for the next run timestamp, worker id, batch limit, and lock window
+- keep resumed dry runs local-only and read-only against the previous output unless a separate output path is provided
+- do not attach this slice to production storage, Worker cron, or Feishu notifications yet
+
 ### PR10 — Review Artifact And Human Review
 
 Goal: make failed content actionable.

--- a/scripts/check-content-kitchen-contract.ts
+++ b/scripts/check-content-kitchen-contract.ts
@@ -57,6 +57,7 @@ import { validateCandidate } from "../lib/puzzles/content-kitchen/validate-candi
 import { ENRICHMENT_WORKER_FILE_STORE_OUTPUT_VERSION } from "./content-kitchen-enrichment-file-store";
 import {
   ENRICHMENT_WORKER_DRY_RUN_RESULT_VERSION,
+  parseAnswerFirstEnrichmentWorkerDryRunInput,
   runAnswerFirstEnrichmentWorkerJsonDryRun,
   runAnswerFirstEnrichmentWorkerJsonDryRunToFile,
   type AnswerFirstEnrichmentWorkerDryRunInput,
@@ -2196,6 +2197,26 @@ async function assertAnswerFirstEnrichmentWorkerJsonDryRun() {
       await readFile(examplePath, "utf8"),
       raw,
       "worker dry-run file mode should not mutate the input file",
+    );
+
+    const resumedInput = parseAnswerFirstEnrichmentWorkerDryRunInput(output, {
+      now: "2026-05-23T09:12:00.000Z",
+      workerId: "worker-dry-run-next",
+      lockMinutes: 10,
+    });
+    const resumedResult = await runAnswerFirstEnrichmentWorkerJsonDryRun(resumedInput);
+    assert.deepEqual(
+      resumedResult.claimedJobs.map((job) => [job.puzzleId, job.attemptCount, job.lockedBy, job.lockedUntil]),
+      [["pinpoint-916-2026-05-23", 2, "worker-dry-run-next", "2026-05-23T09:22:00.000Z"]],
+      "worker dry-run should be able to use a file-store output as the next input",
+    );
+    assert.deepEqual(
+      resumedResult.skippedJobs.map((entry) => [entry.job.puzzleId, entry.reason]),
+      [
+        ["pinpoint-917-2026-05-23", "not_due"],
+        ["pinpoint-918-2026-05-23", "terminal_state"],
+      ],
+      "resumed worker dry-run should preserve skipped job reasons from the output file state",
     );
   } finally {
     await rm(tmpDir, { recursive: true, force: true });

--- a/scripts/run-content-kitchen-enrichment-worker-dry-run.ts
+++ b/scripts/run-content-kitchen-enrichment-worker-dry-run.ts
@@ -6,13 +6,18 @@ import {
   runAnswerFirstEnrichmentWorkerTickFromStore,
 } from "../lib/puzzles/content-kitchen/enrichment-job-store";
 import type { AnswerFirstEnrichmentJob } from "../lib/puzzles/content-kitchen/types";
-import { createJsonFileAnswerFirstEnrichmentJobStore } from "./content-kitchen-enrichment-file-store";
+import {
+  ENRICHMENT_WORKER_FILE_STORE_OUTPUT_VERSION,
+  createJsonFileAnswerFirstEnrichmentJobStore,
+} from "./content-kitchen-enrichment-file-store";
 
 export const ENRICHMENT_WORKER_DRY_RUN_INPUT_VERSION = "content-kitchen-enrichment-worker-dry-run-v0";
 export const ENRICHMENT_WORKER_DRY_RUN_RESULT_VERSION = "content-kitchen-enrichment-worker-dry-run-result-v0";
 
 export type AnswerFirstEnrichmentWorkerDryRunInput = {
-  schemaVersion?: typeof ENRICHMENT_WORKER_DRY_RUN_INPUT_VERSION;
+  schemaVersion?:
+    | typeof ENRICHMENT_WORKER_DRY_RUN_INPUT_VERSION
+    | typeof ENRICHMENT_WORKER_FILE_STORE_OUTPUT_VERSION;
   jobs: AnswerFirstEnrichmentJob[];
   now: string;
   workerId: string;
@@ -63,7 +68,18 @@ export type AnswerFirstEnrichmentWorkerDryRunResult = {
 type ParsedArgs = {
   inputPath: string;
   outputPath?: string;
+  now?: string;
+  workerId?: string;
+  limit?: number;
+  lockMinutes?: number;
   pretty: boolean;
+};
+
+type DryRunInputOverrides = {
+  now?: string;
+  workerId?: string;
+  limit?: number;
+  lockMinutes?: number;
 };
 
 function requireObject(value: unknown, fieldPath: string): Record<string, unknown> {
@@ -74,8 +90,12 @@ function requireObject(value: unknown, fieldPath: string): Record<string, unknow
   return value as Record<string, unknown>;
 }
 
-function readRequiredText(record: Record<string, unknown>, key: string): string {
+function readOptionalText(record: Record<string, unknown>, key: string): string | undefined {
   const value = record[key];
+  if (value === undefined) {
+    return undefined;
+  }
+
   if (typeof value !== "string" || !value.trim()) {
     throw new Error(`${key} must be a non-empty string`);
   }
@@ -96,29 +116,45 @@ function readOptionalInteger(record: Record<string, unknown>, key: string, minim
   return value;
 }
 
-function parseDryRunInput(value: unknown): AnswerFirstEnrichmentWorkerDryRunInput {
+export function parseAnswerFirstEnrichmentWorkerDryRunInput(
+  value: unknown,
+  overrides: DryRunInputOverrides = {},
+): AnswerFirstEnrichmentWorkerDryRunInput {
   const record = requireObject(value, "input");
   const schemaVersion = record.schemaVersion;
-  if (schemaVersion !== undefined && schemaVersion !== ENRICHMENT_WORKER_DRY_RUN_INPUT_VERSION) {
-    throw new Error(`schemaVersion must be ${ENRICHMENT_WORKER_DRY_RUN_INPUT_VERSION}`);
+  if (
+    schemaVersion !== undefined &&
+    schemaVersion !== ENRICHMENT_WORKER_DRY_RUN_INPUT_VERSION &&
+    schemaVersion !== ENRICHMENT_WORKER_FILE_STORE_OUTPUT_VERSION
+  ) {
+    throw new Error(
+      `schemaVersion must be ${ENRICHMENT_WORKER_DRY_RUN_INPUT_VERSION} or ${ENRICHMENT_WORKER_FILE_STORE_OUTPUT_VERSION}`,
+    );
   }
 
   if (!Array.isArray(record.jobs)) {
     throw new Error("jobs must be an array");
   }
 
-  const now = readRequiredText(record, "now");
+  const now = overrides.now ?? readOptionalText(record, "now") ?? readOptionalText(record, "writtenAt");
+  if (!now) {
+    throw new Error("now must be provided in the input file, as writtenAt, or with --now");
+  }
   if (!Number.isFinite(Date.parse(now))) {
     throw new Error("now must be a valid timestamp");
   }
+  const workerId = overrides.workerId ?? readOptionalText(record, "workerId");
+  if (!workerId) {
+    throw new Error("workerId must be provided in the input file or with --worker-id");
+  }
 
   return {
-    schemaVersion: schemaVersion as typeof ENRICHMENT_WORKER_DRY_RUN_INPUT_VERSION | undefined,
+    schemaVersion: schemaVersion as AnswerFirstEnrichmentWorkerDryRunInput["schemaVersion"],
     jobs: record.jobs as AnswerFirstEnrichmentJob[],
     now,
-    workerId: readRequiredText(record, "workerId"),
-    limit: readOptionalInteger(record, "limit", 0),
-    lockMinutes: readOptionalInteger(record, "lockMinutes", 1),
+    workerId,
+    limit: overrides.limit ?? readOptionalInteger(record, "limit", 0),
+    lockMinutes: overrides.lockMinutes ?? readOptionalInteger(record, "lockMinutes", 1),
   };
 }
 
@@ -198,6 +234,10 @@ function buildDryRunResult(input: BuildDryRunResultInput): AnswerFirstEnrichment
 function parseArgs(argv: string[]): ParsedArgs {
   let inputPath = "";
   let outputPath: string | undefined;
+  let now: string | undefined;
+  let workerId: string | undefined;
+  let limit: number | undefined;
+  let lockMinutes: number | undefined;
   let pretty = true;
 
   for (let index = 0; index < argv.length; index += 1) {
@@ -214,6 +254,30 @@ function parseArgs(argv: string[]): ParsedArgs {
       continue;
     }
 
+    if (arg === "--now") {
+      now = readArgValue(argv, index, "--now");
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--worker-id") {
+      workerId = readArgValue(argv, index, "--worker-id");
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--limit") {
+      limit = parseIntegerArg(readArgValue(argv, index, "--limit"), "--limit", 0);
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--lock-minutes") {
+      lockMinutes = parseIntegerArg(readArgValue(argv, index, "--lock-minutes"), "--lock-minutes", 1);
+      index += 1;
+      continue;
+    }
+
     if (arg === "--compact") {
       pretty = false;
       continue;
@@ -226,7 +290,7 @@ function parseArgs(argv: string[]): ParsedArgs {
 
     if (arg === "--help" || arg === "-h") {
       throw new Error(
-        "Usage: npm run content-kitchen:enrichment-dry-run -- --input <path> [--output <path>] [--pretty|--compact]",
+        "Usage: npm run content-kitchen:enrichment-dry-run -- --input <path> [--output <path>] [--now <timestamp>] [--worker-id <id>] [--limit <n>] [--lock-minutes <n>] [--pretty|--compact]",
       );
     }
 
@@ -237,9 +301,18 @@ function parseArgs(argv: string[]): ParsedArgs {
     throw new Error("Missing required --input <path>");
   }
 
+  const resolvedInputPath = resolve(inputPath);
+  if (outputPath === resolvedInputPath) {
+    throw new Error("--output must be different from --input");
+  }
+
   return {
-    inputPath: resolve(inputPath),
+    inputPath: resolvedInputPath,
     outputPath,
+    now,
+    workerId,
+    limit,
+    lockMinutes,
     pretty,
   };
 }
@@ -253,10 +326,24 @@ function readArgValue(argv: string[], index: number, name: string): string {
   return value;
 }
 
+function parseIntegerArg(value: string, name: string, minimum: number): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < minimum) {
+    throw new Error(`${name} must be an integer greater than or equal to ${minimum}`);
+  }
+
+  return parsed;
+}
+
 export async function runCli(argv: string[] = process.argv.slice(2)): Promise<void> {
   const args = parseArgs(argv);
   const raw = await readFile(args.inputPath, "utf8");
-  const input = parseDryRunInput(JSON.parse(raw));
+  const input = parseAnswerFirstEnrichmentWorkerDryRunInput(JSON.parse(raw), {
+    now: args.now,
+    workerId: args.workerId,
+    limit: args.limit,
+    lockMinutes: args.lockMinutes,
+  });
   const result = args.outputPath
     ? await runAnswerFirstEnrichmentWorkerJsonDryRunToFile({
       input,


### PR DESCRIPTION
## Summary
- allow enrichment worker dry runs to use a previous file-store output JSON as the next input
- add CLI overrides for next run timestamp, worker id, batch limit, and lock window
- prevent --output from overwriting --input
- document the PR9 tenth implementation slice

## Checks
- two-round local dry run using a first-round output JSON as second-round input
- npm run test:content-kitchen
- npm run typecheck
- git diff --check
- npm run lint
- npm run validate:data
- npm run build