### PR TITLE
Add PR9 high-priority enrichment dry run

### DIFF
--- a/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
+++ b/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
@@ -2169,6 +2169,14 @@ PR9 twelfth implementation slice:
 - mark notification drafts as `not_sent` and review queue drafts as `not_persisted`
 - keep this local-only; do not send Feishu messages, write review queue storage, attach production storage, or run Worker cron yet
 
+PR9 thirteenth implementation slice:
+
+- add a checked local dry-run example for answer-first enrichment jobs older than the high-priority deadline
+- prove the worker advances those jobs to `dead_letter` before claiming work
+- prove the run summary counts `dead_letter` and high-priority jobs
+- prove the local action drafts include a high-priority Feishu-shaped notification draft and a high-priority review queue draft
+- keep this local-only; do not send Feishu messages, write review queue storage, attach production storage, or run Worker cron yet
+
 ### PR10 — Review Artifact And Human Review
 
 Goal: make failed content actionable.

--- a/lib/puzzles/content-kitchen/examples/enrichment-worker-high-priority.input.json
+++ b/lib/puzzles/content-kitchen/examples/enrichment-worker-high-priority.input.json
@@ -1,0 +1,32 @@
+{
+  "schemaVersion": "content-kitchen-enrichment-worker-dry-run-v0",
+  "now": "2026-05-23T15:05:00.000Z",
+  "workerId": "worker-high-priority-dry-run",
+  "limit": 2,
+  "lockMinutes": 10,
+  "jobs": [
+    {
+      "jobVersion": "answer-first-enrichment-job-v0",
+      "jobId": "job-pinpoint-919-2026-05-23-rev-full-analysis-919",
+      "idempotencyKey": "content-kitchen:answer-first-enrichment:pinpoint-919-2026-05-23:rev-full-analysis-919",
+      "puzzleId": "pinpoint-919-2026-05-23",
+      "sourceRevisionId": "rev-answer-first-919",
+      "targetRevision": "rev-full-analysis-919",
+      "inputSnapshotHash": "sha256:l1-919",
+      "state": "queued",
+      "createdAt": "2026-05-23T08:00:00.000Z",
+      "updatedAt": "2026-05-23T08:00:00.000Z",
+      "nextAttemptAt": "2026-05-23T08:00:00.000Z",
+      "attemptCount": 0,
+      "maxAttempts": 3,
+      "backoffStrategy": "exponential",
+      "deadlineAt": "2026-05-23T08:30:00.000Z",
+      "targetFullAnalysisAt": "2026-05-23T08:30:00.000Z",
+      "firstAlertAt": "2026-05-23T08:30:00.000Z",
+      "reviewRequiredAt": "2026-05-23T09:00:00.000Z",
+      "thinPageNoindexAt": "2026-05-23T10:00:00.000Z",
+      "highPriorityAlertAt": "2026-05-23T14:00:00.000Z",
+      "failureReasonCodes": []
+    }
+  ]
+}

--- a/scripts/check-content-kitchen-contract.ts
+++ b/scripts/check-content-kitchen-contract.ts
@@ -2334,6 +2334,116 @@ async function assertAnswerFirstEnrichmentWorkerJsonDryRun() {
   }
 }
 
