### PR TITLE
Add PR9 enrichment health output file

### DIFF
--- a/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
+++ b/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
@@ -2200,6 +2200,14 @@ PR9 sixteenth implementation slice:
 - cover all four health statuses in the content-kitchen contract test
 - keep this local-only; do not send Feishu messages, write review queue storage, attach production storage, or run Worker cron yet
 
+PR9 seventeenth implementation slice:
+
+- add a local `--health-output` option to the enrichment dry-run runner
+- write only the compact `healthReport` to the health output JSON file, including `sourcePath` and `writtenAt`
+- keep `--output`, `--action-output`, and `--health-output` as three separate local files
+- reject unsafe paths where `--health-output` equals `--input`, `--output`, or `--action-output`
+- keep this local-only; do not send Feishu messages, write review queue storage, attach production storage, or run Worker cron yet
+
 ### PR10 — Review Artifact And Human Review
 
 Goal: make failed content actionable.

--- a/docs/pinpoint-content-kitchen-pr9-enrichment-dry-run-usage-2026-05-24.md
+++ b/docs/pinpoint-content-kitchen-pr9-enrichment-dry-run-usage-2026-05-24.md
@@ -65,6 +65,37 @@ The health report also includes:
 - active issue codes
 - skip reasons
 
+## Write Health Report
+
+Write only the compact health report to a separate local file:
+
+```bash
+npm run content-kitchen:enrichment-dry-run -- \
+  --input lib/puzzles/content-kitchen/examples/enrichment-worker-dry-run.input.json \
+  --health-output /tmp/content-kitchen-health-report.json \
+  --pretty
+```
+
+The health output contains:
+
+- `sourcePath`
+- `writtenAt`
+- `status`
+- `recommendation`
+- compact counts
+- important job ids
+- active issue codes
+- skip reasons
+
+Rules:
+
+- --health-output must not equal `--input`
+- --health-output must not equal `--output`
+- --health-output must not equal `--action-output`
+- health output is for inspection only
+- health output is not sent to Feishu
+- health output is not written to review queue storage
+
 ## Write Job State Preview
 
 Write updated job state to a separate local file:
@@ -117,6 +148,7 @@ npm run content-kitchen:enrichment-dry-run -- \
   --input lib/puzzles/content-kitchen/examples/enrichment-worker-dry-run.input.json \
   --output /tmp/content-kitchen-worker-output.json \
   --action-output /tmp/content-kitchen-action-drafts.json \
