### PR TITLE
Add PR9 enrichment worker health report

### DIFF
--- a/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
+++ b/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
@@ -2192,6 +2192,14 @@ PR9 fifteenth implementation slice:
 - make the contract test check that the usage note names the dry-run command, output flags, and local-only safety markers
 - keep this local-only; do not send Feishu messages, write review queue storage, attach production storage, or run Worker cron yet
 
+PR9 sixteenth implementation slice:
+
+- add a local worker health report derived from the dry-run summary and action drafts
+- return one compact status: `ok`, `needs_review`, `high_priority`, or `blocked`
+- include compact counts, important job ids, active issue codes, skip reasons, and a recommended operator action
+- cover all four health statuses in the content-kitchen contract test
+- keep this local-only; do not send Feishu messages, write review queue storage, attach production storage, or run Worker cron yet
+
 ### PR10 — Review Artifact And Human Review
 
 Goal: make failed content actionable.

--- a/docs/pinpoint-content-kitchen-pr9-enrichment-dry-run-usage-2026-05-24.md
+++ b/docs/pinpoint-content-kitchen-pr9-enrichment-dry-run-usage-2026-05-24.md
@@ -39,9 +39,31 @@ This prints:
 - updated job state preview
 - `runSummary`
 - `actionDrafts`
+- `healthReport`
 - claimed jobs
 - skipped jobs
 - state advancement decisions
+
+## Health Report
+
+Start with `healthReport.status` before reading the full output.
+
+The status values are:
+
+- `ok`: no review action is needed
+- `needs_review`: inspect review queue drafts before allowing automatic enrichment to continue
+- `high_priority`: inspect high-priority action drafts before any future publish automation
+- `blocked`: inspect dead-letter or max-attempt jobs before retrying the queue
+
+The health report also includes:
+
+- compact counts
+- claimed job ids
+- review job ids
+- dead-letter job ids
+- high-priority job ids
+- active issue codes
+- skip reasons
 
 ## Write Job State Preview
 

--- a/scripts/check-content-kitchen-contract.ts
+++ b/scripts/check-content-kitchen-contract.ts
@@ -56,6 +56,7 @@ import { buildReviewArtifactV0, shouldCreateReviewArtifact } from "../lib/puzzle
 import { validateCandidate } from "../lib/puzzles/content-kitchen/validate-candidate";
 import { ENRICHMENT_WORKER_FILE_STORE_OUTPUT_VERSION } from "./content-kitchen-enrichment-file-store";
 import { ENRICHMENT_WORKER_ACTION_DRAFTS_VERSION } from "./content-kitchen-enrichment-action-drafts";
+import { ENRICHMENT_WORKER_HEALTH_REPORT_VERSION } from "./content-kitchen-enrichment-health-report";
 import { ENRICHMENT_WORKER_RUN_SUMMARY_VERSION } from "./content-kitchen-enrichment-run-summary";
 import {
   ENRICHMENT_WORKER_DRY_RUN_RESULT_VERSION,
@@ -2210,6 +2211,41 @@ async function assertAnswerFirstEnrichmentWorkerJsonDryRun() {
     ],
     "worker dry-run should produce a review queue draft without persisting it",
   );