+async function assertAnswerFirstEnrichmentWorkerHighPriorityJsonDryRun() {
+  const examplePath = resolve(EXAMPLE_DIR, "enrichment-worker-high-priority.input.json");
+  const raw = await readFile(examplePath, "utf8");
+  const input = JSON.parse(raw) as AnswerFirstEnrichmentWorkerDryRunInput;
+  const result = await runAnswerFirstEnrichmentWorkerJsonDryRun(input);
+
+  assert.deepEqual(
+    result.summary,
+    {
+      inputJobs: 1,
+      outputJobs: 1,
+      claimedJobs: 0,
+      skippedJobs: 1,
+      stateAdvancements: 1,
+    },
+    "high-priority worker dry-run should summarize dead-letter advancement",
+  );
+  assert.equal(
+    result.runSummary.headline,
+    "worker-high-priority-dry-run @ 2026-05-23T15:05:00.000Z; 0 claimed jobs; 1 skipped job; 1 state change; 0 review; 1 dead-letter",
+    "high-priority worker dry-run should include dead-letter in the headline",
+  );
+  assert.deepEqual(
+    result.runSummary.counts,
+    {
+      inputJobs: 1,
+      outputJobs: 1,
+      claimedJobs: 0,
+      skippedJobs: 1,
+      stateChanges: 1,
+      reviewRequiredJobs: 0,
+      deadLetterJobs: 1,
+      overSlaJobs: 1,
+      highPriorityJobs: 1,
+    },
+    "high-priority worker dry-run should count dead-letter and high-priority jobs",
+  );
+  assert.deepEqual(
+    result.runSummary.byOutputState,
+    {
+      dead_letter: 1,
+    },
+    "high-priority worker dry-run should count dead-letter output state",
+  );
+  assert.deepEqual(
+    result.runSummary.bySkipReason,
+    {
+      terminal_state: 1,
+    },
+    "high-priority worker dry-run should skip the advanced dead-letter job as terminal",
+  );
+  assert.deepEqual(
+    result.runSummary.issueCodesAdded,
+    ["ANSWER_FIRST_HIGH_PRIORITY_ALERT", "ANSWER_FIRST_OVER_SLA", "ANSWER_FIRST_REVIEW_REQUIRED"],
+    "high-priority worker dry-run should list all newly-added escalation codes",
+  );
+  assert.deepEqual(
+    result.actionDrafts.notificationDrafts.map((draft) => [
+      draft.priority,
+      draft.reason,
+      draft.dispatchStatus,
+      draft.jobIds,
+      draft.issueCodes,
+    ]),
+    [
+      [
+        "high_priority",
+        "answer_first_high_priority_alert",
+        "not_sent",
+        ["job-pinpoint-919-2026-05-23-rev-full-analysis-919"],
+        ["ANSWER_FIRST_HIGH_PRIORITY_ALERT", "ANSWER_FIRST_OVER_SLA", "ANSWER_FIRST_REVIEW_REQUIRED"],
+      ],
+    ],
+    "high-priority worker dry-run should create a high-priority notification draft without sending it",
+  );
+  assert.deepEqual(
+    result.actionDrafts.reviewQueueDrafts.map((draft) => [
+      draft.priority,
+      draft.reason,
+      draft.persistenceStatus,
+      draft.state,
+      draft.jobId,
+      draft.issueCodes,
+    ]),
+    [
+      [
+        "high_priority",
+        "answer_first_dead_letter",
+        "not_persisted",
+        "dead_letter",
+        "job-pinpoint-919-2026-05-23-rev-full-analysis-919",
+        ["ANSWER_FIRST_OVER_SLA", "ANSWER_FIRST_REVIEW_REQUIRED", "ANSWER_FIRST_HIGH_PRIORITY_ALERT"],
+      ],
+    ],
+    "high-priority worker dry-run should create a high-priority review queue draft without persisting it",
+  );
+  assert.deepEqual(
+    result.stateAdvancements.map((entry) => [entry.job.puzzleId, entry.transition, entry.issueCodesAdded]),
+    [
+      [
+        "pinpoint-919-2026-05-23",
+        "dead_letter",
+        ["ANSWER_FIRST_OVER_SLA", "ANSWER_FIRST_REVIEW_REQUIRED", "ANSWER_FIRST_HIGH_PRIORITY_ALERT"],
+      ],
+    ],
+    "high-priority worker dry-run should advance stale answer-first jobs to dead-letter",
+  );
+  assert.equal(await readFile(examplePath, "utf8"), raw, "high-priority worker dry-run should not mutate the example");
+}
+
 async function main() {
   const fileNames = (await readdir(FIXTURE_DIR)).filter((fileName) => fileName.endsWith(".json")).sort();
   assert.ok(fileNames.length >= 6, "content kitchen should have at least 6 fixtures");
@@ -2377,6 +2487,7 @@ async function main() {
   assertAnswerFirstEnrichmentWorkerTick();
   await assertAnswerFirstEnrichmentJobStoreAdapter();
   await assertAnswerFirstEnrichmentWorkerJsonDryRun();
+  await assertAnswerFirstEnrichmentWorkerHighPriorityJsonDryRun();
   console.log(`content-kitchen contract fixtures passed (${fileNames.length} fixtures)`);
 }
 


### PR DESCRIPTION
## Summary
- add a local high-priority enrichment dry-run example
- prove stale answer-first jobs advance to dead_letter before work is claimed
- assert high-priority notification drafts stay not_sent and review queue drafts stay not_persisted
- document the thirteenth PR9 implementation slice

## Tests
- npm run test:content-kitchen
- npm run content-kitchen:enrichment-dry-run -- --input lib/puzzles/content-kitchen/examples/enrichment-worker-high-priority.input.json --pretty | rg -n 'high_priority|dead_letter|not_sent|not_persisted|ANSWER_FIRST_HIGH_PRIORITY_ALERT'
- npm run typecheck
- git diff --check
- npm run lint
- npm run validate:data
- npm run build