+  --health-output /tmp/content-kitchen-health-report.json \
   --pretty
 ```
 
@@ -131,6 +163,7 @@ npm run content-kitchen:enrichment-dry-run -- \
   --input /tmp/content-kitchen-worker-output.json \
   --output /tmp/content-kitchen-worker-output-next.json \
   --action-output /tmp/content-kitchen-action-drafts-next.json \
+  --health-output /tmp/content-kitchen-health-report-next.json \
   --now 2026-05-23T09:12:00.000Z \
   --worker-id worker-dry-run-next \
   --lock-minutes 10 \

--- a/scripts/check-content-kitchen-contract.ts
+++ b/scripts/check-content-kitchen-contract.ts
@@ -2304,11 +2304,13 @@ async function assertAnswerFirstEnrichmentWorkerJsonDryRun() {
   try {
     const outputPath = resolve(tmpDir, "worker-output.json");
     const actionOutputPath = resolve(tmpDir, "worker-action-drafts.json");
+    const healthOutputPath = resolve(tmpDir, "worker-health-report.json");
     const fileResult = await runAnswerFirstEnrichmentWorkerJsonDryRunToFile({
       input,
       inputPath: examplePath,
       outputPath,
       actionOutputPath,
+      healthOutputPath,
     });
     const output = JSON.parse(await readFile(outputPath, "utf8")) as {
       schemaVersion: string;
@@ -2335,6 +2337,22 @@ async function assertAnswerFirstEnrichmentWorkerJsonDryRun() {
         issueCodes: string[];
       }>;
     };
+    const healthOutput = JSON.parse(await readFile(healthOutputPath, "utf8")) as {
+      schemaVersion: string;
+      status: string;
+      sourcePath: string;
+      writtenAt: string;
+      recommendation: string;
+      counts: {
+        inputJobs: number;
+        notificationDrafts: number;
+        reviewQueueDrafts: number;
+      };
+      jobIds: {
+        reviewRequired: string[];
+      };
+      activeIssueCodes: string[];
+    };
 
     assert.equal(
       fileResult.outputPath,
@@ -2345,6 +2363,11 @@ async function assertAnswerFirstEnrichmentWorkerJsonDryRun() {
       fileResult.actionOutputPath,
       actionOutputPath,
       "worker dry-run file mode should report the action output path",
+    );
+    assert.equal(
+      fileResult.healthOutputPath,
+      healthOutputPath,
+      "worker dry-run file mode should report the health output path",
     );
     assert.equal(
       output.schemaVersion,
@@ -2411,6 +2434,38 @@ async function assertAnswerFirstEnrichmentWorkerJsonDryRun() {
       "worker dry-run action output should write review queue drafts without persisting them",
     );
     assert.equal(
+      healthOutput.schemaVersion,
+      ENRICHMENT_WORKER_HEALTH_REPORT_VERSION,
+      "worker dry-run health output file should use the health report schema version",
+    );
+    assert.equal(healthOutput.status, "needs_review", "worker dry-run health output should expose the health status");
+    assert.equal(healthOutput.sourcePath, examplePath, "worker dry-run health output should record the source path");
+    assert.equal(healthOutput.writtenAt, input.now, "worker dry-run health output should use the dry-run timestamp");
+    assert.equal(
+      healthOutput.recommendation,
+      "Inspect review queue drafts before allowing automatic enrichment to continue.",
+      "worker dry-run health output should include the operator recommendation",
+    );
+    assert.deepEqual(
+      [
+        healthOutput.counts.inputJobs,
+        healthOutput.counts.notificationDrafts,
+        healthOutput.counts.reviewQueueDrafts,
+      ],
+      [3, 1, 1],
+      "worker dry-run health output should write compact counts",
+    );
+    assert.deepEqual(
+      healthOutput.jobIds.reviewRequired,
+      ["job-pinpoint-918-2026-05-23-rev-full-analysis-918"],
+      "worker dry-run health output should write review-required job ids",
+    );
+    assert.deepEqual(
+      healthOutput.activeIssueCodes,
+      ["ANSWER_FIRST_OVER_SLA", "ANSWER_FIRST_REVIEW_REQUIRED"],
+      "worker dry-run health output should write active issue codes",
+    );
+    assert.equal(
       await readFile(examplePath, "utf8"),
       raw,
       "worker dry-run file mode should not mutate the input file",
@@ -2431,6 +2486,35 @@ async function assertAnswerFirstEnrichmentWorkerJsonDryRun() {
       ]),
       /--action-output must be different from --output/,
       "worker dry-run CLI should keep job output and action output paths separate",
+    );
+    await assert.rejects(
+      () => runAnswerFirstEnrichmentWorkerDryRunCli(["--input", examplePath, "--health-output", examplePath]),
+      /--health-output must be different from --input/,
+      "worker dry-run CLI should reject health output paths that would overwrite the input",
+    );
+    await assert.rejects(
+      () => runAnswerFirstEnrichmentWorkerDryRunCli([
+        "--input",
+        examplePath,
+        "--output",
+        outputPath,
+        "--health-output",
+        outputPath,
+      ]),
+      /--health-output must be different from --output/,
+      "worker dry-run CLI should keep job output and health output paths separate",
+    );
+    await assert.rejects(
+      () => runAnswerFirstEnrichmentWorkerDryRunCli([
+        "--input",
+        examplePath,
+        "--action-output",
+        actionOutputPath,
+        "--health-output",
+        actionOutputPath,
+      ]),
+      /--health-output must be different from --action-output/,
+      "worker dry-run CLI should keep action output and health output paths separate",
     );
 
     const resumedInput = parseAnswerFirstEnrichmentWorkerDryRunInput(output, {
@@ -2638,6 +2722,7 @@ async function assertAnswerFirstEnrichmentDryRunUsageDoc() {
     "--input lib/puzzles/content-kitchen/examples/enrichment-worker-dry-run.input.json",
     "--output /tmp/content-kitchen-worker-output.json",
     "--action-output /tmp/content-kitchen-action-drafts.json",
+    "--health-output /tmp/content-kitchen-health-report.json",
     "`healthReport`",
     "`ok`: no review action is needed",
     "`needs_review`: inspect review queue drafts before allowing automatic enrichment to continue",
@@ -2645,6 +2730,9 @@ async function assertAnswerFirstEnrichmentDryRunUsageDoc() {
     "`blocked`: inspect dead-letter or max-attempt jobs before retrying the queue",
     "--action-output must not equal `--input`",
     "--action-output must not equal `--output`",
+    "--health-output must not equal `--input`",
+    "--health-output must not equal `--output`",
+    "--health-output must not equal `--action-output`",
     "dispatchStatus: \"not_sent\"",
     "persistenceStatus: \"not_persisted\"",
     "does not send Feishu messages",

--- a/scripts/run-content-kitchen-enrichment-worker-dry-run.ts
+++ b/scripts/run-content-kitchen-enrichment-worker-dry-run.ts
@@ -68,6 +68,7 @@ export type AnswerFirstEnrichmentWorkerDryRunResult = {
   healthReport: AnswerFirstEnrichmentWorkerHealthReport;
   outputPath?: string;
   actionOutputPath?: string;
+  healthOutputPath?: string;
   claimedJobs: AnswerFirstEnrichmentWorkerDryRunJobSummary[];
   skippedJobs: Array<{
     job: AnswerFirstEnrichmentWorkerDryRunJobSummary;
@@ -85,6 +86,7 @@ type ParsedArgs = {
   inputPath: string;
   outputPath?: string;
   actionOutputPath?: string;
+  healthOutputPath?: string;
   now?: string;
   workerId?: string;
   limit?: number;
@@ -100,6 +102,11 @@ type DryRunInputOverrides = {
 };
 
 export type AnswerFirstEnrichmentWorkerActionDraftsFileOutput = AnswerFirstEnrichmentWorkerActionDrafts & {
+  sourcePath: string;
+  writtenAt: string;
+};
+
+export type AnswerFirstEnrichmentWorkerHealthReportFileOutput = AnswerFirstEnrichmentWorkerHealthReport & {
   sourcePath: string;
   writtenAt: string;
 };
@@ -279,6 +286,7 @@ function parseArgs(argv: string[]): ParsedArgs {
   let inputPath = "";
   let outputPath: string | undefined;
   let actionOutputPath: string | undefined;
+  let healthOutputPath: string | undefined;
   let now: string | undefined;
   let workerId: string | undefined;
   let limit: number | undefined;
@@ -301,6 +309,12 @@ function parseArgs(argv: string[]): ParsedArgs {
 
     if (arg === "--action-output") {
       actionOutputPath = resolve(readArgValue(argv, index, "--action-output"));
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--health-output") {
+      healthOutputPath = resolve(readArgValue(argv, index, "--health-output"));
       index += 1;
       continue;
     }
@@ -341,7 +355,7 @@ function parseArgs(argv: string[]): ParsedArgs {
 
     if (arg === "--help" || arg === "-h") {
       throw new Error(
-        "Usage: npm run content-kitchen:enrichment-dry-run -- --input <path> [--output <path>] [--action-output <path>] [--now <timestamp>] [--worker-id <id>] [--limit <n>] [--lock-minutes <n>] [--pretty|--compact]",
+        "Usage: npm run content-kitchen:enrichment-dry-run -- --input <path> [--output <path>] [--action-output <path>] [--health-output <path>] [--now <timestamp>] [--worker-id <id>] [--limit <n>] [--lock-minutes <n>] [--pretty|--compact]",
       );
     }
 
@@ -362,11 +376,21 @@ function parseArgs(argv: string[]): ParsedArgs {
   if (actionOutputPath && outputPath === actionOutputPath) {
     throw new Error("--action-output must be different from --output");
   }
+  if (healthOutputPath === resolvedInputPath) {
+    throw new Error("--health-output must be different from --input");
+  }
+  if (healthOutputPath && outputPath === healthOutputPath) {
+    throw new Error("--health-output must be different from --output");
+  }
+  if (healthOutputPath && actionOutputPath === healthOutputPath) {
+    throw new Error("--health-output must be different from --action-output");
+  }
 
   return {
     inputPath: resolvedInputPath,
     outputPath,
     actionOutputPath,
+    healthOutputPath,
     now,
     workerId,
     limit,
@@ -408,17 +432,28 @@ export async function runCli(argv: string[] = process.argv.slice(2)): Promise<vo
       inputPath: args.inputPath,
       outputPath: args.outputPath,
       actionOutputPath: args.actionOutputPath,
+      healthOutputPath: args.healthOutputPath,
     })
     : await runAnswerFirstEnrichmentWorkerJsonDryRun(input);
-  const outputResult = args.actionOutputPath && !args.outputPath
-    ? { ...result, actionOutputPath: args.actionOutputPath }
-    : result;
+  const outputResult = {
+    ...result,
+    actionOutputPath: args.actionOutputPath ?? result.actionOutputPath,
+    healthOutputPath: args.healthOutputPath ?? result.healthOutputPath,
+  };
 
   if (args.actionOutputPath && !args.outputPath) {
     await writeAnswerFirstEnrichmentWorkerActionDraftsFile({
       actionDrafts: result.actionDrafts,
       inputPath: args.inputPath,
       actionOutputPath: args.actionOutputPath,
+      writtenAt: input.now,
+    });
+  }
+  if (args.healthOutputPath && !args.outputPath) {
+    await writeAnswerFirstEnrichmentWorkerHealthReportFile({
+      healthReport: result.healthReport,
+      inputPath: args.inputPath,
+      healthOutputPath: args.healthOutputPath,
       writtenAt: input.now,
     });
   }
@@ -431,6 +466,7 @@ export async function runAnswerFirstEnrichmentWorkerJsonDryRunToFile(input: {
   inputPath: string;
   outputPath: string;
   actionOutputPath?: string;
+  healthOutputPath?: string;
 }): Promise<AnswerFirstEnrichmentWorkerDryRunResult> {
   const store = createJsonFileAnswerFirstEnrichmentJobStore({
     inputPath: input.inputPath,
@@ -462,10 +498,19 @@ export async function runAnswerFirstEnrichmentWorkerJsonDryRunToFile(input: {
       writtenAt: input.input.now,
     });
   }
+  if (input.healthOutputPath) {
+    await writeAnswerFirstEnrichmentWorkerHealthReportFile({
+      healthReport: result.healthReport,
+      inputPath: input.inputPath,
+      healthOutputPath: input.healthOutputPath,
+      writtenAt: input.input.now,
+    });
+  }
 
   return {
     ...result,
     actionOutputPath: input.actionOutputPath,
+    healthOutputPath: input.healthOutputPath,
   };
 }
 
@@ -483,6 +528,24 @@ export async function writeAnswerFirstEnrichmentWorkerActionDraftsFile(input: {
 
   await mkdir(dirname(input.actionOutputPath), { recursive: true });
   await writeFile(input.actionOutputPath, `${JSON.stringify(output, null, 2)}\n`, "utf8");
+
+  return output;
+}
+
+export async function writeAnswerFirstEnrichmentWorkerHealthReportFile(input: {
+  healthReport: AnswerFirstEnrichmentWorkerHealthReport;
+  inputPath: string;
+  healthOutputPath: string;
+  writtenAt: string;
+}): Promise<AnswerFirstEnrichmentWorkerHealthReportFileOutput> {
+  const output: AnswerFirstEnrichmentWorkerHealthReportFileOutput = {
+    ...input.healthReport,
+    sourcePath: resolve(input.inputPath),
+    writtenAt: new Date(Date.parse(input.writtenAt)).toISOString(),
+  };
+
+  await mkdir(dirname(input.healthOutputPath), { recursive: true });
+  await writeFile(input.healthOutputPath, `${JSON.stringify(output, null, 2)}\n`, "utf8");
 
   return output;
 }


### PR DESCRIPTION
## Summary
- add a local --health-output option to the enrichment dry-run runner
- write compact health reports to a separate JSON file with sourcePath and writtenAt
- keep --output, --action-output, and --health-output paths separate
- document the health-output flow in the PR9 usage note and architecture plan

## Tests
- npm run test:content-kitchen
- npm run content-kitchen:enrichment-dry-run -- --input lib/puzzles/content-kitchen/examples/enrichment-worker-dry-run.input.json --output /tmp/.../worker-output.json --action-output /tmp/.../action-drafts.json --health-output /tmp/.../health-report.json --pretty
- npm run typecheck
- git diff --check -- scripts/run-content-kitchen-enrichment-worker-dry-run.ts scripts/check-content-kitchen-contract.ts docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md docs/pinpoint-content-kitchen-pr9-enrichment-dry-run-usage-2026-05-24.md
- npm run lint
- npm run validate:data
- npm run build