### PR TITLE
Add PR9 enrichment dry run usage doc

### DIFF
--- a/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
+++ b/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
@@ -2185,6 +2185,13 @@ PR9 fourteenth implementation slice:
 - reject unsafe paths where `--action-output` equals `--input` or `--output`
 - keep this local-only; do not send Feishu messages, write review queue storage, attach production storage, or run Worker cron yet
 
+PR9 fifteenth implementation slice:
+
+- add a local usage note for the enrichment dry-run runner
+- document inspect-only mode, `--output`, `--action-output`, writing both files, and resuming from a previous output
+- make the contract test check that the usage note names the dry-run command, output flags, and local-only safety markers
+- keep this local-only; do not send Feishu messages, write review queue storage, attach production storage, or run Worker cron yet
+
 ### PR10 — Review Artifact And Human Review
 
 Goal: make failed content actionable.

--- a/docs/pinpoint-content-kitchen-pr9-enrichment-dry-run-usage-2026-05-24.md
+++ b/docs/pinpoint-content-kitchen-pr9-enrichment-dry-run-usage-2026-05-24.md
@@ -1,0 +1,133 @@
+# PR9 Enrichment Dry-Run Usage
+
+This is the local operator note for the PR9 answer-first enrichment worker dry run.
+
+It is intentionally local-only:
+
+- it does not publish content
+- it does not send Feishu messages
+- it does not write review queue storage
+- it does not touch production storage
+- it does not run Worker cron
+
+## Inputs
+
+Use a checked job input file:
+
+```bash
+lib/puzzles/content-kitchen/examples/enrichment-worker-dry-run.input.json
+```
+
+For a high-priority escalation example, use:
+
+```bash
+lib/puzzles/content-kitchen/examples/enrichment-worker-high-priority.input.json
+```
+
+## Inspect Only
+
+Print the full dry-run result without writing files:
+
+```bash
+npm run content-kitchen:enrichment-dry-run -- \
+  --input lib/puzzles/content-kitchen/examples/enrichment-worker-dry-run.input.json \
+  --pretty
+```
+
+This prints:
+
+- updated job state preview
+- `runSummary`
+- `actionDrafts`
+- claimed jobs
+- skipped jobs
+- state advancement decisions
+
+## Write Job State Preview
+
+Write updated job state to a separate local file:
+
+```bash
+npm run content-kitchen:enrichment-dry-run -- \
+  --input lib/puzzles/content-kitchen/examples/enrichment-worker-dry-run.input.json \
+  --output /tmp/content-kitchen-worker-output.json \
+  --pretty
+```
+
+Rules:
+
+- the input file is read-only
+- `--output` must not equal `--input`
+- the output file can be used as the next dry-run input
+
+## Write Action Drafts
+
+Write only notification and review queue drafts to a separate local file:
+
+```bash
+npm run content-kitchen:enrichment-dry-run -- \
+  --input lib/puzzles/content-kitchen/examples/enrichment-worker-dry-run.input.json \
+  --action-output /tmp/content-kitchen-action-drafts.json \
+  --pretty
+```
+
+The action output contains:
+
+- `sourcePath`
+- `writtenAt`
+- notification drafts with `dispatchStatus: "not_sent"`
+- review queue drafts with `persistenceStatus: "not_persisted"`
+
+Rules:
+
+- --action-output must not equal `--input`
+- --action-output must not equal `--output`
+- action drafts are for inspection only
+- action drafts are not sent to Feishu
+- action drafts are not written to review queue storage
+
+## Write Both Files
+
+Write job state preview and action drafts in one local run:
+
+```bash
+npm run content-kitchen:enrichment-dry-run -- \
+  --input lib/puzzles/content-kitchen/examples/enrichment-worker-dry-run.input.json \
+  --output /tmp/content-kitchen-worker-output.json \
+  --action-output /tmp/content-kitchen-action-drafts.json \
+  --pretty
+```
+
+Use this when manually checking one worker pass before any future production wiring.
+
+## Resume From Output
+
+Use a previous job-state output as the next input:
+
+```bash
+npm run content-kitchen:enrichment-dry-run -- \
+  --input /tmp/content-kitchen-worker-output.json \
+  --output /tmp/content-kitchen-worker-output-next.json \
+  --action-output /tmp/content-kitchen-action-drafts-next.json \
+  --now 2026-05-23T09:12:00.000Z \
+  --worker-id worker-dry-run-next \
+  --lock-minutes 10 \
+  --pretty
+```
+
+This is still local-only. It only proves that queue state can be resumed and inspected.
+
+## What To Check
+
+After a normal SLA miss:
+
+- `notificationDrafts[0].dispatchStatus` is `not_sent`
+- `reviewQueueDrafts[0].persistenceStatus` is `not_persisted`
+- `reviewQueueDrafts[0].reason` is `answer_first_review_required`
+
+After a high-priority miss:
+
+- output job state is `dead_letter`
+- notification priority is `high_priority`
+- review queue priority is `high_priority`
+- high-priority action drafts are still `not_sent` and `not_persisted`

