### PR TITLE
Add PR9 enrichment action output file

### DIFF
--- a/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
+++ b/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
@@ -2177,6 +2177,14 @@ PR9 thirteenth implementation slice:
 - prove the local action drafts include a high-priority Feishu-shaped notification draft and a high-priority review queue draft
 - keep this local-only; do not send Feishu messages, write review queue storage, attach production storage, or run Worker cron yet
 
+PR9 fourteenth implementation slice:
+
+- add a local `--action-output` option to the enrichment dry-run runner
+- write only the action drafts to the action output JSON file, including `sourcePath` and `writtenAt`
+- keep the existing `--output` job-state file separate from the action output file
+- reject unsafe paths where `--action-output` equals `--input` or `--output`
+- keep this local-only; do not send Feishu messages, write review queue storage, attach production storage, or run Worker cron yet
+
 ### PR10 — Review Artifact And Human Review
 
 Goal: make failed content actionable.

--- a/scripts/check-content-kitchen-contract.ts
+++ b/scripts/check-content-kitchen-contract.ts
@@ -60,6 +60,7 @@ import { ENRICHMENT_WORKER_RUN_SUMMARY_VERSION } from "./content-kitchen-enrichm
 import {
   ENRICHMENT_WORKER_DRY_RUN_RESULT_VERSION,
   parseAnswerFirstEnrichmentWorkerDryRunInput,
+  runCli as runAnswerFirstEnrichmentWorkerDryRunCli,
   runAnswerFirstEnrichmentWorkerJsonDryRun,
   runAnswerFirstEnrichmentWorkerJsonDryRunToFile,
   type AnswerFirstEnrichmentWorkerDryRunInput,
@@ -2261,10 +2262,12 @@ async function assertAnswerFirstEnrichmentWorkerJsonDryRun() {
   const tmpDir = await mkdtemp(resolve(tmpdir(), "content-kitchen-worker-"));
   try {
     const outputPath = resolve(tmpDir, "worker-output.json");
+    const actionOutputPath = resolve(tmpDir, "worker-action-drafts.json");
     const fileResult = await runAnswerFirstEnrichmentWorkerJsonDryRunToFile({
       input,
       inputPath: examplePath,
       outputPath,
+      actionOutputPath,
     });
     const output = JSON.parse(await readFile(outputPath, "utf8")) as {
       schemaVersion: string;
@@ -2272,11 +2275,35 @@ async function assertAnswerFirstEnrichmentWorkerJsonDryRun() {
       writtenAt: string;
       jobs: Array<{ puzzleId: string; state: string; lockedBy?: string; failureReasonCodes: string[] }>;
     };
+    const actionOutput = JSON.parse(await readFile(actionOutputPath, "utf8")) as {
+      schemaVersion: string;
+      dryRunOnly: boolean;
+      sourcePath: string;
+      writtenAt: string;
+      workerId: string;
+      notificationDrafts: Array<{
+        dispatchStatus: string;
+        priority: string;
+        jobIds: string[];
+        issueCodes: string[];
+      }>;
+      reviewQueueDrafts: Array<{
+        persistenceStatus: string;
+        priority: string;
+        jobId: string;
+        issueCodes: string[];
+      }>;
+    };
 
     assert.equal(
       fileResult.outputPath,
       outputPath,
       "worker dry-run file mode should report the output path",
+    );
+    assert.equal(
+      fileResult.actionOutputPath,
+      actionOutputPath,
+      "worker dry-run file mode should report the action output path",
     );
     assert.equal(
       output.schemaVersion,
@@ -2300,9 +2327,69 @@ async function assertAnswerFirstEnrichmentWorkerJsonDryRun() {
       "worker dry-run file output should persist updated job states",
     );
     assert.equal(
+      actionOutput.schemaVersion,
+      ENRICHMENT_WORKER_ACTION_DRAFTS_VERSION,
+      "worker dry-run action output file should use the action draft schema version",
+    );
+    assert.equal(actionOutput.dryRunOnly, true, "worker dry-run action output file should stay dry-run only");
+    assert.equal(actionOutput.sourcePath, examplePath, "worker dry-run action output should record the source path");
+    assert.equal(actionOutput.writtenAt, input.now, "worker dry-run action output should use the dry-run timestamp");
+    assert.equal(actionOutput.workerId, input.workerId, "worker dry-run action output should record the worker id");
+    assert.deepEqual(
+      actionOutput.notificationDrafts.map((draft) => [
+        draft.dispatchStatus,
+        draft.priority,
+        draft.jobIds,
+        draft.issueCodes,
+      ]),
+      [
+        [
+          "not_sent",
+          "normal",
+          ["job-pinpoint-918-2026-05-23-rev-full-analysis-918"],
+          ["ANSWER_FIRST_OVER_SLA", "ANSWER_FIRST_REVIEW_REQUIRED"],
+        ],
+      ],
+      "worker dry-run action output should write notification drafts without sending them",
+    );
+    assert.deepEqual(
+      actionOutput.reviewQueueDrafts.map((draft) => [
+        draft.persistenceStatus,
+        draft.priority,
+        draft.jobId,
+        draft.issueCodes,
+      ]),
+      [
+        [
+          "not_persisted",
+          "normal",
+          "job-pinpoint-918-2026-05-23-rev-full-analysis-918",
+          ["ANSWER_FIRST_OVER_SLA", "ANSWER_FIRST_REVIEW_REQUIRED"],
+        ],
+      ],
+      "worker dry-run action output should write review queue drafts without persisting them",
+    );
+    assert.equal(
       await readFile(examplePath, "utf8"),
       raw,
       "worker dry-run file mode should not mutate the input file",
+    );
+    await assert.rejects(
+      () => runAnswerFirstEnrichmentWorkerDryRunCli(["--input", examplePath, "--action-output", examplePath]),
+      /--action-output must be different from --input/,
+      "worker dry-run CLI should reject action output paths that would overwrite the input",
+    );
+    await assert.rejects(
+      () => runAnswerFirstEnrichmentWorkerDryRunCli([
+        "--input",
+        examplePath,
+        "--output",
+        outputPath,
+        "--action-output",
+        outputPath,
+      ]),
+      /--action-output must be different from --output/,
+      "worker dry-run CLI should keep job output and action output paths separate",
     );
 
     const resumedInput = parseAnswerFirstEnrichmentWorkerDryRunInput(output, {

--- a/scripts/run-content-kitchen-enrichment-worker-dry-run.ts
+++ b/scripts/run-content-kitchen-enrichment-worker-dry-run.ts
@@ -1,5 +1,5 @@
-import { readFile } from "node:fs/promises";
-import { resolve } from "node:path";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import {
   createInMemoryAnswerFirstEnrichmentJobStore,
@@ -62,6 +62,7 @@ export type AnswerFirstEnrichmentWorkerDryRunResult = {
   runSummary: AnswerFirstEnrichmentWorkerRunSummary;
   actionDrafts: AnswerFirstEnrichmentWorkerActionDrafts;
   outputPath?: string;
+  actionOutputPath?: string;
   claimedJobs: AnswerFirstEnrichmentWorkerDryRunJobSummary[];
   skippedJobs: Array<{
     job: AnswerFirstEnrichmentWorkerDryRunJobSummary;
@@ -78,6 +79,7 @@ export type AnswerFirstEnrichmentWorkerDryRunResult = {
 type ParsedArgs = {
   inputPath: string;
   outputPath?: string;
+  actionOutputPath?: string;
   now?: string;
   workerId?: string;
   limit?: number;
@@ -90,6 +92,11 @@ type DryRunInputOverrides = {
   workerId?: string;
   limit?: number;
   lockMinutes?: number;
+};
+
+export type AnswerFirstEnrichmentWorkerActionDraftsFileOutput = AnswerFirstEnrichmentWorkerActionDrafts & {
+  sourcePath: string;
+  writtenAt: string;
 };
 
 function requireObject(value: unknown, fieldPath: string): Record<string, unknown> {
@@ -261,6 +268,7 @@ function buildDryRunResult(input: BuildDryRunResultInput): AnswerFirstEnrichment
 function parseArgs(argv: string[]): ParsedArgs {
   let inputPath = "";
   let outputPath: string | undefined;
+  let actionOutputPath: string | undefined;
   let now: string | undefined;
   let workerId: string | undefined;
   let limit: number | undefined;
@@ -277,6 +285,12 @@ function parseArgs(argv: string[]): ParsedArgs {
 
     if (arg === "--output") {
       outputPath = resolve(readArgValue(argv, index, "--output"));
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--action-output") {
+      actionOutputPath = resolve(readArgValue(argv, index, "--action-output"));
       index += 1;
       continue;
     }
@@ -317,7 +331,7 @@ function parseArgs(argv: string[]): ParsedArgs {
 
     if (arg === "--help" || arg === "-h") {
       throw new Error(
-        "Usage: npm run content-kitchen:enrichment-dry-run -- --input <path> [--output <path>] [--now <timestamp>] [--worker-id <id>] [--limit <n>] [--lock-minutes <n>] [--pretty|--compact]",
+        "Usage: npm run content-kitchen:enrichment-dry-run -- --input <path> [--output <path>] [--action-output <path>] [--now <timestamp>] [--worker-id <id>] [--limit <n>] [--lock-minutes <n>] [--pretty|--compact]",
       );
     }
 
@@ -332,10 +346,17 @@ function parseArgs(argv: string[]): ParsedArgs {
   if (outputPath === resolvedInputPath) {
     throw new Error("--output must be different from --input");
   }
+  if (actionOutputPath === resolvedInputPath) {
+    throw new Error("--action-output must be different from --input");
+  }
+  if (actionOutputPath && outputPath === actionOutputPath) {
+    throw new Error("--action-output must be different from --output");
+  }
 
   return {
     inputPath: resolvedInputPath,
     outputPath,
+    actionOutputPath,
     now,
     workerId,
     limit,
@@ -376,15 +397,30 @@ export async function runCli(argv: string[] = process.argv.slice(2)): Promise<vo
       input,
       inputPath: args.inputPath,
       outputPath: args.outputPath,
+      actionOutputPath: args.actionOutputPath,
     })
     : await runAnswerFirstEnrichmentWorkerJsonDryRun(input);
-  console.log(JSON.stringify(result, null, args.pretty ? 2 : 0));
+  const outputResult = args.actionOutputPath && !args.outputPath
+    ? { ...result, actionOutputPath: args.actionOutputPath }
+    : result;
+
+  if (args.actionOutputPath && !args.outputPath) {
+    await writeAnswerFirstEnrichmentWorkerActionDraftsFile({
+      actionDrafts: result.actionDrafts,
+      inputPath: args.inputPath,
+      actionOutputPath: args.actionOutputPath,
+      writtenAt: input.now,
+    });
+  }
+
+  console.log(JSON.stringify(outputResult, null, args.pretty ? 2 : 0));
 }
 
 export async function runAnswerFirstEnrichmentWorkerJsonDryRunToFile(input: {
   input: AnswerFirstEnrichmentWorkerDryRunInput;
   inputPath: string;
   outputPath: string;
+  actionOutputPath?: string;
 }): Promise<AnswerFirstEnrichmentWorkerDryRunResult> {
   const store = createJsonFileAnswerFirstEnrichmentJobStore({
     inputPath: input.inputPath,
@@ -399,7 +435,7 @@ export async function runAnswerFirstEnrichmentWorkerJsonDryRunToFile(input: {
     lockMinutes: input.input.lockMinutes,
   });
 
-  return buildDryRunResult({
+  const result = buildDryRunResult({
     input: input.input,
     outputPath: input.outputPath,
     outputJobs: tick.updatedJobs,
@@ -407,6 +443,38 @@ export async function runAnswerFirstEnrichmentWorkerJsonDryRunToFile(input: {
     skippedJobs: tick.skippedJobs,
     stateAdvancements: tick.stateAdvancements,
   });
+
+  if (input.actionOutputPath) {
+    await writeAnswerFirstEnrichmentWorkerActionDraftsFile({
+      actionDrafts: result.actionDrafts,
+      inputPath: input.inputPath,
+      actionOutputPath: input.actionOutputPath,
+      writtenAt: input.input.now,
+    });
+  }
+
+  return {
+    ...result,
+    actionOutputPath: input.actionOutputPath,
+  };
+}
+
+export async function writeAnswerFirstEnrichmentWorkerActionDraftsFile(input: {
+  actionDrafts: AnswerFirstEnrichmentWorkerActionDrafts;
+  inputPath: string;
+  actionOutputPath: string;
+  writtenAt: string;
+}): Promise<AnswerFirstEnrichmentWorkerActionDraftsFileOutput> {
+  const output: AnswerFirstEnrichmentWorkerActionDraftsFileOutput = {
+    ...input.actionDrafts,
+    sourcePath: resolve(input.inputPath),
+    writtenAt: new Date(Date.parse(input.writtenAt)).toISOString(),
+  };
+
+  await mkdir(dirname(input.actionOutputPath), { recursive: true });
+  await writeFile(input.actionOutputPath, `${JSON.stringify(output, null, 2)}\n`, "utf8");
+
+  return output;
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {


### PR DESCRIPTION
## Summary
- add a local --action-output option to the enrichment dry-run runner
- write action drafts to a separate JSON file with sourcePath and writtenAt
- keep job-state output and action output paths separate
- document the fourteenth PR9 implementation slice

## Tests
- npm run test:content-kitchen
- npm run content-kitchen:enrichment-dry-run -- --input lib/puzzles/content-kitchen/examples/enrichment-worker-dry-run.input.json --action-output /tmp/content-kitchen-action-output.LUUS6M/actions.json --pretty
- rg -n 'sourcePath|writtenAt|notificationDrafts|reviewQueueDrafts|not_sent|not_persisted' /tmp/content-kitchen-action-output.LUUS6M/actions.json
- npm run typecheck
- git diff --check
- npm run lint
- npm run validate:data
- npm run build