### PR TITLE
Add PR9 enrichment worker run summary

### DIFF
--- a/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
+++ b/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
@@ -2154,6 +2154,13 @@ PR9 tenth implementation slice:
 - keep resumed dry runs local-only and read-only against the previous output unless a separate output path is provided
 - do not attach this slice to production storage, Worker cron, or Feishu notifications yet
 
+PR9 eleventh implementation slice:
+
+- add a local worker run summary for dry-run results
+- include a short headline, human-readable lines, important counts, skip reason counts, output state counts, and issue code lists
+- keep the summary machine-readable so later notification and review queue layers can reuse it
+- keep this local-only; do not attach it to Feishu, review queue storage, production storage, or Worker cron yet
+
 ### PR10 — Review Artifact And Human Review
 
 Goal: make failed content actionable.

--- a/scripts/check-content-kitchen-contract.ts
+++ b/scripts/check-content-kitchen-contract.ts
@@ -55,6 +55,7 @@ import {
 import { buildReviewArtifactV0, shouldCreateReviewArtifact } from "../lib/puzzles/content-kitchen/review-artifact";
 import { validateCandidate } from "../lib/puzzles/content-kitchen/validate-candidate";
 import { ENRICHMENT_WORKER_FILE_STORE_OUTPUT_VERSION } from "./content-kitchen-enrichment-file-store";
+import { ENRICHMENT_WORKER_RUN_SUMMARY_VERSION } from "./content-kitchen-enrichment-run-summary";
 import {
   ENRICHMENT_WORKER_DRY_RUN_RESULT_VERSION,
   parseAnswerFirstEnrichmentWorkerDryRunInput,
@@ -2098,6 +2099,58 @@ async function assertAnswerFirstEnrichmentWorkerJsonDryRun() {
     },
     "worker dry-run should summarize claimed, skipped, and advanced jobs",
   );
+  assert.equal(
+    result.runSummary.schemaVersion,
+    ENRICHMENT_WORKER_RUN_SUMMARY_VERSION,
+    "worker dry-run should include a stable run summary schema",
+  );
+  assert.equal(
+    result.runSummary.headline,
+    "worker-dry-run @ 2026-05-23T09:01:00.000Z; 1 claimed job; 2 skipped jobs; 1 state change; 1 review; 0 dead-letter",
+    "worker dry-run should include a short human-readable headline",
+  );
+  assert.deepEqual(
+    result.runSummary.counts,
+    {
+      inputJobs: 3,
+      outputJobs: 3,
+      claimedJobs: 1,
+      skippedJobs: 2,
+      stateChanges: 1,
+      reviewRequiredJobs: 1,
+      deadLetterJobs: 0,
+      overSlaJobs: 1,
+      highPriorityJobs: 0,
+    },
+    "worker dry-run run summary should count important job states",
+  );
+  assert.deepEqual(
+    result.runSummary.bySkipReason,
+    {
+      not_due: 1,
+      terminal_state: 1,
+    },
+    "worker dry-run run summary should count skip reasons",
+  );
+  assert.deepEqual(
+    result.runSummary.byOutputState,
+    {
+      queued: 1,
+      review_required: 1,
+      running: 1,
+    },
+    "worker dry-run run summary should count output states",
+  );
+  assert.deepEqual(
+    result.runSummary.issueCodesAdded,
+    ["ANSWER_FIRST_OVER_SLA", "ANSWER_FIRST_REVIEW_REQUIRED"],
+    "worker dry-run run summary should list issue codes added this run",
+  );
+  assert.deepEqual(
+    result.runSummary.activeIssueCodes,
+    ["ANSWER_FIRST_OVER_SLA", "ANSWER_FIRST_REVIEW_REQUIRED"],
+    "worker dry-run run summary should list active issue codes after the run",
+  );
   assert.deepEqual(
     result.claimedJobs.map((job) => [job.puzzleId, job.state, job.lockedBy, job.lockedUntil]),
     [["pinpoint-916-2026-05-23", "running", "worker-dry-run", "2026-05-23T09:11:00.000Z"]],
@@ -2205,6 +2258,11 @@ async function assertAnswerFirstEnrichmentWorkerJsonDryRun() {
       lockMinutes: 10,
     });
     const resumedResult = await runAnswerFirstEnrichmentWorkerJsonDryRun(resumedInput);
+    assert.equal(
+      resumedResult.runSummary.headline,
+      "worker-dry-run-next @ 2026-05-23T09:12:00.000Z; 1 claimed job; 2 skipped jobs; 1 state change; 1 review; 0 dead-letter",
+      "resumed worker dry-run should include an updated run summary headline",
+    );
     assert.deepEqual(
       resumedResult.claimedJobs.map((job) => [job.puzzleId, job.attemptCount, job.lockedBy, job.lockedUntil]),
       [["pinpoint-916-2026-05-23", 2, "worker-dry-run-next", "2026-05-23T09:22:00.000Z"]],

--- a/scripts/content-kitchen-enrichment-run-summary.ts
+++ b/scripts/content-kitchen-enrichment-run-summary.ts
@@ -1,0 +1,162 @@
+import type {
+  EnrichmentJobStateAdvanceTransition,
+  EnrichmentQueueSkipReason,
+} from "../lib/puzzles/content-kitchen/enrichment-job";
+import type {
+  AnswerFirstEnrichmentJob,
+  ContentKitchenIssueCode,
+  EnrichmentJobState,
+} from "../lib/puzzles/content-kitchen/types";
+
+export const ENRICHMENT_WORKER_RUN_SUMMARY_VERSION =
+  "content-kitchen-enrichment-worker-run-summary-v0";
+
+export type AnswerFirstEnrichmentWorkerRunSummaryInput = {
+  now: string;
+  workerId: string;
+  inputJobs: number;
+  outputJobs: AnswerFirstEnrichmentJob[];
+  claimedJobs: AnswerFirstEnrichmentJob[];
+  skippedJobs: Array<{
+    job: AnswerFirstEnrichmentJob;
+    reason: EnrichmentQueueSkipReason;
+  }>;
+  stateAdvancements: Array<{
+    job: AnswerFirstEnrichmentJob;
+    transition: EnrichmentJobStateAdvanceTransition;
+    issueCodesAdded: ContentKitchenIssueCode[];
+  }>;
+};
+
+export type AnswerFirstEnrichmentWorkerRunSummary = {
+  schemaVersion: typeof ENRICHMENT_WORKER_RUN_SUMMARY_VERSION;
+  headline: string;
+  lines: string[];
+  counts: {
+    inputJobs: number;
+    outputJobs: number;
+    claimedJobs: number;
+    skippedJobs: number;
+    stateChanges: number;
+    reviewRequiredJobs: number;
+    deadLetterJobs: number;
+    overSlaJobs: number;
+    highPriorityJobs: number;
+  };
+  byOutputState: Partial<Record<EnrichmentJobState, number>>;
+  bySkipReason: Partial<Record<EnrichmentQueueSkipReason, number>>;
+  byTransition: Partial<Record<EnrichmentJobStateAdvanceTransition, number>>;
+  claimedJobIds: string[];
+  reviewRequiredJobIds: string[];
+  deadLetterJobIds: string[];
+  issueCodesAdded: ContentKitchenIssueCode[];
+  activeIssueCodes: ContentKitchenIssueCode[];
+};
+
+function increment<T extends string>(counts: Partial<Record<T, number>>, key: T) {
+  counts[key] = (counts[key] ?? 0) + 1;
+}
+
+function uniqueSorted<T extends string>(values: T[]): T[] {
+  return [...new Set(values)].sort();
+}
+
+function plural(count: number, singular: string, pluralValue = `${singular}s`): string {
+  return count === 1 ? singular : pluralValue;
+}
+
+function summarizeIds(ids: string[]): string {
+  if (ids.length === 0) {
+    return "none";
+  }
+
+  return ids.join(", ");
+}
+
+function summarizeCounts<T extends string>(counts: Partial<Record<T, number>>): string {
+  const entries = Object.entries(counts)
+    .filter((entry): entry is [T, number] => typeof entry[1] === "number")
+    .sort(([left], [right]) => left.localeCompare(right));
+
+  if (entries.length === 0) {
+    return "none";
+  }
+
+  return entries.map(([key, count]) => `${key}=${count}`).join(", ");
+}
+
+export function buildAnswerFirstEnrichmentWorkerRunSummary(
+  input: AnswerFirstEnrichmentWorkerRunSummaryInput,
+): AnswerFirstEnrichmentWorkerRunSummary {
+  const byOutputState: Partial<Record<EnrichmentJobState, number>> = {};
+  const bySkipReason: Partial<Record<EnrichmentQueueSkipReason, number>> = {};
+  const byTransition: Partial<Record<EnrichmentJobStateAdvanceTransition, number>> = {};
+
+  for (const job of input.outputJobs) {
+    increment(byOutputState, job.state);
+  }
+
+  for (const entry of input.skippedJobs) {
+    increment(bySkipReason, entry.reason);
+  }
+
+  for (const entry of input.stateAdvancements) {
+    increment(byTransition, entry.transition);
+  }
+
+  const claimedJobIds = input.claimedJobs.map((job) => job.jobId);
+  const reviewRequiredJobIds = input.outputJobs
+    .filter((job) => job.state === "review_required")
+    .map((job) => job.jobId);
+  const deadLetterJobIds = input.outputJobs
+    .filter((job) => job.state === "dead_letter")
+    .map((job) => job.jobId);
+  const overSlaJobs = input.outputJobs.filter((job) => job.failureReasonCodes.includes("ANSWER_FIRST_OVER_SLA"));
+  const highPriorityJobs = input.outputJobs.filter((job) =>
+    job.failureReasonCodes.includes("ANSWER_FIRST_HIGH_PRIORITY_ALERT"),
+  );
+  const stateChanges = input.stateAdvancements.filter((entry) => entry.transition !== "unchanged").length;
+  const issueCodesAdded = uniqueSorted(input.stateAdvancements.flatMap((entry) => entry.issueCodesAdded));
+  const activeIssueCodes = uniqueSorted(input.outputJobs.flatMap((job) => job.failureReasonCodes));
+
+  const headline = [
+    `${input.workerId} @ ${input.now}`,
+    `${input.claimedJobs.length} ${plural(input.claimedJobs.length, "claimed job")}`,
+    `${input.skippedJobs.length} ${plural(input.skippedJobs.length, "skipped job")}`,
+    `${stateChanges} state ${plural(stateChanges, "change")}`,
+    `${reviewRequiredJobIds.length} review`,
+    `${deadLetterJobIds.length} dead-letter`,
+  ].join("; ");
+
+  return {
+    schemaVersion: ENRICHMENT_WORKER_RUN_SUMMARY_VERSION,
+    headline,
+    lines: [
+      `Claimed: ${summarizeIds(claimedJobIds)}`,
+      `Skipped: ${summarizeCounts(bySkipReason)}`,
+      `State changes: ${summarizeCounts(byTransition)}`,
+      `Review required: ${summarizeIds(reviewRequiredJobIds)}`,
+      `Dead letter: ${summarizeIds(deadLetterJobIds)}`,
+      `Active issue codes: ${summarizeIds(activeIssueCodes)}`,
+    ],
+    counts: {
+      inputJobs: input.inputJobs,
+      outputJobs: input.outputJobs.length,
+      claimedJobs: input.claimedJobs.length,
+      skippedJobs: input.skippedJobs.length,
+      stateChanges,
+      reviewRequiredJobs: reviewRequiredJobIds.length,
+      deadLetterJobs: deadLetterJobIds.length,
+      overSlaJobs: overSlaJobs.length,
+      highPriorityJobs: highPriorityJobs.length,
+    },
+    byOutputState,
+    bySkipReason,
+    byTransition,
+    claimedJobIds,
+    reviewRequiredJobIds,
+    deadLetterJobIds,
+    issueCodesAdded,
+    activeIssueCodes,
+  };
+}

--- a/scripts/run-content-kitchen-enrichment-worker-dry-run.ts
+++ b/scripts/run-content-kitchen-enrichment-worker-dry-run.ts
@@ -10,6 +10,10 @@ import {
   ENRICHMENT_WORKER_FILE_STORE_OUTPUT_VERSION,
   createJsonFileAnswerFirstEnrichmentJobStore,
 } from "./content-kitchen-enrichment-file-store";
+import {
+  buildAnswerFirstEnrichmentWorkerRunSummary,
+  type AnswerFirstEnrichmentWorkerRunSummary,
+} from "./content-kitchen-enrichment-run-summary";
 
 export const ENRICHMENT_WORKER_DRY_RUN_INPUT_VERSION = "content-kitchen-enrichment-worker-dry-run-v0";
 export const ENRICHMENT_WORKER_DRY_RUN_RESULT_VERSION = "content-kitchen-enrichment-worker-dry-run-result-v0";
@@ -51,6 +55,7 @@ export type AnswerFirstEnrichmentWorkerDryRunResult = {
     skippedJobs: number;
     stateAdvancements: number;
   };
+  runSummary: AnswerFirstEnrichmentWorkerRunSummary;
   outputPath?: string;
   claimedJobs: AnswerFirstEnrichmentWorkerDryRunJobSummary[];
   skippedJobs: Array<{
@@ -216,6 +221,15 @@ function buildDryRunResult(input: BuildDryRunResultInput): AnswerFirstEnrichment
       skippedJobs: input.skippedJobs.length,
       stateAdvancements: input.stateAdvancements.filter((result) => result.transition !== "unchanged").length,
     },
+    runSummary: buildAnswerFirstEnrichmentWorkerRunSummary({
+      now: input.input.now,
+      workerId: input.input.workerId,
+      inputJobs: input.input.jobs.length,
+      outputJobs: input.outputJobs,
+      claimedJobs: input.claimedJobs,
+      skippedJobs: input.skippedJobs,
+      stateAdvancements: input.stateAdvancements,
+    }),
     outputPath: input.outputPath,
     claimedJobs: input.claimedJobs.map(summarizeJob),
     skippedJobs: input.skippedJobs.map((entry) => ({


### PR DESCRIPTION
## Summary
- add a local enrichment worker run summary builder
- include runSummary in JSON dry-run results with a short headline, lines, counts, skip reasons, output states, and issue code lists
- extend contract tests for normal and resumed dry runs
- document the PR9 eleventh implementation slice

## Checks
- npm run content-kitchen:enrichment-dry-run -- --input lib/puzzles/content-kitchen/examples/enrichment-worker-dry-run.input.json --compact
- npm run test:content-kitchen
- npm run typecheck
- git diff --check
- npm run lint
- npm run validate:data
- npm run build