--- a/scripts/check-content-kitchen-contract.ts
+++ b/scripts/check-content-kitchen-contract.ts
@@ -81,6 +81,11 @@ const ROOT = resolve(SCRIPT_DIR, "..");
 const FIXTURE_DIR = resolve(ROOT, "lib", "puzzles", "content-kitchen", "fixtures");
 const EXAMPLE_DIR = resolve(ROOT, "lib", "puzzles", "content-kitchen", "examples");
 const PACKAGE_JSON_PATH = resolve(ROOT, "package.json");
+const PR9_ENRICHMENT_DRY_RUN_USAGE_DOC_PATH = resolve(
+  ROOT,
+  "docs",
+  "pinpoint-content-kitchen-pr9-enrichment-dry-run-usage-2026-05-24.md",
+);
 
 type Fixture = {
   name: string;
@@ -2531,6 +2536,28 @@ async function assertAnswerFirstEnrichmentWorkerHighPriorityJsonDryRun() {
   assert.equal(await readFile(examplePath, "utf8"), raw, "high-priority worker dry-run should not mutate the example");
 }
 
+async function assertAnswerFirstEnrichmentDryRunUsageDoc() {
+  const doc = await readFile(PR9_ENRICHMENT_DRY_RUN_USAGE_DOC_PATH, "utf8");
+  const requiredSnippets = [
+    "npm run content-kitchen:enrichment-dry-run",
+    "--input lib/puzzles/content-kitchen/examples/enrichment-worker-dry-run.input.json",
+    "--output /tmp/content-kitchen-worker-output.json",
+    "--action-output /tmp/content-kitchen-action-drafts.json",
+    "--action-output must not equal `--input`",
+    "--action-output must not equal `--output`",
+    "dispatchStatus: \"not_sent\"",
+    "persistenceStatus: \"not_persisted\"",
+    "does not send Feishu messages",
+    "does not write review queue storage",
+    "does not touch production storage",
+    "does not run Worker cron",
+  ];
+
+  for (const snippet of requiredSnippets) {
+    assert.ok(doc.includes(snippet), `PR9 enrichment dry-run usage doc should include: ${snippet}`);
+  }
+}
+
 async function main() {
   const fileNames = (await readdir(FIXTURE_DIR)).filter((fileName) => fileName.endsWith(".json")).sort();
   assert.ok(fileNames.length >= 6, "content kitchen should have at least 6 fixtures");
@@ -2575,6 +2602,7 @@ async function main() {
   await assertAnswerFirstEnrichmentJobStoreAdapter();
   await assertAnswerFirstEnrichmentWorkerJsonDryRun();
   await assertAnswerFirstEnrichmentWorkerHighPriorityJsonDryRun();
+  await assertAnswerFirstEnrichmentDryRunUsageDoc();
   console.log(`content-kitchen contract fixtures passed (${fileNames.length} fixtures)`);
 }
 


### PR DESCRIPTION
## Summary
- add a local PR9 enrichment dry-run usage note
- document inspect-only mode, --output, --action-output, writing both files, and resume usage
- add a contract check so the usage note keeps the command flags and local-only safety markers
- document the fifteenth PR9 implementation slice

## Tests
- npm run test:content-kitchen
- npm run content-kitchen:enrichment-dry-run -- --input lib/puzzles/content-kitchen/examples/enrichment-worker-dry-run.input.json --output /tmp/.../worker-output.json --action-output /tmp/.../action-drafts.json --pretty
- npm run typecheck
- git diff --check
- npm run lint
- npm run validate:data
- npm run build