### PR TITLE
[codex] Add PR9 enrichment run manifest output

### DIFF
--- a/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
+++ b/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
@@ -2208,6 +2208,14 @@ PR9 seventeenth implementation slice:
 - reject unsafe paths where `--health-output` equals `--input`, `--output`, or `--action-output`
 - keep this local-only; do not send Feishu messages, write review queue storage, attach production storage, or run Worker cron yet
 
+PR9 eighteenth implementation slice:
+
+- add a local `--manifest-output` option to the enrichment dry-run runner
+- write a compact run manifest with `sourcePath`, `writtenAt`, worker id, local file paths, run summary, health status, health recommendation, health counts, and active issue codes
+- keep the manifest as a local index for one dry-run pass; do not make it a durable queue record
+- reject unsafe paths where `--manifest-output` equals `--input`, `--output`, `--action-output`, or `--health-output`
+- keep this local-only; do not send Feishu messages, write review queue storage, attach production storage, or run Worker cron yet
+
 ### PR10 — Review Artifact And Human Review
 
 Goal: make failed content actionable.

--- a/docs/pinpoint-content-kitchen-pr9-enrichment-dry-run-usage-2026-05-24.md
+++ b/docs/pinpoint-content-kitchen-pr9-enrichment-dry-run-usage-2026-05-24.md
@@ -40,6 +40,7 @@ This prints:
 - `runSummary`
 - `actionDrafts`
 - `healthReport`
+- optional run manifest path
 - claimed jobs
 - skipped jobs
 - state advancement decisions
@@ -96,6 +97,43 @@ Rules:
 - health output is not sent to Feishu
 - health output is not written to review queue storage
 
+## Write Run Manifest
+
+Write a small local manifest that points to the files produced by one dry run:
+
+```bash
+npm run content-kitchen:enrichment-dry-run -- \
+  --input lib/puzzles/content-kitchen/examples/enrichment-worker-dry-run.input.json \
+  --output /tmp/content-kitchen-worker-output.json \
+  --action-output /tmp/content-kitchen-action-drafts.json \
+  --health-output /tmp/content-kitchen-health-report.json \
+  --manifest-output /tmp/content-kitchen-run-manifest.json \
+  --pretty
+```
+
+The manifest output contains:
+
+- `sourcePath`
+- `writtenAt`
+- `workerId`
+- all local run file paths
+- compact run summary
+- `healthStatus`
+- `healthRecommendation`
+- compact health counts
+- active issue codes
+
+Rules:
+
+- --manifest-output must not equal `--input`
+- --manifest-output must not equal `--output`
+- --manifest-output must not equal `--action-output`
+- --manifest-output must not equal `--health-output`
+- manifest output is for local inspection only
+- manifest output is not sent to Feishu
+- manifest output is not written to review queue storage
+- manifest output is not written to production storage
+
 ## Write Job State Preview
 
 Write updated job state to a separate local file:
@@ -149,10 +187,11 @@ npm run content-kitchen:enrichment-dry-run -- \
   --output /tmp/content-kitchen-worker-output.json \
   --action-output /tmp/content-kitchen-action-drafts.json \
   --health-output /tmp/content-kitchen-health-report.json \
