### PR TITLE
[codex] Add PR10 review routing decision contract

### DIFF
--- a/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
+++ b/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
@@ -2243,6 +2243,19 @@ Acceptance:
 - Feishu notifications include puzzle number, logical date, current mode, issue severity, recommended action, public URL, and review URL when available
 - normal Feishu alerts are used for 30-minute upgrade misses; high-priority Feishu alerts are used for 6-hour unresolved pages and P0 publish/audit issues
 
+PR10 first implementation slice:
+
+- add a local `ReviewRoute` contract with `auto_approve`, `auto_reject`, `model_review`, and `human_review`
+- add a local `ReviewDecision` contract that binds every decision to `artifactId`, `puzzleId`, `candidateRevisionId`, issue codes, reviewer type, reviewer id, timestamp, and note
+- route obvious hard-rule failures to `auto_reject`; do not let model review overrule answer, identity, canonical, clue-count, missing-evidence, noindex, or schema-visibility failures
+- route soft quality issues to `model_review` without calling a real model in this slice
+- route low-confidence model results, source conflicts, prohibited sources, unsupported clue fits, and escalation cases to `human_review`
+- allow `rule_engine` to approve low-risk artifacts and reject hard-rule failures only
+- allow `model` to recommend approve, reject, regeneration, or human escalation for soft issues only
+- allow only `human` decisions to use `override_issue`
+- reject decisions with missing artifact id, puzzle id mismatch, candidate revision mismatch, model override attempts, or override issue codes that are not present on the artifact
+- keep this local-only; do not build Review UI, call a model, send Feishu messages, write review queue storage, attach production storage, publish content, or run Worker cron yet
+
 ### PR11 — Post-Publish Content Audit
 
 Goal: verify what users and crawlers see after publish.

--- a/docs/pinpoint-content-kitchen-pr10-review-routing-decision-2026-05-24.md
+++ b/docs/pinpoint-content-kitchen-pr10-review-routing-decision-2026-05-24.md
@@ -1,0 +1,133 @@
+# PR10 Review Routing And Decision Contract
+
+This is the local contract note for PR10.1.
+
+It defines how a review artifact is routed and how a final review decision is recorded.
+
+It is intentionally local-only:
+
+- it does not build Review UI
+- it does not call a model
+- it does not send Feishu messages
+- it does not write review queue storage
+- it does not touch production storage
+- it does not publish content
+- it does not run Worker cron
+
+## Review Route
+
+`ReviewRoute` decides who should inspect the artifact:
+
+- `auto_approve`: rules found no review issue
+- `auto_reject`: hard rules found a clear failure
+- `model_review`: only soft quality issues remain
+- `human_review`: risk is too high, unclear, or low-confidence
+
+`auto_approve` means local rules think no reviewer is needed. It does not mean automatic publishing.
+
+## Hard Rules
+
+Hard-rule failures are not sent to model review.
+
+Examples:
+
+- answer or L1 mismatch
+- invalid candidate metadata
+- canonical URL mismatch
+- missing or duplicate clue rows
+- missing evidence refs
+- unsupported reasoning shape
+- noindex requirement mismatch
+- FAQ schema without visible FAQ
+
+These route to `auto_reject` in v0.
+
+## Model Review
+
+Model review is only a route in PR10.1. No model is called in this slice.
+
+Soft issues can route to `model_review`, for example:
+
+- generic reasoning
+- weak fit evidence
+- L4-only evidence
+- low-confidence full-analysis evidence
+- optional internal-link quality issues
+- stale indexed answer-first cleanup advice
+
+Model decisions can recommend:
+
+- approve
+- reject
+- request regeneration
+- escalate to human
+
+Model decisions cannot:
+
+- override issue codes
+- force answer-first
+- approve hard-rule failures
+- publish content
+
+Low-confidence model decisions must use `escalate_to_human`.
+
+## Human Review
+
+Human review is required when:
+
+- rendered answer visibility is unclear
+- full-analysis structure is not certified yet
+- clue fit is unsupported
+- a prohibited source appears
+- evidence sources conflict
+- answer-first SLA review is required
+- high-priority escalation is active
+- a model decision has low confidence
+
+Only a human can use `override_issue`.
+
+## Review Decision
+
+Every decision uses `decisionVersion: "content-kitchen-review-decision-v0"`.
+
+Required fields:
+
+- `artifactId`
+- `puzzleId`
+- `candidateRevisionId`
+- `issueCodes`
+- `route`
+- `action`
+- `reviewerType`
+- `reviewerId`
+- `reviewedAt`
+- `note`
+
+Model decisions also require:
+
+- `confidence`
+- `modelName`
+- `modelVersion`
+
+Validation rules:
+
+- `artifactId` must match the review artifact
+- `puzzleId` must match the review artifact
+- `candidateRevisionId` must match the review artifact
+- every decision issue code must already exist on the artifact
+- model decisions cannot override issues
+- model decisions below confidence threshold must escalate to human
+- human override decisions must name at least one real artifact issue code
+
+## First Local Checks
+
+The content-kitchen contract test covers:
+
+- low-risk artifact routes to `auto_approve`
+- answer mismatch routes to `auto_reject`
+- soft quality issue routes to `model_review`
+- low-confidence model decision routes to `human_review`
+- model override of a hard rule fails
+- missing `artifactId` fails
+- revision mismatch fails
+- override of an absent issue code fails