+  assert.equal(
+    result.healthReport.schemaVersion,
+    ENRICHMENT_WORKER_HEALTH_REPORT_VERSION,
+    "worker dry-run should include a stable health report schema",
+  );
+  assert.equal(result.healthReport.status, "needs_review", "worker dry-run health should surface review needs");
+  assert.equal(
+    result.healthReport.recommendation,
+    "Inspect review queue drafts before allowing automatic enrichment to continue.",
+    "worker dry-run health should recommend review for normal SLA misses",
+  );
+  assert.deepEqual(
+    result.healthReport.counts,
+    {
+      inputJobs: 3,
+      claimedJobs: 1,
+      skippedJobs: 2,
+      reviewRequiredJobs: 1,
+      deadLetterJobs: 0,
+      highPriorityJobs: 0,
+      notificationDrafts: 1,
+      reviewQueueDrafts: 1,
+    },
+    "worker dry-run health should include compact counts",
+  );
+  assert.deepEqual(
+    result.healthReport.jobIds,
+    {
+      claimed: ["job-pinpoint-916-2026-05-23-rev-full-analysis-916"],
+      reviewRequired: ["job-pinpoint-918-2026-05-23-rev-full-analysis-918"],
+      deadLetter: [],
+      highPriority: [],
+    },
+    "worker dry-run health should include compact job id groups",
+  );
   assert.deepEqual(
     result.claimedJobs.map((job) => [job.puzzleId, job.state, job.lockedBy, job.lockedUntil]),
     [["pinpoint-916-2026-05-23", "running", "worker-dry-run", "2026-05-23T09:11:00.000Z"]],
@@ -2413,6 +2449,11 @@ async function assertAnswerFirstEnrichmentWorkerJsonDryRun() {
       [["pinpoint-916-2026-05-23", 2, "worker-dry-run-next", "2026-05-23T09:22:00.000Z"]],
       "worker dry-run should be able to use a file-store output as the next input",
     );
+    assert.equal(
+      resumedResult.healthReport.status,
+      "needs_review",
+      "resumed worker dry-run health should keep surfacing unresolved review work",
+    );
     assert.deepEqual(
       resumedResult.skippedJobs.map((entry) => [entry.job.puzzleId, entry.reason]),
       [
@@ -2522,6 +2563,21 @@ async function assertAnswerFirstEnrichmentWorkerHighPriorityJsonDryRun() {
     ],
     "high-priority worker dry-run should create a high-priority review queue draft without persisting it",
   );
+  assert.equal(
+    result.healthReport.status,
+    "high_priority",
+    "high-priority worker dry-run health should surface urgent action",
+  );
+  assert.deepEqual(
+    result.healthReport.jobIds.highPriority,
+    ["job-pinpoint-919-2026-05-23-rev-full-analysis-919"],
+    "high-priority worker dry-run health should include high-priority job ids",
+  );
+  assert.equal(
+    result.healthReport.recommendation,
+    "Inspect high-priority action drafts before any future publish automation.",
+    "high-priority worker dry-run health should recommend urgent inspection",
+  );
   assert.deepEqual(
     result.stateAdvancements.map((entry) => [entry.job.puzzleId, entry.transition, entry.issueCodesAdded]),
     [
@@ -2536,6 +2592,45 @@ async function assertAnswerFirstEnrichmentWorkerHighPriorityJsonDryRun() {
   assert.equal(await readFile(examplePath, "utf8"), raw, "high-priority worker dry-run should not mutate the example");
 }
 
+async function assertAnswerFirstEnrichmentWorkerHealthStatuses() {
+  const examplePath = resolve(EXAMPLE_DIR, "enrichment-worker-dry-run.input.json");
+  const raw = await readFile(examplePath, "utf8");
+  const input = JSON.parse(raw) as AnswerFirstEnrichmentWorkerDryRunInput;
+  const freshResult = await runAnswerFirstEnrichmentWorkerJsonDryRun({
+    ...input,
+    jobs: [input.jobs[0]],
+  });
+  assert.equal(freshResult.healthReport.status, "ok", "fresh runnable jobs should produce ok health");
+  assert.equal(
+    freshResult.healthReport.recommendation,
+    "No review action is needed for this dry run.",
+    "ok health should not ask for review",
+  );
+
+  const maxAttemptsResult = await runAnswerFirstEnrichmentWorkerJsonDryRun({
+    ...input,
+    jobs: [{
+      ...input.jobs[0],
+      attemptCount: input.jobs[0].maxAttempts,
+    }],
+  });
+  assert.equal(
+    maxAttemptsResult.healthReport.status,
+    "blocked",
+    "jobs at max attempts should produce blocked health",
+  );
+  assert.deepEqual(
+    maxAttemptsResult.healthReport.skipReasons,
+    { max_attempts_reached: 1 },
+    "blocked health should expose the max-attempt skip reason",
+  );
+  assert.equal(
+    maxAttemptsResult.healthReport.recommendation,
+    "Inspect dead-letter or max-attempt jobs before retrying the queue.",
+    "blocked health should recommend queue inspection before retrying",
+  );
+}
+
 async function assertAnswerFirstEnrichmentDryRunUsageDoc() {
   const doc = await readFile(PR9_ENRICHMENT_DRY_RUN_USAGE_DOC_PATH, "utf8");
   const requiredSnippets = [
@@ -2543,6 +2638,11 @@ async function assertAnswerFirstEnrichmentDryRunUsageDoc() {
     "--input lib/puzzles/content-kitchen/examples/enrichment-worker-dry-run.input.json",
     "--output /tmp/content-kitchen-worker-output.json",
     "--action-output /tmp/content-kitchen-action-drafts.json",
+    "`healthReport`",
+    "`ok`: no review action is needed",
+    "`needs_review`: inspect review queue drafts before allowing automatic enrichment to continue",
+    "`high_priority`: inspect high-priority action drafts before any future publish automation",
+    "`blocked`: inspect dead-letter or max-attempt jobs before retrying the queue",
     "--action-output must not equal `--input`",
     "--action-output must not equal `--output`",
     "dispatchStatus: \"not_sent\"",
@@ -2602,6 +2702,7 @@ async function main() {
   await assertAnswerFirstEnrichmentJobStoreAdapter();
   await assertAnswerFirstEnrichmentWorkerJsonDryRun();
   await assertAnswerFirstEnrichmentWorkerHighPriorityJsonDryRun();
+  await assertAnswerFirstEnrichmentWorkerHealthStatuses();
   await assertAnswerFirstEnrichmentDryRunUsageDoc();
   console.log(`content-kitchen contract fixtures passed (${fileNames.length} fixtures)`);
 }

--- a/scripts/content-kitchen-enrichment-health-report.ts
+++ b/scripts/content-kitchen-enrichment-health-report.ts
@@ -1,0 +1,138 @@
+import type { EnrichmentQueueSkipReason } from "../lib/puzzles/content-kitchen/enrichment-job";
+import type { ContentKitchenIssueCode } from "../lib/puzzles/content-kitchen/types";
+import type { AnswerFirstEnrichmentWorkerActionDrafts } from "./content-kitchen-enrichment-action-drafts";
+import type { AnswerFirstEnrichmentWorkerRunSummary } from "./content-kitchen-enrichment-run-summary";
+
+export const ENRICHMENT_WORKER_HEALTH_REPORT_VERSION =
+  "content-kitchen-enrichment-worker-health-report-v0";
+
+export type AnswerFirstEnrichmentWorkerHealthStatus =
+  | "ok"
+  | "needs_review"
+  | "high_priority"
+  | "blocked";
+
+export type AnswerFirstEnrichmentWorkerHealthReport = {
+  schemaVersion: typeof ENRICHMENT_WORKER_HEALTH_REPORT_VERSION;
+  status: AnswerFirstEnrichmentWorkerHealthStatus;
+  headline: string;
+  recommendation: string;
+  counts: {
+    inputJobs: number;
+    claimedJobs: number;
+    skippedJobs: number;
+    reviewRequiredJobs: number;
+    deadLetterJobs: number;
+    highPriorityJobs: number;
+    notificationDrafts: number;
+    reviewQueueDrafts: number;
+  };
+  jobIds: {
+    claimed: string[];
+    reviewRequired: string[];
+    deadLetter: string[];
+    highPriority: string[];
+  };
+  activeIssueCodes: ContentKitchenIssueCode[];
+  skipReasons: Partial<Record<EnrichmentQueueSkipReason, number>>;
+};
+
+export type BuildAnswerFirstEnrichmentWorkerHealthReportInput = {
+  runSummary: AnswerFirstEnrichmentWorkerRunSummary;
+  actionDrafts: AnswerFirstEnrichmentWorkerActionDrafts;
+};
+
+function uniqueSorted(values: string[]): string[] {
+  return [...new Set(values)].sort();
+}
+
+function buildStatus(
+  input: BuildAnswerFirstEnrichmentWorkerHealthReportInput,
+): AnswerFirstEnrichmentWorkerHealthStatus {
+  const highPriorityDrafts =
+    input.actionDrafts.notificationDrafts.some((draft) => draft.priority === "high_priority") ||
+    input.actionDrafts.reviewQueueDrafts.some((draft) => draft.priority === "high_priority");
+
+  if (input.runSummary.counts.highPriorityJobs > 0 || highPriorityDrafts) {
+    return "high_priority";
+  }
+
+  if (
+    input.runSummary.counts.deadLetterJobs > 0 ||
+    (input.runSummary.bySkipReason.max_attempts_reached ?? 0) > 0
+  ) {
+    return "blocked";
+  }
+
+  if (
+    input.runSummary.counts.reviewRequiredJobs > 0 ||
+    input.actionDrafts.notificationDrafts.length > 0 ||
+    input.actionDrafts.reviewQueueDrafts.length > 0
+  ) {
+    return "needs_review";
+  }
+
+  return "ok";
+}
+
+function recommendationFor(status: AnswerFirstEnrichmentWorkerHealthStatus): string {
+  if (status === "high_priority") {
+    return "Inspect high-priority action drafts before any future publish automation.";
+  }
+
+  if (status === "blocked") {
+    return "Inspect dead-letter or max-attempt jobs before retrying the queue.";
+  }
+
+  if (status === "needs_review") {
+    return "Inspect review queue drafts before allowing automatic enrichment to continue.";
+  }
+
+  return "No review action is needed for this dry run.";
+}
+
+function headlineFor(
+  status: AnswerFirstEnrichmentWorkerHealthStatus,
+  runSummary: AnswerFirstEnrichmentWorkerRunSummary,
+): string {
+  return `${status}: ${runSummary.headline}`;
+}
+
+export function buildAnswerFirstEnrichmentWorkerHealthReport(
+  input: BuildAnswerFirstEnrichmentWorkerHealthReportInput,
+): AnswerFirstEnrichmentWorkerHealthReport {
+  const status = buildStatus(input);
+  const highPriorityJobIds = uniqueSorted([
+    ...input.actionDrafts.notificationDrafts
+      .filter((draft) => draft.priority === "high_priority")
+      .flatMap((draft) => draft.jobIds),
+    ...input.actionDrafts.reviewQueueDrafts
+      .filter((draft) => draft.priority === "high_priority")
+      .map((draft) => draft.jobId),
+  ]);
+
+  return {
+    schemaVersion: ENRICHMENT_WORKER_HEALTH_REPORT_VERSION,
+    status,
+    headline: headlineFor(status, input.runSummary),
+    recommendation: recommendationFor(status),
+    counts: {
+      inputJobs: input.runSummary.counts.inputJobs,
+      claimedJobs: input.runSummary.counts.claimedJobs,
+      skippedJobs: input.runSummary.counts.skippedJobs,
+      reviewRequiredJobs: input.runSummary.counts.reviewRequiredJobs,
+      deadLetterJobs: input.runSummary.counts.deadLetterJobs,
+      highPriorityJobs: input.runSummary.counts.highPriorityJobs,
+      notificationDrafts: input.actionDrafts.notificationDrafts.length,
+      reviewQueueDrafts: input.actionDrafts.reviewQueueDrafts.length,
+    },
+    jobIds: {
+      claimed: [...input.runSummary.claimedJobIds],
+      reviewRequired: [...input.runSummary.reviewRequiredJobIds],
+      deadLetter: [...input.runSummary.deadLetterJobIds],
+      highPriority: highPriorityJobIds,
+    },
+    activeIssueCodes: [...input.runSummary.activeIssueCodes],
+    skipReasons: { ...input.runSummary.bySkipReason },
+  };
+}

--- a/scripts/run-content-kitchen-enrichment-worker-dry-run.ts
+++ b/scripts/run-content-kitchen-enrichment-worker-dry-run.ts
@@ -15,6 +15,10 @@ import {
   type AnswerFirstEnrichmentWorkerActionDrafts,
 } from "./content-kitchen-enrichment-action-drafts";
 import {
+  buildAnswerFirstEnrichmentWorkerHealthReport,
+  type AnswerFirstEnrichmentWorkerHealthReport,
+} from "./content-kitchen-enrichment-health-report";
+import {
   buildAnswerFirstEnrichmentWorkerRunSummary,
   type AnswerFirstEnrichmentWorkerRunSummary,
 } from "./content-kitchen-enrichment-run-summary";
@@ -61,6 +65,7 @@ export type AnswerFirstEnrichmentWorkerDryRunResult = {
   };
   runSummary: AnswerFirstEnrichmentWorkerRunSummary;
   actionDrafts: AnswerFirstEnrichmentWorkerActionDrafts;
+  healthReport: AnswerFirstEnrichmentWorkerHealthReport;
   outputPath?: string;
   actionOutputPath?: string;
   claimedJobs: AnswerFirstEnrichmentWorkerDryRunJobSummary[];
@@ -230,6 +235,12 @@ function buildDryRunResult(input: BuildDryRunResultInput): AnswerFirstEnrichment
     skippedJobs: input.skippedJobs,
     stateAdvancements: input.stateAdvancements,
   });
+  const actionDrafts = buildAnswerFirstEnrichmentWorkerActionDrafts({
+    now: input.input.now,
+    workerId: input.input.workerId,
+    runSummary,
+    outputJobs: input.outputJobs,
+  });
 
   return {
     schemaVersion: ENRICHMENT_WORKER_DRY_RUN_RESULT_VERSION,
@@ -244,11 +255,10 @@ function buildDryRunResult(input: BuildDryRunResultInput): AnswerFirstEnrichment
       stateAdvancements: input.stateAdvancements.filter((result) => result.transition !== "unchanged").length,
     },
     runSummary,
-    actionDrafts: buildAnswerFirstEnrichmentWorkerActionDrafts({
-      now: input.input.now,
-      workerId: input.input.workerId,
+    actionDrafts,
+    healthReport: buildAnswerFirstEnrichmentWorkerHealthReport({
       runSummary,
-      outputJobs: input.outputJobs,
+      actionDrafts,
     }),
     outputPath: input.outputPath,
     claimedJobs: input.claimedJobs.map(summarizeJob),


### PR DESCRIPTION
## Summary
- add a local enrichment worker health report derived from run summaries and action drafts
- surface compact statuses: ok, needs_review, high_priority, and blocked
- include compact counts, job id groups, active issue codes, skip reasons, and operator recommendations
- document the health report in the PR9 usage note and architecture plan

## Tests
- npm run test:content-kitchen
- npm run content-kitchen:enrichment-dry-run -- --input lib/puzzles/content-kitchen/examples/enrichment-worker-dry-run.input.json --pretty | rg -n 'healthReport|needs_review|recommendation|reviewRequired|highPriority|blocked|ok'
- npm run content-kitchen:enrichment-dry-run -- --input lib/puzzles/content-kitchen/examples/enrichment-worker-high-priority.input.json --pretty | rg -n 'healthReport|high_priority|deadLetter|recommendation|blocked|needs_review|ok'
- npm run typecheck
- git diff --check
- npm run lint
- npm run validate:data
- npm run build