### PR TITLE
Add PR9 enrichment worker action drafts

### DIFF
--- a/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
+++ b/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
@@ -2161,6 +2161,14 @@ PR9 eleventh implementation slice:
 - keep the summary machine-readable so later notification and review queue layers can reuse it
 - keep this local-only; do not attach it to Feishu, review queue storage, production storage, or Worker cron yet
 
+PR9 twelfth implementation slice:
+
+- add local action drafts derived from the worker dry-run summary
+- include a Feishu-shaped notification draft with priority, issue codes, job ids, puzzle ids, and a dedupe key
+- include a review queue draft for `review_required` and `dead_letter` jobs with revision ids, snapshot hash, deadlines, issue codes, and recommended action
+- mark notification drafts as `not_sent` and review queue drafts as `not_persisted`
+- keep this local-only; do not send Feishu messages, write review queue storage, attach production storage, or run Worker cron yet
+
 ### PR10 — Review Artifact And Human Review
 
 Goal: make failed content actionable.

--- a/scripts/check-content-kitchen-contract.ts
+++ b/scripts/check-content-kitchen-contract.ts
@@ -55,6 +55,7 @@ import {
 import { buildReviewArtifactV0, shouldCreateReviewArtifact } from "../lib/puzzles/content-kitchen/review-artifact";
 import { validateCandidate } from "../lib/puzzles/content-kitchen/validate-candidate";
 import { ENRICHMENT_WORKER_FILE_STORE_OUTPUT_VERSION } from "./content-kitchen-enrichment-file-store";
+import { ENRICHMENT_WORKER_ACTION_DRAFTS_VERSION } from "./content-kitchen-enrichment-action-drafts";
 import { ENRICHMENT_WORKER_RUN_SUMMARY_VERSION } from "./content-kitchen-enrichment-run-summary";
 import {
   ENRICHMENT_WORKER_DRY_RUN_RESULT_VERSION,
@@ -2150,6 +2151,58 @@ async function assertAnswerFirstEnrichmentWorkerJsonDryRun() {
     result.runSummary.activeIssueCodes,
     ["ANSWER_FIRST_OVER_SLA", "ANSWER_FIRST_REVIEW_REQUIRED"],
     "worker dry-run run summary should list active issue codes after the run",
+  );
+  assert.equal(
+    result.actionDrafts.schemaVersion,
+    ENRICHMENT_WORKER_ACTION_DRAFTS_VERSION,
+    "worker dry-run should include stable local action drafts",
+  );
+  assert.equal(result.actionDrafts.dryRunOnly, true, "worker dry-run action drafts must stay local-only");
+  assert.deepEqual(
+    result.actionDrafts.notificationDrafts.map((draft) => [
+      draft.channel,
+      draft.priority,
+      draft.dispatchStatus,
+      draft.reason,
+      draft.jobIds,
+      draft.issueCodes,
+    ]),
+    [
+      [
+        "feishu",
+        "normal",
+        "not_sent",
+        "answer_first_sla_alert",
+        ["job-pinpoint-918-2026-05-23-rev-full-analysis-918"],
+        ["ANSWER_FIRST_OVER_SLA", "ANSWER_FIRST_REVIEW_REQUIRED"],
+      ],
+    ],
+    "worker dry-run should produce a Feishu-shaped notification draft without sending it",
+  );
+  assert.ok(
+    result.actionDrafts.notificationDrafts[0]?.lines.some((line) => line.includes("not sent to Feishu")),
+    "worker dry-run notification draft should say it is not sent",
+  );
+  assert.deepEqual(
+    result.actionDrafts.reviewQueueDrafts.map((draft) => [
+      draft.queueName,
+      draft.persistenceStatus,
+      draft.priority,
+      draft.reason,
+      draft.jobId,
+      draft.issueCodes,
+    ]),
+    [
+      [
+        "content-kitchen-review",
+        "not_persisted",
+        "normal",
+        "answer_first_review_required",
+        "job-pinpoint-918-2026-05-23-rev-full-analysis-918",
+        ["ANSWER_FIRST_OVER_SLA", "ANSWER_FIRST_REVIEW_REQUIRED"],
+      ],
+    ],
+    "worker dry-run should produce a review queue draft without persisting it",
   );
   assert.deepEqual(
     result.claimedJobs.map((job) => [job.puzzleId, job.state, job.lockedBy, job.lockedUntil]),

--- a/scripts/content-kitchen-enrichment-action-drafts.ts
+++ b/scripts/content-kitchen-enrichment-action-drafts.ts
@@ -1,0 +1,197 @@
+import type { AnswerFirstEnrichmentWorkerRunSummary } from "./content-kitchen-enrichment-run-summary";
+import type {
+  AnswerFirstEnrichmentJob,
+  ContentKitchenIssueCode,
+  EnrichmentJobState,
+} from "../lib/puzzles/content-kitchen/types";
+
+export const ENRICHMENT_WORKER_ACTION_DRAFTS_VERSION =
+  "content-kitchen-enrichment-worker-action-drafts-v0";
+
+export type AnswerFirstEnrichmentWorkerNotificationDraft = {
+  draftVersion: typeof ENRICHMENT_WORKER_ACTION_DRAFTS_VERSION;
+  draftId: string;
+  draftOnly: true;
+  dispatchStatus: "not_sent";
+  channel: "feishu";
+  priority: "normal" | "high_priority";
+  reason: "answer_first_sla_alert" | "answer_first_high_priority_alert";
+  title: string;
+  lines: string[];
+  jobIds: string[];
+  puzzleIds: string[];
+  issueCodes: ContentKitchenIssueCode[];
+  dedupeKey: string;
+};
+
+export type AnswerFirstEnrichmentWorkerReviewQueueDraft = {
+  draftVersion: typeof ENRICHMENT_WORKER_ACTION_DRAFTS_VERSION;
+  draftId: string;
+  draftOnly: true;
+  persistenceStatus: "not_persisted";
+  queueName: "content-kitchen-review";
+  priority: "normal" | "high_priority";
+  reason: "answer_first_review_required" | "answer_first_dead_letter";
+  jobId: string;
+  puzzleId: string;
+  sourceRevisionId: string;
+  targetRevision: string;
+  inputSnapshotHash: string;
+  state: Extract<EnrichmentJobState, "review_required" | "dead_letter">;
+  issueCodes: ContentKitchenIssueCode[];
+  recommendedAction: "review";
+  createdAt: string;
+  deadlineAt: string;
+  reviewRequiredAt: string;
+  highPriorityAlertAt: string;
+};
+
+export type AnswerFirstEnrichmentWorkerActionDrafts = {
+  schemaVersion: typeof ENRICHMENT_WORKER_ACTION_DRAFTS_VERSION;
+  dryRunOnly: true;
+  createdAt: string;
+  workerId: string;
+  notificationDrafts: AnswerFirstEnrichmentWorkerNotificationDraft[];
+  reviewQueueDrafts: AnswerFirstEnrichmentWorkerReviewQueueDraft[];
+};
+
+export type BuildAnswerFirstEnrichmentWorkerActionDraftsInput = {
+  now: string;
+  workerId: string;
+  runSummary: AnswerFirstEnrichmentWorkerRunSummary;
+  outputJobs: AnswerFirstEnrichmentJob[];
+};
+
+function uniqueSorted<T extends string>(values: T[]): T[] {
+  return [...new Set(values)].sort();
+}
+
+function hasIssue(job: AnswerFirstEnrichmentJob, issueCode: ContentKitchenIssueCode): boolean {
+  return job.failureReasonCodes.includes(issueCode);
+}
+
+function summarizeJobIds(jobs: AnswerFirstEnrichmentJob[]): string {
+  if (jobs.length === 0) {
+    return "none";
+  }
+
+  return jobs.map((job) => job.jobId).join(", ");
+}
+
+function buildNotificationDraft(input: {
+  now: string;
+  workerId: string;
+  priority: AnswerFirstEnrichmentWorkerNotificationDraft["priority"];
+  jobs: AnswerFirstEnrichmentJob[];
+  runSummary: AnswerFirstEnrichmentWorkerRunSummary;
+}): AnswerFirstEnrichmentWorkerNotificationDraft {
+  const issueCodes = uniqueSorted(input.jobs.flatMap((job) => job.failureReasonCodes));
+  const reason =
+    input.priority === "high_priority" ? "answer_first_high_priority_alert" : "answer_first_sla_alert";
+  const title =
+    input.priority === "high_priority"
+      ? "Content Kitchen high-priority enrichment alert"
+      : "Content Kitchen enrichment SLA alert";
+
+  return {
+    draftVersion: ENRICHMENT_WORKER_ACTION_DRAFTS_VERSION,
+    draftId: `notification:${input.priority}:${input.workerId}:${input.now}`,
+    draftOnly: true,
+    dispatchStatus: "not_sent",
+    channel: "feishu",
+    priority: input.priority,
+    reason,
+    title,
+    lines: [
+      input.runSummary.headline,
+      `Jobs: ${summarizeJobIds(input.jobs)}`,
+      `Issue codes: ${issueCodes.length > 0 ? issueCodes.join(", ") : "none"}`,
+      "Dry run only: not sent to Feishu.",
+    ],
+    jobIds: input.jobs.map((job) => job.jobId),
+    puzzleIds: uniqueSorted(input.jobs.map((job) => job.puzzleId)),
+    issueCodes,
+    dedupeKey: `content-kitchen:${input.priority}:${input.jobs.map((job) => job.jobId).join("|")}`,
+  };
+}
+
+function buildReviewQueueDraft(
+  job: AnswerFirstEnrichmentJob,
+  now: string,
+): AnswerFirstEnrichmentWorkerReviewQueueDraft | null {
+  if (job.state !== "review_required" && job.state !== "dead_letter") {
+    return null;
+  }
+
+  const priority =
+    job.state === "dead_letter" || hasIssue(job, "ANSWER_FIRST_HIGH_PRIORITY_ALERT")
+      ? "high_priority"
+      : "normal";
+
+  return {
+    draftVersion: ENRICHMENT_WORKER_ACTION_DRAFTS_VERSION,
+    draftId: `review:${job.jobId}:${job.state}`,
+    draftOnly: true,
+    persistenceStatus: "not_persisted",
+    queueName: "content-kitchen-review",
+    priority,
+    reason: job.state === "dead_letter" ? "answer_first_dead_letter" : "answer_first_review_required",
+    jobId: job.jobId,
+    puzzleId: job.puzzleId,
+    sourceRevisionId: job.sourceRevisionId,
+    targetRevision: job.targetRevision,
+    inputSnapshotHash: job.inputSnapshotHash,
+    state: job.state,
+    issueCodes: [...job.failureReasonCodes],
+    recommendedAction: "review",
+    createdAt: now,
+    deadlineAt: job.deadlineAt,
+    reviewRequiredAt: job.reviewRequiredAt,
+    highPriorityAlertAt: job.highPriorityAlertAt,
+  };
+}
+
+export function buildAnswerFirstEnrichmentWorkerActionDrafts(
+  input: BuildAnswerFirstEnrichmentWorkerActionDraftsInput,
+): AnswerFirstEnrichmentWorkerActionDrafts {
+  const highPriorityJobs = input.outputJobs.filter((job) => hasIssue(job, "ANSWER_FIRST_HIGH_PRIORITY_ALERT"));
+  const normalAlertJobs = input.outputJobs.filter((job) => {
+    if (hasIssue(job, "ANSWER_FIRST_HIGH_PRIORITY_ALERT")) {
+      return false;
+    }
+
+    return hasIssue(job, "ANSWER_FIRST_OVER_SLA") || hasIssue(job, "ANSWER_FIRST_REVIEW_REQUIRED");
+  });
+
+  const notificationDrafts: AnswerFirstEnrichmentWorkerNotificationDraft[] = [];
+  if (normalAlertJobs.length > 0) {
+    notificationDrafts.push(buildNotificationDraft({
+      now: input.now,
+      workerId: input.workerId,
+      priority: "normal",
+      jobs: normalAlertJobs,
+      runSummary: input.runSummary,
+    }));
+  }
+  if (highPriorityJobs.length > 0) {
+    notificationDrafts.push(buildNotificationDraft({
+      now: input.now,
+      workerId: input.workerId,
+      priority: "high_priority",
+      jobs: highPriorityJobs,
+      runSummary: input.runSummary,
+    }));
+  }
+
+  return {
+    schemaVersion: ENRICHMENT_WORKER_ACTION_DRAFTS_VERSION,
+    dryRunOnly: true,
+    createdAt: input.now,
+    workerId: input.workerId,
+    notificationDrafts,
+    reviewQueueDrafts: input.outputJobs.flatMap((job) => {
+      const draft = buildReviewQueueDraft(job, input.now);
+      return draft ? [draft] : [];
+    }),
+  };
+}

--- a/scripts/run-content-kitchen-enrichment-worker-dry-run.ts
+++ b/scripts/run-content-kitchen-enrichment-worker-dry-run.ts
@@ -11,6 +11,10 @@ import {
   createJsonFileAnswerFirstEnrichmentJobStore,
 } from "./content-kitchen-enrichment-file-store";
 import {
+  buildAnswerFirstEnrichmentWorkerActionDrafts,
+  type AnswerFirstEnrichmentWorkerActionDrafts,
+} from "./content-kitchen-enrichment-action-drafts";
+import {
   buildAnswerFirstEnrichmentWorkerRunSummary,
   type AnswerFirstEnrichmentWorkerRunSummary,
 } from "./content-kitchen-enrichment-run-summary";
@@ -56,6 +60,7 @@ export type AnswerFirstEnrichmentWorkerDryRunResult = {
     stateAdvancements: number;
   };
   runSummary: AnswerFirstEnrichmentWorkerRunSummary;
+  actionDrafts: AnswerFirstEnrichmentWorkerActionDrafts;
   outputPath?: string;
   claimedJobs: AnswerFirstEnrichmentWorkerDryRunJobSummary[];
   skippedJobs: Array<{
@@ -209,6 +214,16 @@ type BuildDryRunResultInput = {
 };
 
 function buildDryRunResult(input: BuildDryRunResultInput): AnswerFirstEnrichmentWorkerDryRunResult {
+  const runSummary = buildAnswerFirstEnrichmentWorkerRunSummary({
+    now: input.input.now,
+    workerId: input.input.workerId,
+    inputJobs: input.input.jobs.length,
+    outputJobs: input.outputJobs,
+    claimedJobs: input.claimedJobs,
+    skippedJobs: input.skippedJobs,
+    stateAdvancements: input.stateAdvancements,
+  });
+
   return {
     schemaVersion: ENRICHMENT_WORKER_DRY_RUN_RESULT_VERSION,
     dryRun: true,
@@ -221,14 +236,12 @@ function buildDryRunResult(input: BuildDryRunResultInput): AnswerFirstEnrichment
       skippedJobs: input.skippedJobs.length,
       stateAdvancements: input.stateAdvancements.filter((result) => result.transition !== "unchanged").length,
     },
-    runSummary: buildAnswerFirstEnrichmentWorkerRunSummary({
+    runSummary,
+    actionDrafts: buildAnswerFirstEnrichmentWorkerActionDrafts({
       now: input.input.now,
       workerId: input.input.workerId,
-      inputJobs: input.input.jobs.length,
+      runSummary,
       outputJobs: input.outputJobs,
-      claimedJobs: input.claimedJobs,
-      skippedJobs: input.skippedJobs,
-      stateAdvancements: input.stateAdvancements,
     }),
     outputPath: input.outputPath,
     claimedJobs: input.claimedJobs.map(summarizeJob),


### PR DESCRIPTION
## Summary
- add local PR9 enrichment action drafts derived from the dry-run run summary
- include Feishu-shaped notification drafts marked not_sent
- include review queue drafts marked not_persisted for review_required and dead_letter jobs
- document the twelfth PR9 implementation slice

## Tests
- npm run test:content-kitchen
- npm run content-kitchen:enrichment-dry-run -- --input lib/puzzles/content-kitchen/examples/enrichment-worker-dry-run.input.json --pretty | rg -n 'actionDrafts|notificationDrafts|reviewQueueDrafts|not_sent|not_persisted|answer_first_sla_alert'
- npm run typecheck
- git diff --check
- npm run lint
- npm run validate:data
- npm run build