+  --manifest-output /tmp/content-kitchen-run-manifest.json \
   --pretty
 ```
 
-Use this when manually checking one worker pass before any future production wiring.
+Use this when manually checking one worker pass before any future production wiring. The manifest is the small index file for that run.
 
 ## Resume From Output
 
@@ -164,6 +203,7 @@ npm run content-kitchen:enrichment-dry-run -- \
   --output /tmp/content-kitchen-worker-output-next.json \
   --action-output /tmp/content-kitchen-action-drafts-next.json \
   --health-output /tmp/content-kitchen-health-report-next.json \
+  --manifest-output /tmp/content-kitchen-run-manifest-next.json \
   --now 2026-05-23T09:12:00.000Z \
   --worker-id worker-dry-run-next \
   --lock-minutes 10 \

--- a/scripts/check-content-kitchen-contract.ts
+++ b/scripts/check-content-kitchen-contract.ts
@@ -60,6 +60,7 @@ import { ENRICHMENT_WORKER_HEALTH_REPORT_VERSION } from "./content-kitchen-enric
 import { ENRICHMENT_WORKER_RUN_SUMMARY_VERSION } from "./content-kitchen-enrichment-run-summary";
 import {
   ENRICHMENT_WORKER_DRY_RUN_RESULT_VERSION,
+  ENRICHMENT_WORKER_RUN_MANIFEST_VERSION,
   parseAnswerFirstEnrichmentWorkerDryRunInput,
   runCli as runAnswerFirstEnrichmentWorkerDryRunCli,
   runAnswerFirstEnrichmentWorkerJsonDryRun,
@@ -2305,12 +2306,14 @@ async function assertAnswerFirstEnrichmentWorkerJsonDryRun() {
     const outputPath = resolve(tmpDir, "worker-output.json");
     const actionOutputPath = resolve(tmpDir, "worker-action-drafts.json");
     const healthOutputPath = resolve(tmpDir, "worker-health-report.json");
+    const manifestOutputPath = resolve(tmpDir, "worker-run-manifest.json");
     const fileResult = await runAnswerFirstEnrichmentWorkerJsonDryRunToFile({
       input,
       inputPath: examplePath,
       outputPath,
       actionOutputPath,
       healthOutputPath,
+      manifestOutputPath,
     });
     const output = JSON.parse(await readFile(outputPath, "utf8")) as {
       schemaVersion: string;
@@ -2353,6 +2356,34 @@ async function assertAnswerFirstEnrichmentWorkerJsonDryRun() {
       };
       activeIssueCodes: string[];
     };
+    const manifestOutput = JSON.parse(await readFile(manifestOutputPath, "utf8")) as {
+      schemaVersion: string;
+      dryRunOnly: boolean;
+      sourcePath: string;
+      writtenAt: string;
+      workerId: string;
+      paths: {
+        inputPath: string;
+        outputPath: string;
+        actionOutputPath: string;
+        healthOutputPath: string;
+        manifestOutputPath: string;
+      };
+      summary: {
+        inputJobs: number;
+        claimedJobs: number;
+        skippedJobs: number;
+        stateAdvancements: number;
+      };
+      healthStatus: string;
+      healthRecommendation: string;
+      counts: {
+        inputJobs: number;
+        notificationDrafts: number;
+        reviewQueueDrafts: number;
+      };
+      activeIssueCodes: string[];
+    };
 
     assert.equal(
       fileResult.outputPath,
@@ -2368,6 +2399,11 @@ async function assertAnswerFirstEnrichmentWorkerJsonDryRun() {
       fileResult.healthOutputPath,
       healthOutputPath,
       "worker dry-run file mode should report the health output path",
+    );
+    assert.equal(
+      fileResult.manifestOutputPath,
+      manifestOutputPath,
+      "worker dry-run file mode should report the manifest output path",
     );
     assert.equal(
       output.schemaVersion,
@@ -2466,6 +2502,60 @@ async function assertAnswerFirstEnrichmentWorkerJsonDryRun() {
       "worker dry-run health output should write active issue codes",
     );
     assert.equal(
+      manifestOutput.schemaVersion,
+      ENRICHMENT_WORKER_RUN_MANIFEST_VERSION,
+      "worker dry-run manifest output file should use the manifest schema version",
+    );
+    assert.equal(manifestOutput.dryRunOnly, true, "worker dry-run manifest output should stay dry-run only");
+    assert.equal(manifestOutput.sourcePath, examplePath, "worker dry-run manifest should record the source path");
+    assert.equal(manifestOutput.writtenAt, input.now, "worker dry-run manifest should use the dry-run timestamp");
+    assert.equal(manifestOutput.workerId, input.workerId, "worker dry-run manifest should record the worker id");
+    assert.deepEqual(
+      manifestOutput.paths,
+      {
+        inputPath: examplePath,
+        outputPath,
+        actionOutputPath,
+        healthOutputPath,
+        manifestOutputPath,
+      },
+      "worker dry-run manifest should point to every local run file",
+    );
+    assert.deepEqual(
+      [
+        manifestOutput.summary.inputJobs,
+        manifestOutput.summary.claimedJobs,
+        manifestOutput.summary.skippedJobs,
+        manifestOutput.summary.stateAdvancements,
+      ],
+      [3, 1, 2, 1],
+      "worker dry-run manifest should include the compact run summary",
+    );
+    assert.equal(
+      manifestOutput.healthStatus,
+      "needs_review",
+      "worker dry-run manifest should include the health status",
+    );
+    assert.equal(
+      manifestOutput.healthRecommendation,
+      "Inspect review queue drafts before allowing automatic enrichment to continue.",
+      "worker dry-run manifest should include the health recommendation",
+    );
+    assert.deepEqual(
+      [
+        manifestOutput.counts.inputJobs,
+        manifestOutput.counts.notificationDrafts,
+        manifestOutput.counts.reviewQueueDrafts,
+      ],
+      [3, 1, 1],
+      "worker dry-run manifest should include compact health counts",
+    );
+    assert.deepEqual(
+      manifestOutput.activeIssueCodes,
+      ["ANSWER_FIRST_OVER_SLA", "ANSWER_FIRST_REVIEW_REQUIRED"],
+      "worker dry-run manifest should include active issue codes",
+    );
+    assert.equal(
       await readFile(examplePath, "utf8"),
       raw,
       "worker dry-run file mode should not mutate the input file",
@@ -2515,6 +2605,47 @@ async function assertAnswerFirstEnrichmentWorkerJsonDryRun() {
       ]),
       /--health-output must be different from --action-output/,
       "worker dry-run CLI should keep action output and health output paths separate",
+    );
+    await assert.rejects(
+      () => runAnswerFirstEnrichmentWorkerDryRunCli(["--input", examplePath, "--manifest-output", examplePath]),
+      /--manifest-output must be different from --input/,
+      "worker dry-run CLI should reject manifest output paths that would overwrite the input",
+    );
+    await assert.rejects(
+      () => runAnswerFirstEnrichmentWorkerDryRunCli([
+        "--input",
+        examplePath,
+        "--output",
+        outputPath,
+        "--manifest-output",
+        outputPath,
+      ]),
+      /--manifest-output must be different from --output/,
+      "worker dry-run CLI should keep job output and manifest output paths separate",
+    );
+    await assert.rejects(
+      () => runAnswerFirstEnrichmentWorkerDryRunCli([
+        "--input",
+        examplePath,
+        "--action-output",
+        actionOutputPath,
+        "--manifest-output",
+        actionOutputPath,
+      ]),
+      /--manifest-output must be different from --action-output/,
+      "worker dry-run CLI should keep action output and manifest output paths separate",
+    );
+    await assert.rejects(
+      () => runAnswerFirstEnrichmentWorkerDryRunCli([
+        "--input",
+        examplePath,
+        "--health-output",
+        healthOutputPath,
+        "--manifest-output",
+        healthOutputPath,
+      ]),
+      /--manifest-output must be different from --health-output/,
+      "worker dry-run CLI should keep health output and manifest output paths separate",
     );
 
     const resumedInput = parseAnswerFirstEnrichmentWorkerDryRunInput(output, {
@@ -2723,7 +2854,9 @@ async function assertAnswerFirstEnrichmentDryRunUsageDoc() {
     "--output /tmp/content-kitchen-worker-output.json",
     "--action-output /tmp/content-kitchen-action-drafts.json",
     "--health-output /tmp/content-kitchen-health-report.json",
+    "--manifest-output /tmp/content-kitchen-run-manifest.json",
     "`healthReport`",
+    "`healthStatus`",
     "`ok`: no review action is needed",
     "`needs_review`: inspect review queue drafts before allowing automatic enrichment to continue",
     "`high_priority`: inspect high-priority action drafts before any future publish automation",
@@ -2733,6 +2866,10 @@ async function assertAnswerFirstEnrichmentDryRunUsageDoc() {
     "--health-output must not equal `--input`",
     "--health-output must not equal `--output`",
     "--health-output must not equal `--action-output`",
+    "--manifest-output must not equal `--input`",
+    "--manifest-output must not equal `--output`",
+    "--manifest-output must not equal `--action-output`",
+    "--manifest-output must not equal `--health-output`",
     "dispatchStatus: \"not_sent\"",
     "persistenceStatus: \"not_persisted\"",
     "does not send Feishu messages",

--- a/scripts/run-content-kitchen-enrichment-worker-dry-run.ts
+++ b/scripts/run-content-kitchen-enrichment-worker-dry-run.ts
@@ -25,6 +25,8 @@ import {
 
 export const ENRICHMENT_WORKER_DRY_RUN_INPUT_VERSION = "content-kitchen-enrichment-worker-dry-run-v0";
 export const ENRICHMENT_WORKER_DRY_RUN_RESULT_VERSION = "content-kitchen-enrichment-worker-dry-run-result-v0";
+export const ENRICHMENT_WORKER_RUN_MANIFEST_VERSION =
+  "content-kitchen-enrichment-worker-run-manifest-v0";
 
 export type AnswerFirstEnrichmentWorkerDryRunInput = {
   schemaVersion?:
@@ -69,6 +71,7 @@ export type AnswerFirstEnrichmentWorkerDryRunResult = {
   outputPath?: string;
   actionOutputPath?: string;
   healthOutputPath?: string;
+  manifestOutputPath?: string;
   claimedJobs: AnswerFirstEnrichmentWorkerDryRunJobSummary[];
   skippedJobs: Array<{
     job: AnswerFirstEnrichmentWorkerDryRunJobSummary;
@@ -87,6 +90,7 @@ type ParsedArgs = {
   outputPath?: string;
   actionOutputPath?: string;
   healthOutputPath?: string;
+  manifestOutputPath?: string;
   now?: string;
   workerId?: string;
   limit?: number;
@@ -109,6 +113,26 @@ export type AnswerFirstEnrichmentWorkerActionDraftsFileOutput = AnswerFirstEnric
 export type AnswerFirstEnrichmentWorkerHealthReportFileOutput = AnswerFirstEnrichmentWorkerHealthReport & {
   sourcePath: string;
   writtenAt: string;
+};
+
+export type AnswerFirstEnrichmentWorkerRunManifestFileOutput = {
+  schemaVersion: typeof ENRICHMENT_WORKER_RUN_MANIFEST_VERSION;
+  dryRunOnly: true;
+  sourcePath: string;
+  writtenAt: string;
+  workerId: string;
+  paths: {
+    inputPath: string;
+    outputPath?: string;
+    actionOutputPath?: string;
+    healthOutputPath?: string;
+    manifestOutputPath: string;
+  };
+  summary: AnswerFirstEnrichmentWorkerDryRunResult["summary"];
+  healthStatus: AnswerFirstEnrichmentWorkerHealthReport["status"];
+  healthRecommendation: string;
+  counts: AnswerFirstEnrichmentWorkerHealthReport["counts"];
+  activeIssueCodes: string[];
 };
 
 function requireObject(value: unknown, fieldPath: string): Record<string, unknown> {
@@ -287,6 +311,7 @@ function parseArgs(argv: string[]): ParsedArgs {
   let outputPath: string | undefined;
   let actionOutputPath: string | undefined;
   let healthOutputPath: string | undefined;
+  let manifestOutputPath: string | undefined;
   let now: string | undefined;
   let workerId: string | undefined;
   let limit: number | undefined;
@@ -315,6 +340,12 @@ function parseArgs(argv: string[]): ParsedArgs {
 
     if (arg === "--health-output") {
       healthOutputPath = resolve(readArgValue(argv, index, "--health-output"));
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--manifest-output") {
+      manifestOutputPath = resolve(readArgValue(argv, index, "--manifest-output"));
       index += 1;
       continue;
     }
@@ -355,7 +386,7 @@ function parseArgs(argv: string[]): ParsedArgs {
 
     if (arg === "--help" || arg === "-h") {
       throw new Error(
-        "Usage: npm run content-kitchen:enrichment-dry-run -- --input <path> [--output <path>] [--action-output <path>] [--health-output <path>] [--now <timestamp>] [--worker-id <id>] [--limit <n>] [--lock-minutes <n>] [--pretty|--compact]",
+        "Usage: npm run content-kitchen:enrichment-dry-run -- --input <path> [--output <path>] [--action-output <path>] [--health-output <path>] [--manifest-output <path>] [--now <timestamp>] [--worker-id <id>] [--limit <n>] [--lock-minutes <n>] [--pretty|--compact]",
       );
     }
 
@@ -385,12 +416,25 @@ function parseArgs(argv: string[]): ParsedArgs {
   if (healthOutputPath && actionOutputPath === healthOutputPath) {
     throw new Error("--health-output must be different from --action-output");
   }
+  if (manifestOutputPath === resolvedInputPath) {
+    throw new Error("--manifest-output must be different from --input");
+  }
+  if (manifestOutputPath && outputPath === manifestOutputPath) {
+    throw new Error("--manifest-output must be different from --output");
+  }
+  if (manifestOutputPath && actionOutputPath === manifestOutputPath) {
+    throw new Error("--manifest-output must be different from --action-output");
+  }
+  if (manifestOutputPath && healthOutputPath === manifestOutputPath) {
+    throw new Error("--manifest-output must be different from --health-output");
+  }
 
   return {
     inputPath: resolvedInputPath,
     outputPath,
     actionOutputPath,
     healthOutputPath,
+    manifestOutputPath,
     now,
     workerId,
     limit,
@@ -433,13 +477,9 @@ export async function runCli(argv: string[] = process.argv.slice(2)): Promise<vo
       outputPath: args.outputPath,
       actionOutputPath: args.actionOutputPath,
       healthOutputPath: args.healthOutputPath,
+      manifestOutputPath: args.manifestOutputPath,
     })
     : await runAnswerFirstEnrichmentWorkerJsonDryRun(input);
-  const outputResult = {
-    ...result,
-    actionOutputPath: args.actionOutputPath ?? result.actionOutputPath,
-    healthOutputPath: args.healthOutputPath ?? result.healthOutputPath,
-  };
 
   if (args.actionOutputPath && !args.outputPath) {
     await writeAnswerFirstEnrichmentWorkerActionDraftsFile({
@@ -457,6 +497,24 @@ export async function runCli(argv: string[] = process.argv.slice(2)): Promise<vo
       writtenAt: input.now,
     });
   }
+  if (args.manifestOutputPath && !args.outputPath) {
+    await writeAnswerFirstEnrichmentWorkerRunManifestFile({
+      result,
+      inputPath: args.inputPath,
+      outputPath: args.outputPath,
+      actionOutputPath: args.actionOutputPath,
+      healthOutputPath: args.healthOutputPath,
+      manifestOutputPath: args.manifestOutputPath,
+      writtenAt: input.now,
+    });
+  }
+
+  const outputResult = {
+    ...result,
+    actionOutputPath: args.actionOutputPath ?? result.actionOutputPath,
+    healthOutputPath: args.healthOutputPath ?? result.healthOutputPath,
+    manifestOutputPath: args.manifestOutputPath ?? result.manifestOutputPath,
+  };
 
   console.log(JSON.stringify(outputResult, null, args.pretty ? 2 : 0));
 }
@@ -467,6 +525,7 @@ export async function runAnswerFirstEnrichmentWorkerJsonDryRunToFile(input: {
   outputPath: string;
   actionOutputPath?: string;
   healthOutputPath?: string;
+  manifestOutputPath?: string;
 }): Promise<AnswerFirstEnrichmentWorkerDryRunResult> {
   const store = createJsonFileAnswerFirstEnrichmentJobStore({
     inputPath: input.inputPath,
@@ -506,11 +565,23 @@ export async function runAnswerFirstEnrichmentWorkerJsonDryRunToFile(input: {
       writtenAt: input.input.now,
     });
   }
+  if (input.manifestOutputPath) {
+    await writeAnswerFirstEnrichmentWorkerRunManifestFile({
+      result,
+      inputPath: input.inputPath,
+      outputPath: input.outputPath,
+      actionOutputPath: input.actionOutputPath,
+      healthOutputPath: input.healthOutputPath,
+      manifestOutputPath: input.manifestOutputPath,
+      writtenAt: input.input.now,
+    });
+  }
 
   return {
     ...result,
     actionOutputPath: input.actionOutputPath,
     healthOutputPath: input.healthOutputPath,
+    manifestOutputPath: input.manifestOutputPath,
   };
 }
 
@@ -546,6 +617,41 @@ export async function writeAnswerFirstEnrichmentWorkerHealthReportFile(input: {
 
   await mkdir(dirname(input.healthOutputPath), { recursive: true });
   await writeFile(input.healthOutputPath, `${JSON.stringify(output, null, 2)}\n`, "utf8");
+
+  return output;
+}
+
+export async function writeAnswerFirstEnrichmentWorkerRunManifestFile(input: {
+  result: AnswerFirstEnrichmentWorkerDryRunResult;
+  inputPath: string;
+  outputPath?: string;
+  actionOutputPath?: string;
+  healthOutputPath?: string;
+  manifestOutputPath: string;
+  writtenAt: string;
+}): Promise<AnswerFirstEnrichmentWorkerRunManifestFileOutput> {
+  const output: AnswerFirstEnrichmentWorkerRunManifestFileOutput = {
+    schemaVersion: ENRICHMENT_WORKER_RUN_MANIFEST_VERSION,
+    dryRunOnly: true,
+    sourcePath: resolve(input.inputPath),
+    writtenAt: new Date(Date.parse(input.writtenAt)).toISOString(),
+    workerId: input.result.workerId,
+    paths: {
+      inputPath: resolve(input.inputPath),
+      outputPath: input.outputPath ? resolve(input.outputPath) : undefined,
+      actionOutputPath: input.actionOutputPath ? resolve(input.actionOutputPath) : undefined,
+      healthOutputPath: input.healthOutputPath ? resolve(input.healthOutputPath) : undefined,
+      manifestOutputPath: resolve(input.manifestOutputPath),
+    },
+    summary: input.result.summary,
+    healthStatus: input.result.healthReport.status,
+    healthRecommendation: input.result.healthReport.recommendation,
+    counts: input.result.healthReport.counts,
+    activeIssueCodes: [...input.result.healthReport.activeIssueCodes],
+  };
+
+  await mkdir(dirname(input.manifestOutputPath), { recursive: true });
+  await writeFile(input.manifestOutputPath, `${JSON.stringify(output, null, 2)}\n`, "utf8");
 
   return output;
 }


### PR DESCRIPTION
## Summary
- add a local --manifest-output option for the PR9 enrichment dry-run runner
- write a compact run manifest with input/output paths, summary, health status, counts, and issue codes
- cover manifest output and unsafe path collisions in the content-kitchen contract test
- document the local-only manifest workflow in the PR9 usage note and architecture plan

## Validation
- npm run test:content-kitchen
- npm run content-kitchen:enrichment-dry-run -- --input lib/puzzles/content-kitchen/examples/enrichment-worker-dry-run.input.json --output /tmp/content-kitchen-worker-output-manifest-check.json --action-output /tmp/content-kitchen-action-drafts-manifest-check.json --health-output /tmp/content-kitchen-health-report-manifest-check.json --manifest-output /tmp/content-kitchen-run-manifest-check.json --compact
- cat /tmp/content-kitchen-run-manifest-check.json
- git diff --check -- scripts/run-content-kitchen-enrichment-worker-dry-run.ts scripts/check-content-kitchen-contract.ts docs/pinpoint-content-kitchen-pr9-enrichment-dry-run-usage-2026-05-24.md docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
- npm run typecheck
- npm run lint
- npm run validate:data
- npm run build