--- a/lib/puzzles/content-kitchen/review-decision.ts
+++ b/lib/puzzles/content-kitchen/review-decision.ts
@@ -1,0 +1,279 @@
+import { getIssueDefinition } from "./issue-registry";
+import type {
+  ContentKitchenIssueCode,
+  ReviewArtifactV0,
+  ReviewDecisionV0,
+  ReviewDecisionValidationResult,
+  ReviewRouteResult,
+} from "./types";
+
+export const REVIEW_DECISION_VERSION = "content-kitchen-review-decision-v0";
+export const MODEL_REVIEW_MIN_CONFIDENCE = 0.75;
+
+const HARD_RULE_AUTO_REJECT_ISSUES = new Set<ContentKitchenIssueCode>([
+  "MISSING_L1_INPUT",
+  "INVALID_L1_INPUT",
+  "INVALID_CANDIDATE_METADATA",
+  "CANDIDATE_L1_MISMATCH",
+  "CANONICAL_URL_MISMATCH",
+  "NOINDEX_REQUIRED_BUT_MISSING",
+  "MISSING_CLUE_ROW",
+  "DUPLICATE_CLUE_ROW",
+  "MISSING_EVIDENCE_REF",
+  "MISSING_REASONING_PATTERN",
+  "UNSUPPORTED_REASONING_PATTERN",
+  "FAQ_SCHEMA_WITHOUT_VISIBLE_FAQ",
+  "INVALID_FAQ_STRUCTURE",
+]);
+
+const MODEL_REVIEW_ISSUES = new Set<ContentKitchenIssueCode>([
+  "GENERIC_REASONING_PATTERN",
+  "WEAK_FIT_EVIDENCE",
+  "L4_ONLY_EVIDENCE",
+  "FULL_ANALYSIS_WITH_LOW_CONFIDENCE",
+  "INTERNAL_LINK_BROKEN",
+  "INDEXED_ANSWER_FIRST_STALE",
+]);
+
+const HUMAN_REVIEW_ISSUES = new Set<ContentKitchenIssueCode>([
+  "ANSWER_HIDDEN_FROM_RENDERED_HTML",
+  "FULL_ANALYSIS_STRUCTURE_NOT_VALIDATED",
+  "UNSUPPORTED_CLUE_FIT",
+  "PROHIBITED_EVIDENCE_SOURCE",
+  "EVIDENCE_SOURCE_CONFLICT",
+  "ANSWER_FIRST_OVER_SLA",
+  "ANSWER_FIRST_REVIEW_REQUIRED",
+  "ANSWER_FIRST_HIGH_PRIORITY_ALERT",
+]);
+
+function uniqueIssueCodes(issueCodes: ContentKitchenIssueCode[]): ContentKitchenIssueCode[] {
+  return [...new Set(issueCodes)];
+}
+
+function registeredIssueCodes(artifact: ReviewArtifactV0): ContentKitchenIssueCode[] {
+  const issueCodes = uniqueIssueCodes([
+    ...artifact.validation.issueCodes,
+    ...artifact.issueCodesRequiringDecision,
+  ]);
+
+  for (const issueCode of issueCodes) {
+    getIssueDefinition(issueCode);
+  }
+
+  return issueCodes;
+}
+
+function partitionIssueCodes(issueCodes: ContentKitchenIssueCode[]) {
+  const hardRuleIssueCodes = issueCodes.filter((issueCode) => HARD_RULE_AUTO_REJECT_ISSUES.has(issueCode));
+  const modelReviewIssueCodes = issueCodes.filter((issueCode) => MODEL_REVIEW_ISSUES.has(issueCode));
+  const humanReviewIssueCodes = issueCodes.filter((issueCode) => HUMAN_REVIEW_ISSUES.has(issueCode));
+
+  return {
+    hardRuleIssueCodes,
+    modelReviewIssueCodes,
+    humanReviewIssueCodes,
+  };
+}
+
+export function deriveReviewRoute(
+  artifact: ReviewArtifactV0,
+  options: {
+    modelConfidence?: number;
+    modelConfidenceThreshold?: number;
+  } = {},
+): ReviewRouteResult {
+  const issueCodes = registeredIssueCodes(artifact);
+  const {
+    hardRuleIssueCodes,
+    modelReviewIssueCodes,
+    humanReviewIssueCodes,
+  } = partitionIssueCodes(issueCodes);
+  const threshold = options.modelConfidenceThreshold ?? MODEL_REVIEW_MIN_CONFIDENCE;
+
+  if (issueCodes.length === 0) {
+    return {
+      route: "auto_approve",
+      reason: "no_review_issues",
+      issueCodes,
+      hardRuleIssueCodes,
+      modelReviewIssueCodes,
+      humanReviewIssueCodes,
+    };
+  }
+
+  if (artifact.validation.outcome === "block_publish" || hardRuleIssueCodes.length > 0) {
+    return {
+      route: "auto_reject",
+      reason: "hard_rule_failure",
+      issueCodes,
+      hardRuleIssueCodes,
+      modelReviewIssueCodes,
+      humanReviewIssueCodes,
+    };
+  }
+
+  if (options.modelConfidence !== undefined && options.modelConfidence < threshold) {
+    return {
+      route: "human_review",
+      reason: "model_low_confidence",
+      issueCodes,
+      hardRuleIssueCodes,
+      modelReviewIssueCodes,
+      humanReviewIssueCodes,
+    };
+  }
+
+  if (humanReviewIssueCodes.length > 0) {
+    return {
+      route: "human_review",
+      reason: "human_review_required_issue",
+      issueCodes,
+      hardRuleIssueCodes,
+      modelReviewIssueCodes,
+      humanReviewIssueCodes,
+    };
+  }
+
+  if (modelReviewIssueCodes.length === issueCodes.length) {
+    return {
+      route: "model_review",
+      reason: "soft_quality_review",
+      issueCodes,
+      hardRuleIssueCodes,
+      modelReviewIssueCodes,
+      humanReviewIssueCodes,
+    };
+  }
+
+  return {
+    route: "human_review",
+    reason: "unclassified_review_issue",
+    issueCodes,
+    hardRuleIssueCodes,
+    modelReviewIssueCodes,
+    humanReviewIssueCodes,
+  };
+}
+
+function nonEmptyText(value: string | undefined): boolean {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function isValidIsoTimestamp(value: string): boolean {
+  return Number.isFinite(Date.parse(value));
+}
+
+export function validateReviewDecision(input: {
+  artifact: ReviewArtifactV0;
+  decision: ReviewDecisionV0;
+  modelConfidenceThreshold?: number;
+}): ReviewDecisionValidationResult {
+  const { artifact, decision } = input;
+  const derivedRoute = deriveReviewRoute(artifact, {
+    modelConfidence: decision.reviewerType === "model" ? decision.confidence : undefined,
+    modelConfidenceThreshold: input.modelConfidenceThreshold,
+  });
+  const errors: string[] = [];
+  const artifactIssueCodes = new Set(artifact.validation.issueCodes);
+
+  if (decision.decisionVersion !== REVIEW_DECISION_VERSION) {
+    errors.push("decisionVersion is unsupported");
+  }
+  if (!nonEmptyText(decision.artifactId)) {
+    errors.push("artifactId is required");
+  } else if (decision.artifactId !== artifact.artifactId) {
+    errors.push("artifactId must match the review artifact");
+  }
+  if (!nonEmptyText(artifact.puzzleId)) {
+    errors.push("artifact puzzleId is required");
+  } else if (!nonEmptyText(decision.puzzleId)) {
+    errors.push("puzzleId is required");
+  } else if (decision.puzzleId !== artifact.puzzleId) {
+    errors.push("puzzleId must match the review artifact");
+  }
+  if (!nonEmptyText(artifact.candidateRevisionId)) {
+    errors.push("artifact candidateRevisionId is required");
+  } else if (!nonEmptyText(decision.candidateRevisionId)) {
+    errors.push("candidateRevisionId is required");
+  } else if (decision.candidateRevisionId !== artifact.candidateRevisionId) {
+    errors.push("candidateRevisionId must match the review artifact");
+  }
+  if (decision.route !== derivedRoute.route) {
+    errors.push(`route must be ${derivedRoute.route}`);
+  }
+  if (!nonEmptyText(decision.reviewerId)) {
+    errors.push("reviewerId is required");
+  }
+  if (!nonEmptyText(decision.note)) {
+    errors.push("note is required");
+  }
+  if (!nonEmptyText(decision.reviewedAt) || !isValidIsoTimestamp(decision.reviewedAt)) {
+    errors.push("reviewedAt must be a valid timestamp");
+  }
+  if (
+    decision.confidence !== undefined &&
+    (!Number.isFinite(decision.confidence) || decision.confidence < 0 || decision.confidence > 1)
+  ) {
+    errors.push("confidence must be between 0 and 1");
+  }
+
+  if (artifactIssueCodes.size > 0 && decision.issueCodes.length === 0) {
+    errors.push("issueCodes are required when the artifact has issues");
+  }
+  for (const issueCode of decision.issueCodes) {
+    getIssueDefinition(issueCode);
+    if (!artifactIssueCodes.has(issueCode)) {
+      errors.push(`issueCodes contains ${issueCode}, which is not in the review artifact`);
+    }
+  }
+
+  if (decision.reviewerType === "rule_engine") {
+    if (derivedRoute.route === "auto_approve" && decision.action !== "approve") {
+      errors.push("rule_engine can only approve auto_approve routes");
+    }
+    if (derivedRoute.route === "auto_reject" && decision.action !== "reject") {
+      errors.push("rule_engine can only reject auto_reject routes");
+    }
+    if (derivedRoute.route !== "auto_approve" && derivedRoute.route !== "auto_reject") {
+      errors.push("rule_engine cannot decide model_review or human_review routes");
+    }
+  }
+
+  if (decision.reviewerType === "model") {
+    if (!nonEmptyText(decision.modelName)) {
+      errors.push("modelName is required for model decisions");
+    }
+    if (!nonEmptyText(decision.modelVersion)) {
+      errors.push("modelVersion is required for model decisions");
+    }
+    if (decision.confidence === undefined) {
+      errors.push("confidence is required for model decisions");
+    }
+    if (decision.action === "override_issue") {
+      errors.push("model reviewers cannot override issues");
+    }
+    if (decision.action === "force_answer_first") {
+      errors.push("model reviewers cannot force answer-first");
+    }
+    if (derivedRoute.route === "human_review" && decision.action !== "escalate_to_human") {
+      errors.push("low-confidence or high-risk model decisions must escalate to human");
+    }
+    if (derivedRoute.route === "auto_reject" && decision.action !== "escalate_to_human") {
+      errors.push("model reviewers cannot approve or reject hard-rule failures");
+    }
+  }
+
+  if (decision.reviewerType === "human" && decision.action === "override_issue" && decision.issueCodes.length === 0) {
+    errors.push("human override decisions must name at least one issue code");
+  }
+
+  if (decision.action === "override_issue" && decision.reviewerType !== "human") {
+    errors.push("only human reviewers can override issues");
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+    derivedRoute,
+  };
+}

--- a/lib/puzzles/content-kitchen/types.ts
+++ b/lib/puzzles/content-kitchen/types.ts
@@ -703,3 +703,54 @@ export type ReviewArtifactV0 = {
   evidenceSummary?: ReviewArtifactEvidenceSummary;
   renderedPreviewUrl?: string;
 };
+
+export type ReviewRoute =
+  | "auto_approve"
+  | "auto_reject"
+  | "model_review"
+  | "human_review";
+
+export type ReviewDecisionAction =
+  | "approve"
+  | "reject"
+  | "request_regeneration"
+  | "force_answer_first"
+  | "override_issue"
+  | "escalate_to_human";
+
+export type ReviewDecisionReviewerType =
+  | "rule_engine"
+  | "model"
+  | "human";
+
+export type ReviewRouteResult = {
+  route: ReviewRoute;
+  reason: string;
+  issueCodes: ContentKitchenIssueCode[];
+  hardRuleIssueCodes: ContentKitchenIssueCode[];
+  modelReviewIssueCodes: ContentKitchenIssueCode[];
+  humanReviewIssueCodes: ContentKitchenIssueCode[];
+};
+
+export type ReviewDecisionV0 = {
+  decisionVersion: "content-kitchen-review-decision-v0";
+  artifactId: string;
+  puzzleId: string;
+  candidateRevisionId: string;
+  issueCodes: ContentKitchenIssueCode[];
+  route: ReviewRoute;
+  action: ReviewDecisionAction;
+  reviewerType: ReviewDecisionReviewerType;
+  reviewerId: string;
+  reviewedAt: string;
+  confidence?: number;
+  modelName?: string;
+  modelVersion?: string;
+  note: string;
+};
+
+export type ReviewDecisionValidationResult = {
+  valid: boolean;
+  errors: string[];
+  derivedRoute: ReviewRouteResult;
+};

--- a/scripts/check-content-kitchen-contract.ts
+++ b/scripts/check-content-kitchen-contract.ts
@@ -53,6 +53,11 @@ import {
   getPr7IssueCodes,
 } from "../lib/puzzles/content-kitchen/issue-registry";
 import { buildReviewArtifactV0, shouldCreateReviewArtifact } from "../lib/puzzles/content-kitchen/review-artifact";
+import {
+  REVIEW_DECISION_VERSION,
+  deriveReviewRoute,
+  validateReviewDecision,
+} from "../lib/puzzles/content-kitchen/review-decision";
 import { validateCandidate } from "../lib/puzzles/content-kitchen/validate-candidate";
 import { ENRICHMENT_WORKER_FILE_STORE_OUTPUT_VERSION } from "./content-kitchen-enrichment-file-store";
 import { ENRICHMENT_WORKER_ACTION_DRAFTS_VERSION } from "./content-kitchen-enrichment-action-drafts";
@@ -73,6 +78,8 @@ import type {
   FullAnalysisSlotIssueCode,
   FullAnalysisSlotPlanV0,
   L1PuzzleInput,
+  ReviewArtifactV0,
+  ReviewDecisionV0,
   ValidateCandidateInput,
   ValidationOutcome,
   ValidationPolicies,
@@ -87,6 +94,11 @@ const PR9_ENRICHMENT_DRY_RUN_USAGE_DOC_PATH = resolve(
   ROOT,
   "docs",
   "pinpoint-content-kitchen-pr9-enrichment-dry-run-usage-2026-05-24.md",
+);
+const PR10_REVIEW_ROUTING_DECISION_DOC_PATH = resolve(
+  ROOT,
+  "docs",
+  "pinpoint-content-kitchen-pr10-review-routing-decision-2026-05-24.md",
 );
 
 type Fixture = {
@@ -191,6 +203,237 @@ function assertReviewArtifactBehavior(fileName: string, fixture: Fixture, actual
     );
   }
   assert.ok(!serialized.includes("secret"), `${fileName}: artifact must not include obvious secret strings`);
+}
+
+function makeReviewArtifactForDecision(
+  issueCodes: ContentKitchenIssueCode[],
+  overrides: Partial<ReviewArtifactV0> = {},
+): ReviewArtifactV0 {
+  const validationIssues = issueCodes.map((issueCode) => {
+    const definition = getIssueDefinition(issueCode);
+    return {
+      issueCode,
+      severity: definition.defaultSeverity,
+      fieldPath: "candidate",
+      message: definition.description,
+      suggestedAction: definition.defaultRequiredAction,
+      blocking: definition.defaultSeverity === "P0",
+      candidateRevisionId: "rev-full-analysis-916",
+    };
+  });
+
+  return {
+    artifactVersion: "content-kitchen-review-artifact-v0",
+    artifactId: "art_review_decision_contract",
+    artifactType: "review",
+    createdAt: "2026-05-24T00:00:00.000Z",
+    puzzleId: "pinpoint-916-2026-05-23",
+    canonicalUrl: "https://example.com/linkedin-pinpoint-answers/pinpoint-answer-916/",
+    contentMode: "full-analysis",
+    candidateRevisionId: "rev-full-analysis-916",
+    validation: {
+      outcome: issueCodes.length > 0 ? "requires_review" : "pass_full_analysis",
+      policies: {
+        indexPolicy: issueCodes.length > 0 ? "review_required" : "index",
+        sitemapPolicy: issueCodes.length > 0 ? "include_after_audit" : "include",
+        schemaPolicy: "article_only",
+        internalLinkPolicy: issueCodes.length > 0 ? "deemphasized" : "normal",
+        requiredAction: issueCodes.length > 0 ? "review" : "none",
+      },
+      issueCodes,
+      issues: validationIssues,
+    },
+    issueCodesRequiringDecision: issueCodes,
+    recommendedAction: issueCodes.length > 0 ? "review" : "none",
+    allowedReviewerActions: ["approve_candidate", "reject_candidate", "create_fix_task"],
+    ...overrides,
+  };
+}
+
+function makeReviewDecisionForArtifact(
+  artifact: ReviewArtifactV0,
+  overrides: Partial<ReviewDecisionV0> = {},
+): ReviewDecisionV0 {
+  const route = deriveReviewRoute(artifact, {
+    modelConfidence: overrides.reviewerType === "model" ? overrides.confidence : undefined,
+  }).route;
+
+  return {
+    decisionVersion: REVIEW_DECISION_VERSION,
+    artifactId: artifact.artifactId,
+    puzzleId: artifact.puzzleId ?? "pinpoint-916-2026-05-23",
+    candidateRevisionId: artifact.candidateRevisionId ?? "rev-full-analysis-916",
+    issueCodes: artifact.validation.issueCodes,
+    route,
+    action: route === "auto_reject" ? "reject" : "approve",
+    reviewerType: route === "model_review" ? "model" : "rule_engine",
+    reviewerId: route === "model_review" ? "model-reviewer" : "content-kitchen-rules",
+    reviewedAt: "2026-05-24T00:01:00.000Z",
+    note: "Local contract test decision.",
+    ...(route === "model_review"
+      ? {
+        confidence: 0.9,
+        modelName: "contract-model",
+        modelVersion: "v0",
+      }
+      : {}),
+    ...overrides,
+  };
+}
+
+function assertReviewRoutingAndDecisionContract() {
+  const lowRiskArtifact = makeReviewArtifactForDecision([]);
+  const lowRiskRoute = deriveReviewRoute(lowRiskArtifact);
+  assert.equal(lowRiskRoute.route, "auto_approve", "low-risk review artifacts should route to auto_approve");
+  assert.equal(
+    validateReviewDecision({
+      artifact: lowRiskArtifact,
+      decision: makeReviewDecisionForArtifact(lowRiskArtifact),
+    }).valid,
+    true,
+    "rule engine should be able to approve a low-risk artifact locally",
+  );
+
+  const hardRuleArtifact = makeReviewArtifactForDecision(["CANDIDATE_L1_MISMATCH"], {
+    validation: {
+      ...makeReviewArtifactForDecision(["CANDIDATE_L1_MISMATCH"]).validation,
+      outcome: "block_publish",
+      policies: {
+        indexPolicy: "block_publish",
+        sitemapPolicy: "exclude",
+        schemaPolicy: "block_schema",
+        internalLinkPolicy: "hidden_from_recent",
+        requiredAction: "block_publish",
+      },
+    },
+    recommendedAction: "block_publish",
+  });
+  const hardRuleRoute = deriveReviewRoute(hardRuleArtifact);
+  assert.equal(hardRuleRoute.route, "auto_reject", "hard-rule failures should route to auto_reject");
+  assert.deepEqual(
+    hardRuleRoute.hardRuleIssueCodes,
+    ["CANDIDATE_L1_MISMATCH"],
+    "hard-rule routes should expose the exact hard issue code",
+  );
+  assert.equal(
+    validateReviewDecision({
+      artifact: hardRuleArtifact,
+      decision: makeReviewDecisionForArtifact(hardRuleArtifact),
+    }).valid,
+    true,
+    "rule engine should be able to reject obvious hard-rule failures",
+  );
+
+  const softArtifact = makeReviewArtifactForDecision(["GENERIC_REASONING_PATTERN"]);
+  const softRoute = deriveReviewRoute(softArtifact);
+  assert.equal(softRoute.route, "model_review", "soft quality issues should route to model_review");
+  assert.deepEqual(
+    softRoute.modelReviewIssueCodes,
+    ["GENERIC_REASONING_PATTERN"],
+    "model review routes should expose soft issue codes",
+  );
+
+  const modelDecision = makeReviewDecisionForArtifact(softArtifact, {
+    reviewerType: "model",
+    reviewerId: "model-reviewer",
+    action: "request_regeneration",
+    confidence: 0.9,
+    modelName: "contract-model",
+    modelVersion: "v0",
+    note: "Reasoning is too generic; regenerate the explanation.",
+  });
+  assert.equal(
+    validateReviewDecision({ artifact: softArtifact, decision: modelDecision }).valid,
+    true,
+    "model reviewers should be able to recommend regeneration for soft issues",
+  );
+
+  const lowConfidenceRoute = deriveReviewRoute(softArtifact, { modelConfidence: 0.4 });
+  assert.equal(lowConfidenceRoute.route, "human_review", "low-confidence model review should route to human_review");
+  const lowConfidenceDecision = makeReviewDecisionForArtifact(softArtifact, {
+    route: "human_review",
+    reviewerType: "model",
+    reviewerId: "model-reviewer",
+    action: "escalate_to_human",
+    confidence: 0.4,
+    modelName: "contract-model",
+    modelVersion: "v0",
+    note: "Model confidence is too low for a final decision.",
+  });
+  assert.equal(
+    validateReviewDecision({ artifact: softArtifact, decision: lowConfidenceDecision }).valid,
+    true,
+    "low-confidence model decisions should be valid only when escalated to human",
+  );
+
+  const modelOverride = validateReviewDecision({
+    artifact: hardRuleArtifact,
+    decision: makeReviewDecisionForArtifact(hardRuleArtifact, {
+      route: "auto_reject",
+      reviewerType: "model",
+      reviewerId: "model-reviewer",
+      action: "override_issue",
+      confidence: 0.9,
+      modelName: "contract-model",
+      modelVersion: "v0",
+      note: "Model tried to override a hard rule.",
+    }),
+  });
+  assert.equal(modelOverride.valid, false, "model reviewers must not override hard-rule failures");
+  assert.ok(
+    modelOverride.errors.some((error) => error.includes("cannot override")),
+    "model override validation should explain the override failure",
+  );
+
+  const missingArtifactId = validateReviewDecision({
+    artifact: softArtifact,
+    decision: makeReviewDecisionForArtifact(softArtifact, {
+      artifactId: "",
+      reviewerType: "model",
+      action: "request_regeneration",
+      confidence: 0.9,
+      modelName: "contract-model",
+      modelVersion: "v0",
+    }),
+  });
+  assert.equal(missingArtifactId.valid, false, "review decisions without artifactId should fail");
+  assert.ok(
+    missingArtifactId.errors.includes("artifactId is required"),
+    "missing artifactId should produce a specific validation error",
+  );
+
+  const revisionMismatch = validateReviewDecision({
+    artifact: softArtifact,
+    decision: makeReviewDecisionForArtifact(softArtifact, {
+      candidateRevisionId: "rev-other",
+      reviewerType: "model",
+      action: "request_regeneration",
+      confidence: 0.9,
+      modelName: "contract-model",
+      modelVersion: "v0",
+    }),
+  });
+  assert.equal(revisionMismatch.valid, false, "review decisions with revision mismatch should fail");
+  assert.ok(
+    revisionMismatch.errors.includes("candidateRevisionId must match the review artifact"),
+    "revision mismatch should produce a specific validation error",
+  );
+
+  const invalidOverride = validateReviewDecision({
+    artifact: hardRuleArtifact,
+    decision: makeReviewDecisionForArtifact(hardRuleArtifact, {
+      reviewerType: "human",
+      reviewerId: "human-reviewer",
+      action: "override_issue",
+      issueCodes: ["WEAK_FIT_EVIDENCE"],
+      note: "Human tried to override an issue that is not on this artifact.",
+    }),
+  });
+  assert.equal(invalidOverride.valid, false, "override decisions for absent issue codes should fail");
+  assert.ok(
+    invalidOverride.errors.some((error) => error.includes("not in the review artifact")),
+    "absent override issue codes should produce a specific validation error",
+  );
 }
 
 function assertPr6P0Coverage(fixtures: Fixture[]) {
@@ -2883,6 +3126,40 @@ async function assertAnswerFirstEnrichmentDryRunUsageDoc() {
   }
 }
 
+async function assertReviewRoutingDecisionDoc() {
+  const doc = await readFile(PR10_REVIEW_ROUTING_DECISION_DOC_PATH, "utf8");
+  const requiredSnippets = [
+    "PR10 Review Routing And Decision Contract",
+    "`ReviewRoute`",
+    "`auto_approve`: rules found no review issue",
+    "`auto_reject`: hard rules found a clear failure",
+    "`model_review`: only soft quality issues remain",
+    "`human_review`: risk is too high, unclear, or low-confidence",
+    "`auto_approve` means local rules think no reviewer is needed. It does not mean automatic publishing.",
+    "Hard-rule failures are not sent to model review.",
+    "Model review is only a route in PR10.1. No model is called in this slice.",
+    "Only a human can use `override_issue`.",
+    "decisionVersion: \"content-kitchen-review-decision-v0\"",
+    "`artifactId`",
+    "`puzzleId`",
+    "`candidateRevisionId`",
+    "model decisions cannot override issues",
+    "model decisions below confidence threshold must escalate to human",
+    "override of an absent issue code fails",
+    "does not build Review UI",
+    "does not call a model",
+    "does not send Feishu messages",
+    "does not write review queue storage",
+    "does not touch production storage",
+    "does not publish content",
+    "does not run Worker cron",
+  ];
+
+  for (const snippet of requiredSnippets) {
+    assert.ok(doc.includes(snippet), `PR10 review routing decision doc should include: ${snippet}`);
+  }
+}
+
 async function main() {
   const fileNames = (await readdir(FIXTURE_DIR)).filter((fileName) => fileName.endsWith(".json")).sort();
   assert.ok(fileNames.length >= 6, "content kitchen should have at least 6 fixtures");
@@ -2906,6 +3183,7 @@ async function main() {
   checkHashExcludesVolatileFields();
   assertFullAnalysisSlotContract();
   assertIssueRegistryIsStable();
+  assertReviewRoutingAndDecisionContract();
   assertPr6P0Coverage(fixtures);
   assertPr7Coverage(fixtures);
   await assertExamplesAreValidJson();
@@ -2929,6 +3207,7 @@ async function main() {
   await assertAnswerFirstEnrichmentWorkerHighPriorityJsonDryRun();
   await assertAnswerFirstEnrichmentWorkerHealthStatuses();
   await assertAnswerFirstEnrichmentDryRunUsageDoc();
+  await assertReviewRoutingDecisionDoc();
   console.log(`content-kitchen contract fixtures passed (${fileNames.length} fixtures)`);
 }
 


### PR DESCRIPTION
## Summary
- add local PR10.1 review routing and review decision types
- add deriveReviewRoute and validateReviewDecision helpers for rule, model, and human decision boundaries
- cover auto approve, auto reject, model review, low-confidence human escalation, and invalid override cases in the content-kitchen contract test
- document the local-only PR10.1 boundary and update the architecture plan

## Validation
- npm run test:content-kitchen
- git diff --check -- lib/puzzles/content-kitchen/types.ts lib/puzzles/content-kitchen/review-decision.ts scripts/check-content-kitchen-contract.ts docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md docs/pinpoint-content-kitchen-pr10-review-routing-decision-2026-05-24.md
- npm run typecheck
- npm run lint
- npm run validate:data
- npm run build