### PR TITLE
[codex] Add PR10 review decision runner examples

### DIFF
--- a/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
+++ b/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
@@ -2256,6 +2256,15 @@ PR10 first implementation slice:
 - reject decisions with missing artifact id, puzzle id mismatch, candidate revision mismatch, model override attempts, or override issue codes that are not present on the artifact
 - keep this local-only; do not build Review UI, call a model, send Feishu messages, write review queue storage, attach production storage, publish content, or run Worker cron yet
 
+PR10 second implementation slice:
+
+- add checked local example artifacts and decisions for `auto_approve`, `auto_reject`, `model_review`, low-confidence `human_review`, and human `override_issue`
+- add a local review decision runner that reads a review artifact JSON file and optional decision JSON file, then prints the derived route and decision validation result
+- allow the runner to write its result to a separate local `--output` file
+- reject unsafe paths where `--output` equals `--artifact` or `--decision`
+- make the contract test prove the examples validate, revision mismatch fails, model override fails, and override of an absent issue code fails
+- keep this local-only; do not build Review UI, call a model, send Feishu messages, write review queue storage, attach production storage, publish content, or run Worker cron yet
+
 ### PR11 — Post-Publish Content Audit
 
 Goal: verify what users and crawlers see after publish.

--- a/docs/pinpoint-content-kitchen-pr10-review-routing-decision-2026-05-24.md
+++ b/docs/pinpoint-content-kitchen-pr10-review-routing-decision-2026-05-24.md
@@ -131,3 +131,63 @@ The content-kitchen contract test covers:
 - missing `artifactId` fails
 - revision mismatch fails
 - override of an absent issue code fails
+
+## Example Files
+
+Checked examples live in `lib/puzzles/content-kitchen/examples`.
+
+Each example has an artifact file and a decision file:
+
+- `review-decision-auto-approve.*.example.json`
+- `review-decision-auto-reject.*.example.json`
+- `review-decision-model-review.*.example.json`
+- `review-decision-low-confidence-human.*.example.json`
+- `review-decision-human-override.*.example.json`
+
+These examples cover:
+
+- low-risk route to `auto_approve`
+- hard-rule route to `auto_reject`
+- soft quality route to `model_review`
+- low-confidence model route to `human_review`
+- human-only `override_issue`
+
+## Local Runner
+
+Use the local runner to inspect a route and validate a decision file:
+
+```bash
+npm run content-kitchen:review-decision -- \
+  --artifact lib/puzzles/content-kitchen/examples/review-decision-model-review.artifact.example.json \
+  --decision lib/puzzles/content-kitchen/examples/review-decision-model-review.decision.example.json \
+  --pretty
+```
+
+Write the result to a local file:
+
+```bash
+npm run content-kitchen:review-decision -- \
+  --artifact lib/puzzles/content-kitchen/examples/review-decision-model-review.artifact.example.json \
+  --decision lib/puzzles/content-kitchen/examples/review-decision-model-review.decision.example.json \
+  --output /tmp/content-kitchen-review-decision-result.json \
+  --pretty
+```
+
+Route without a decision file:
+
+```bash
+npm run content-kitchen:review-decision -- \
+  --artifact lib/puzzles/content-kitchen/examples/review-decision-human-override.artifact.example.json \
+  --pretty
+```
+
+Rules:
+
+- `--output` must not equal `--artifact`
+- `--output` must not equal `--decision`
+- the runner is for local inspection only
+- the runner does not call a model
+- the runner does not send Feishu messages
+- the runner does not write review queue storage
+- the runner does not touch production storage
+- the runner does not publish content

--- a/lib/puzzles/content-kitchen/examples/review-decision-auto-approve.artifact.example.json
+++ b/lib/puzzles/content-kitchen/examples/review-decision-auto-approve.artifact.example.json
@@ -1,0 +1,27 @@
+{
+  "artifactVersion": "content-kitchen-review-artifact-v0",
+  "artifactId": "art_review_auto_approve_example",
+  "artifactType": "review",
+  "createdAt": "2026-05-24T00:00:00.000Z",
+  "puzzleId": "pinpoint-920-2026-05-24",
+  "canonicalUrl": "https://example.com/linkedin-pinpoint-answers/pinpoint-answer-920/",
+  "contentMode": "full-analysis",
+  "candidateRevisionId": "rev-full-analysis-920",
+  "validation": {
+    "outcome": "pass_full_analysis",
+    "policies": {
+      "indexPolicy": "index",
+      "sitemapPolicy": "include",
+      "schemaPolicy": "article_only",
+      "internalLinkPolicy": "normal",
+      "requiredAction": "none"
+    },
+    "issueCodes": [],
+    "issues": []
+  },
+  "issueCodesRequiringDecision": [],
+  "recommendedAction": "none",
+  "allowedReviewerActions": [
+    "approve_candidate"
+  ]
+}

--- a/lib/puzzles/content-kitchen/examples/review-decision-auto-approve.decision.example.json
+++ b/lib/puzzles/content-kitchen/examples/review-decision-auto-approve.decision.example.json
@@ -1,0 +1,13 @@
+{
+  "decisionVersion": "content-kitchen-review-decision-v0",
+  "artifactId": "art_review_auto_approve_example",
+  "puzzleId": "pinpoint-920-2026-05-24",
+  "candidateRevisionId": "rev-full-analysis-920",
+  "issueCodes": [],
+  "route": "auto_approve",
+  "action": "approve",
+  "reviewerType": "rule_engine",
+  "reviewerId": "content-kitchen-rules",
+  "reviewedAt": "2026-05-24T00:01:00.000Z",
+  "note": "Rules found no review issue. This does not publish content."
+}

--- a/lib/puzzles/content-kitchen/examples/review-decision-auto-reject.artifact.example.json
+++ b/lib/puzzles/content-kitchen/examples/review-decision-auto-reject.artifact.example.json
@@ -1,0 +1,42 @@
+{
+  "artifactVersion": "content-kitchen-review-artifact-v0",
+  "artifactId": "art_review_auto_reject_example",
+  "artifactType": "review",
+  "createdAt": "2026-05-24T00:00:00.000Z",
+  "puzzleId": "pinpoint-921-2026-05-24",
+  "canonicalUrl": "https://example.com/linkedin-pinpoint-answers/pinpoint-answer-921/",
+  "contentMode": "full-analysis",
+  "candidateRevisionId": "rev-full-analysis-921",
+  "validation": {
+    "outcome": "block_publish",
+    "policies": {
+      "indexPolicy": "block_publish",
+      "sitemapPolicy": "exclude",
+      "schemaPolicy": "block_schema",
+      "internalLinkPolicy": "hidden_from_recent",
+      "requiredAction": "block_publish"
+    },
+    "issueCodes": [
+      "CANDIDATE_L1_MISMATCH"
+    ],
+    "issues": [
+      {
+        "issueCode": "CANDIDATE_L1_MISMATCH",
+        "severity": "P0",
+        "fieldPath": "candidate.answer",
+        "message": "Candidate answer or clue data does not match L1.",
+        "suggestedAction": "Reject this candidate and regenerate from the current L1 input.",
+        "blocking": true,
+        "candidateRevisionId": "rev-full-analysis-921"
+      }
+    ]
+  },
+  "issueCodesRequiringDecision": [
+    "CANDIDATE_L1_MISMATCH"
+  ],
+  "recommendedAction": "block_publish",
+  "allowedReviewerActions": [
+    "reject_candidate",
+    "create_fix_task"
+  ]
+}

--- a/lib/puzzles/content-kitchen/examples/review-decision-auto-reject.decision.example.json
+++ b/lib/puzzles/content-kitchen/examples/review-decision-auto-reject.decision.example.json
@@ -1,0 +1,15 @@
+{
+  "decisionVersion": "content-kitchen-review-decision-v0",
+  "artifactId": "art_review_auto_reject_example",
+  "puzzleId": "pinpoint-921-2026-05-24",
+  "candidateRevisionId": "rev-full-analysis-921",
+  "issueCodes": [
+    "CANDIDATE_L1_MISMATCH"
+  ],
+  "route": "auto_reject",
+  "action": "reject",
+  "reviewerType": "rule_engine",
+  "reviewerId": "content-kitchen-rules",
+  "reviewedAt": "2026-05-24T00:02:00.000Z",
+  "note": "Hard rule failed. The model must not overrule this."
+}

--- a/lib/puzzles/content-kitchen/examples/review-decision-human-override.artifact.example.json
+++ b/lib/puzzles/content-kitchen/examples/review-decision-human-override.artifact.example.json
@@ -1,0 +1,43 @@
+{
+  "artifactVersion": "content-kitchen-review-artifact-v0",
+  "artifactId": "art_review_human_override_example",
+  "artifactType": "review",
+  "createdAt": "2026-05-24T00:00:00.000Z",
+  "puzzleId": "pinpoint-924-2026-05-24",
+  "canonicalUrl": "https://example.com/linkedin-pinpoint-answers/pinpoint-answer-924/",
+  "contentMode": "full-analysis",
+  "candidateRevisionId": "rev-full-analysis-924",
+  "validation": {
+    "outcome": "requires_review",
+    "policies": {
+      "indexPolicy": "review_required",
+      "sitemapPolicy": "include_after_audit",
+      "schemaPolicy": "article_only",
+      "internalLinkPolicy": "deemphasized",
+      "requiredAction": "review"
+    },
+    "issueCodes": [
+      "EVIDENCE_SOURCE_CONFLICT"
+    ],
+    "issues": [
+      {
+        "issueCode": "EVIDENCE_SOURCE_CONFLICT",
+        "severity": "P1",
+        "fieldPath": "evidenceRecords",
+        "message": "Evidence sources conflict and require human judgment.",
+        "suggestedAction": "Human reviewer may resolve or override the specific conflict.",
+        "blocking": false,
+        "candidateRevisionId": "rev-full-analysis-924"
+      }
+    ]
+  },
+  "issueCodesRequiringDecision": [
+    "EVIDENCE_SOURCE_CONFLICT"
+  ],
+  "recommendedAction": "review",
+  "allowedReviewerActions": [
+    "approve_candidate",
+    "reject_candidate",
+    "create_fix_task"
+  ]
+}

--- a/lib/puzzles/content-kitchen/examples/review-decision-human-override.decision.example.json
+++ b/lib/puzzles/content-kitchen/examples/review-decision-human-override.decision.example.json
@@ -1,0 +1,15 @@
+{
+  "decisionVersion": "content-kitchen-review-decision-v0",
+  "artifactId": "art_review_human_override_example",
+  "puzzleId": "pinpoint-924-2026-05-24",
+  "candidateRevisionId": "rev-full-analysis-924",
+  "issueCodes": [
+    "EVIDENCE_SOURCE_CONFLICT"
+  ],
+  "route": "human_review",
+  "action": "override_issue",
+  "reviewerType": "human",
+  "reviewerId": "human-reviewer",
+  "reviewedAt": "2026-05-24T00:05:00.000Z",
+  "note": "Human reviewer resolved this exact evidence conflict for this candidate revision only."
+}

--- a/lib/puzzles/content-kitchen/examples/review-decision-low-confidence-human.artifact.example.json
+++ b/lib/puzzles/content-kitchen/examples/review-decision-low-confidence-human.artifact.example.json
@@ -1,0 +1,43 @@
+{
+  "artifactVersion": "content-kitchen-review-artifact-v0",
+  "artifactId": "art_review_low_confidence_human_example",
+  "artifactType": "review",
+  "createdAt": "2026-05-24T00:00:00.000Z",
+  "puzzleId": "pinpoint-923-2026-05-24",
+  "canonicalUrl": "https://example.com/linkedin-pinpoint-answers/pinpoint-answer-923/",
+  "contentMode": "full-analysis",
+  "candidateRevisionId": "rev-full-analysis-923",
+  "validation": {
+    "outcome": "requires_review",
+    "policies": {
+      "indexPolicy": "review_required",
+      "sitemapPolicy": "include_after_audit",
+      "schemaPolicy": "article_only",
+      "internalLinkPolicy": "deemphasized",
+      "requiredAction": "review"
+    },
+    "issueCodes": [
+      "GENERIC_REASONING_PATTERN"
+    ],
+    "issues": [
+      {
+        "issueCode": "GENERIC_REASONING_PATTERN",
+        "severity": "P1",
+        "fieldPath": "candidate.fullAnalysis.reasoning",
+        "message": "Reasoning is too generic and model confidence is low.",
+        "suggestedAction": "Escalate to human review.",
+        "blocking": false,
+        "candidateRevisionId": "rev-full-analysis-923"
+      }
+    ]
+  },
+  "issueCodesRequiringDecision": [
+    "GENERIC_REASONING_PATTERN"
+  ],
+  "recommendedAction": "review",
+  "allowedReviewerActions": [
+    "approve_candidate",
+    "reject_candidate",
+    "request_full_analysis_fix"
+  ]
+}

--- a/lib/puzzles/content-kitchen/examples/review-decision-low-confidence-human.decision.example.json
+++ b/lib/puzzles/content-kitchen/examples/review-decision-low-confidence-human.decision.example.json
@@ -1,0 +1,18 @@
+{
+  "decisionVersion": "content-kitchen-review-decision-v0",
+  "artifactId": "art_review_low_confidence_human_example",
+  "puzzleId": "pinpoint-923-2026-05-24",
+  "candidateRevisionId": "rev-full-analysis-923",
+  "issueCodes": [
+    "GENERIC_REASONING_PATTERN"
+  ],
+  "route": "human_review",
+  "action": "escalate_to_human",
+  "reviewerType": "model",
+  "reviewerId": "model-reviewer",
+  "reviewedAt": "2026-05-24T00:04:00.000Z",
+  "confidence": 0.4,
+  "modelName": "contract-model",
+  "modelVersion": "v0",
+  "note": "Model confidence is below threshold, so this must go to a human."
+}

--- a/lib/puzzles/content-kitchen/examples/review-decision-model-review.artifact.example.json
+++ b/lib/puzzles/content-kitchen/examples/review-decision-model-review.artifact.example.json
@@ -1,0 +1,43 @@
+{
+  "artifactVersion": "content-kitchen-review-artifact-v0",
+  "artifactId": "art_review_model_review_example",
+  "artifactType": "review",
+  "createdAt": "2026-05-24T00:00:00.000Z",
+  "puzzleId": "pinpoint-922-2026-05-24",
+  "canonicalUrl": "https://example.com/linkedin-pinpoint-answers/pinpoint-answer-922/",
+  "contentMode": "full-analysis",
+  "candidateRevisionId": "rev-full-analysis-922",
+  "validation": {
+    "outcome": "requires_review",
+    "policies": {
+      "indexPolicy": "review_required",
+      "sitemapPolicy": "include_after_audit",
+      "schemaPolicy": "article_only",
+      "internalLinkPolicy": "deemphasized",
+      "requiredAction": "review"
+    },
+    "issueCodes": [
+      "GENERIC_REASONING_PATTERN"
+    ],
+    "issues": [
+      {
+        "issueCode": "GENERIC_REASONING_PATTERN",
+        "severity": "P1",
+        "fieldPath": "candidate.fullAnalysis.reasoning",
+        "message": "Reasoning is too generic to trust as a solve path.",
+        "suggestedAction": "Ask for a more specific explanation or regenerate.",
+        "blocking": false,
+        "candidateRevisionId": "rev-full-analysis-922"
+      }
+    ]
+  },
+  "issueCodesRequiringDecision": [
+    "GENERIC_REASONING_PATTERN"
+  ],
+  "recommendedAction": "review",
+  "allowedReviewerActions": [
+    "approve_candidate",
+    "reject_candidate",
+    "request_full_analysis_fix"
+  ]
+}

--- a/lib/puzzles/content-kitchen/examples/review-decision-model-review.decision.example.json
+++ b/lib/puzzles/content-kitchen/examples/review-decision-model-review.decision.example.json
@@ -1,0 +1,18 @@
+{
+  "decisionVersion": "content-kitchen-review-decision-v0",
+  "artifactId": "art_review_model_review_example",
+  "puzzleId": "pinpoint-922-2026-05-24",
+  "candidateRevisionId": "rev-full-analysis-922",
+  "issueCodes": [
+    "GENERIC_REASONING_PATTERN"
+  ],
+  "route": "model_review",
+  "action": "request_regeneration",
+  "reviewerType": "model",
+  "reviewerId": "model-reviewer",
+  "reviewedAt": "2026-05-24T00:03:00.000Z",
+  "confidence": 0.9,
+  "modelName": "contract-model",
+  "modelVersion": "v0",
+  "note": "The explanation is too generic. Regenerate before any publish decision."
+}

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "visual:pinpoint-smoke": "node scripts/check-pinpoint-visibility-smoke.mjs",
     "gsc:pinpoint": "node scripts/gsc-pinpoint.mjs",
     "content-kitchen:enrichment-dry-run": "tsx scripts/run-content-kitchen-enrichment-worker-dry-run.ts",
+    "content-kitchen:review-decision": "tsx scripts/run-content-kitchen-review-decision.ts",
     "test:pinpoint-seo": "tsx scripts/check-pinpoint-seo-builders.ts",
     "test:content-kitchen": "tsx scripts/check-content-kitchen-contract.ts",
     "test:pinpoint-routing": "tsx scripts/check-routing-regressions.ts",

--- a/scripts/check-content-kitchen-contract.ts
+++ b/scripts/check-content-kitchen-contract.ts
@@ -72,6 +72,11 @@ import {
   runAnswerFirstEnrichmentWorkerJsonDryRunToFile,
   type AnswerFirstEnrichmentWorkerDryRunInput,
 } from "./run-content-kitchen-enrichment-worker-dry-run";
+import {
+  REVIEW_DECISION_RUNNER_RESULT_VERSION,
+  runCli as runContentKitchenReviewDecisionCli,
+  runContentKitchenReviewDecisionFromFiles,
+} from "./run-content-kitchen-review-decision";
 import type {
   ContentKitchenDictionaries,
   ContentKitchenIssueCode,
@@ -3146,6 +3151,17 @@ async function assertReviewRoutingDecisionDoc() {
     "model decisions cannot override issues",
     "model decisions below confidence threshold must escalate to human",
     "override of an absent issue code fails",
+    "review-decision-auto-approve.*.example.json",
+    "review-decision-auto-reject.*.example.json",
+    "review-decision-model-review.*.example.json",
+    "review-decision-low-confidence-human.*.example.json",
+    "review-decision-human-override.*.example.json",
+    "npm run content-kitchen:review-decision",
+    "--artifact lib/puzzles/content-kitchen/examples/review-decision-model-review.artifact.example.json",
+    "--decision lib/puzzles/content-kitchen/examples/review-decision-model-review.decision.example.json",
+    "--output /tmp/content-kitchen-review-decision-result.json",
+    "`--output` must not equal `--artifact`",
+    "`--output` must not equal `--decision`",
     "does not build Review UI",
     "does not call a model",
     "does not send Feishu messages",
@@ -3158,6 +3174,155 @@ async function assertReviewRoutingDecisionDoc() {
   for (const snippet of requiredSnippets) {
     assert.ok(doc.includes(snippet), `PR10 review routing decision doc should include: ${snippet}`);
   }
+}
+
+async function assertReviewDecisionExamplesAndRunner() {
+  const pairs = [
+    ["review-decision-auto-approve", "auto_approve"],
+    ["review-decision-auto-reject", "auto_reject"],
+    ["review-decision-model-review", "model_review"],
+    ["review-decision-low-confidence-human", "human_review"],
+    ["review-decision-human-override", "human_review"],
+  ] as const;
+
+  const packageJson = JSON.parse(await readFile(PACKAGE_JSON_PATH, "utf8")) as {
+    scripts?: Record<string, string>;
+  };
+  assert.ok(
+    packageJson.scripts?.["content-kitchen:review-decision"]?.includes(
+      "run-content-kitchen-review-decision.ts",
+    ),
+    "package.json should expose the content-kitchen review decision runner",
+  );
+
+  for (const [baseName, expectedRoute] of pairs) {
+    const artifactPath = resolve(EXAMPLE_DIR, `${baseName}.artifact.example.json`);
+    const decisionPath = resolve(EXAMPLE_DIR, `${baseName}.decision.example.json`);
+    const result = await runContentKitchenReviewDecisionFromFiles({
+      artifactPath,
+      decisionPath,
+    });
+
+    assert.equal(
+      result.schemaVersion,
+      REVIEW_DECISION_RUNNER_RESULT_VERSION,
+      `${baseName}: review decision runner result schema should be stable`,
+    );
+    assert.equal(result.dryRunOnly, true, `${baseName}: review decision runner should stay dry-run only`);
+    assert.equal(result.sourceArtifactPath, artifactPath, `${baseName}: runner should record artifact path`);
+    assert.equal(result.sourceDecisionPath, decisionPath, `${baseName}: runner should record decision path`);
+    assert.equal(result.route.route, expectedRoute, `${baseName}: route should match expected route`);
+    assert.equal(
+      result.decisionValidation?.valid,
+      true,
+      `${baseName}: example decision should validate`,
+    );
+  }
+
+  const tmpDir = await mkdtemp(resolve(tmpdir(), "content-kitchen-review-decision-"));
+  try {
+    const artifactPath = resolve(EXAMPLE_DIR, "review-decision-model-review.artifact.example.json");
+    const decisionPath = resolve(EXAMPLE_DIR, "review-decision-model-review.decision.example.json");
+    const outputPath = resolve(tmpDir, "review-decision-result.json");
+    const outputResult = await runContentKitchenReviewDecisionFromFiles({
+      artifactPath,
+      decisionPath,
+      outputPath,
+    });
+    const writtenOutput = JSON.parse(await readFile(outputPath, "utf8")) as {
+      schemaVersion: string;
+      dryRunOnly: boolean;
+      outputPath: string;
+      route: { route: string };
+      decisionValidation: { valid: boolean };
+    };
+
+    assert.equal(outputResult.outputPath, outputPath, "review decision runner should report output path");
+    assert.equal(
+      writtenOutput.schemaVersion,
+      REVIEW_DECISION_RUNNER_RESULT_VERSION,
+      "review decision runner output file should use the stable schema",
+    );
+    assert.equal(writtenOutput.dryRunOnly, true, "review decision runner output file should stay dry-run only");
+    assert.equal(writtenOutput.outputPath, outputPath, "review decision runner output file should record its path");
+    assert.equal(writtenOutput.route.route, "model_review", "review decision runner output should include the route");
+    assert.equal(
+      writtenOutput.decisionValidation.valid,
+      true,
+      "review decision runner output should include decision validation",
+    );
+
+    await assert.rejects(
+      () => runContentKitchenReviewDecisionCli(["--artifact", artifactPath, "--output", artifactPath]),
+      /--output must be different from --artifact/,
+      "review decision CLI should reject output paths that would overwrite the artifact",
+    );
+    await assert.rejects(
+      () => runContentKitchenReviewDecisionCli([
+        "--artifact",
+        artifactPath,
+        "--decision",
+        decisionPath,
+        "--output",
+        decisionPath,
+      ]),
+      /--output must be different from --decision/,
+      "review decision CLI should reject output paths that would overwrite the decision",
+    );
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+
+  const artifact = JSON.parse(
+    await readFile(resolve(EXAMPLE_DIR, "review-decision-model-review.artifact.example.json"), "utf8"),
+  ) as ReviewArtifactV0;
+  const decision = JSON.parse(
+    await readFile(resolve(EXAMPLE_DIR, "review-decision-model-review.decision.example.json"), "utf8"),
+  ) as ReviewDecisionV0;
+  const revisionMismatch = validateReviewDecision({
+    artifact,
+    decision: {
+      ...decision,
+      candidateRevisionId: "rev-other",
+    },
+  });
+  assert.equal(revisionMismatch.valid, false, "example revision mismatch should fail validation");
+  assert.ok(
+    revisionMismatch.errors.includes("candidateRevisionId must match the review artifact"),
+    "example revision mismatch should include a clear error",
+  );
+
+  const modelOverride = validateReviewDecision({
+    artifact,
+    decision: {
+      ...decision,
+      action: "override_issue",
+    },
+  });
+  assert.equal(modelOverride.valid, false, "example model override should fail validation");
+  assert.ok(
+    modelOverride.errors.some((error) => error.includes("cannot override")),
+    "example model override should include a clear error",
+  );
+
+  const overrideArtifact = JSON.parse(
+    await readFile(resolve(EXAMPLE_DIR, "review-decision-human-override.artifact.example.json"), "utf8"),
+  ) as ReviewArtifactV0;
+  const overrideDecision = JSON.parse(
+    await readFile(resolve(EXAMPLE_DIR, "review-decision-human-override.decision.example.json"), "utf8"),
+  ) as ReviewDecisionV0;
+  const absentIssueOverride = validateReviewDecision({
+    artifact: overrideArtifact,
+    decision: {
+      ...overrideDecision,
+      issueCodes: ["WEAK_FIT_EVIDENCE"],
+    },
+  });
+  assert.equal(absentIssueOverride.valid, false, "example override for absent issue code should fail validation");
+  assert.ok(
+    absentIssueOverride.errors.some((error) => error.includes("not in the review artifact")),
+    "example override for absent issue code should include a clear error",
+  );
 }
 
 async function main() {
@@ -3208,6 +3373,7 @@ async function main() {
   await assertAnswerFirstEnrichmentWorkerHealthStatuses();
   await assertAnswerFirstEnrichmentDryRunUsageDoc();
   await assertReviewRoutingDecisionDoc();
+  await assertReviewDecisionExamplesAndRunner();
   console.log(`content-kitchen contract fixtures passed (${fileNames.length} fixtures)`);
 }
 

--- a/scripts/run-content-kitchen-review-decision.ts
+++ b/scripts/run-content-kitchen-review-decision.ts
@@ -1,0 +1,179 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import {
+  deriveReviewRoute,
+  validateReviewDecision,
+} from "../lib/puzzles/content-kitchen/review-decision";
+import type {
+  ReviewArtifactV0,
+  ReviewDecisionV0,
+  ReviewDecisionValidationResult,
+  ReviewRouteResult,
+} from "../lib/puzzles/content-kitchen/types";
+
+export const REVIEW_DECISION_RUNNER_RESULT_VERSION =
+  "content-kitchen-review-decision-runner-result-v0";
+
+export type ContentKitchenReviewDecisionRunnerResult = {
+  schemaVersion: typeof REVIEW_DECISION_RUNNER_RESULT_VERSION;
+  dryRunOnly: true;
+  sourceArtifactPath: string;
+  sourceDecisionPath?: string;
+  outputPath?: string;
+  route: ReviewRouteResult;
+  decision?: ReviewDecisionV0;
+  decisionValidation?: ReviewDecisionValidationResult;
+};
+
+type ParsedArgs = {
+  artifactPath: string;
+  decisionPath?: string;
+  outputPath?: string;
+  modelConfidence?: number;
+  pretty: boolean;
+};
+
+function readArgValue(argv: string[], index: number, name: string): string {
+  const value = argv[index + 1];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${name} requires a value`);
+  }
+
+  return value;
+}
+
+function parseNumberArg(value: string, name: string): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) {
+    throw new Error(`${name} must be a number between 0 and 1`);
+  }
+
+  return parsed;
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
+  let artifactPath = "";
+  let decisionPath: string | undefined;
+  let outputPath: string | undefined;
+  let modelConfidence: number | undefined;
+  let pretty = true;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--artifact") {
+      artifactPath = resolve(readArgValue(argv, index, "--artifact"));
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--decision") {
+      decisionPath = resolve(readArgValue(argv, index, "--decision"));
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--output") {
+      outputPath = resolve(readArgValue(argv, index, "--output"));
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--model-confidence") {
+      modelConfidence = parseNumberArg(readArgValue(argv, index, "--model-confidence"), "--model-confidence");
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--compact") {
+      pretty = false;
+      continue;
+    }
+
+    if (arg === "--pretty") {
+      pretty = true;
+      continue;
+    }
+
+    if (arg === "--help" || arg === "-h") {
+      throw new Error(
+        "Usage: npm run content-kitchen:review-decision -- --artifact <path> [--decision <path>] [--output <path>] [--model-confidence <0..1>] [--pretty|--compact]",
+      );
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  if (!artifactPath) {
+    throw new Error("Missing required --artifact <path>");
+  }
+  if (outputPath === artifactPath) {
+    throw new Error("--output must be different from --artifact");
+  }
+  if (outputPath && decisionPath === outputPath) {
+    throw new Error("--output must be different from --decision");
+  }
+
+  return {
+    artifactPath,
+    decisionPath,
+    outputPath,
+    modelConfidence,
+    pretty,
+  };
+}
+
+async function readJsonFile<T>(path: string): Promise<T> {
+  return JSON.parse(await readFile(path, "utf8")) as T;
+}
+
+export async function runContentKitchenReviewDecisionFromFiles(input: {
+  artifactPath: string;
+  decisionPath?: string;
+  outputPath?: string;
+  modelConfidence?: number;
+}): Promise<ContentKitchenReviewDecisionRunnerResult> {
+  const artifactPath = resolve(input.artifactPath);
+  const decisionPath = input.decisionPath ? resolve(input.decisionPath) : undefined;
+  const outputPath = input.outputPath ? resolve(input.outputPath) : undefined;
+  const artifact = await readJsonFile<ReviewArtifactV0>(artifactPath);
+  const decision = decisionPath ? await readJsonFile<ReviewDecisionV0>(decisionPath) : undefined;
+  const routeModelConfidence =
+    input.modelConfidence ?? (decision?.reviewerType === "model" ? decision.confidence : undefined);
+  const route = deriveReviewRoute(artifact, {
+    modelConfidence: routeModelConfidence,
+  });
+  const decisionValidation = decision
+    ? validateReviewDecision({ artifact, decision })
+    : undefined;
+  const result: ContentKitchenReviewDecisionRunnerResult = {
+    schemaVersion: REVIEW_DECISION_RUNNER_RESULT_VERSION,
+    dryRunOnly: true,
+    sourceArtifactPath: artifactPath,
+    ...(decisionPath ? { sourceDecisionPath: decisionPath } : {}),
+    ...(outputPath ? { outputPath } : {}),
+    route,
+    ...(decision ? { decision } : {}),
+    ...(decisionValidation ? { decisionValidation } : {}),
+  };
+
+  if (outputPath) {
+    await mkdir(dirname(outputPath), { recursive: true });
+    await writeFile(outputPath, `${JSON.stringify(result, null, 2)}\n`, "utf8");
+  }
+
+  return result;
+}
+
+export async function runCli(argv: string[] = process.argv.slice(2)): Promise<void> {
+  const args = parseArgs(argv);
+  const result = await runContentKitchenReviewDecisionFromFiles(args);
+  console.log(JSON.stringify(result, null, args.pretty ? 2 : 0));
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  runCli().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Summary
- add checked PR10 review decision artifact/decision examples for auto approve, auto reject, model review, low-confidence human escalation, and human override
- add a local content-kitchen review decision runner with optional output file support
- cover runner output, unsafe output paths, valid examples, revision mismatch, model override, and absent issue override in the contract test
- document the local-only runner usage and update the PR10 plan slice

## Validation
- npm run test:content-kitchen
- npm run content-kitchen:review-decision -- --artifact lib/puzzles/content-kitchen/examples/review-decision-model-review.artifact.example.json --decision lib/puzzles/content-kitchen/examples/review-decision-model-review.decision.example.json --output /tmp/content-kitchen-review-decision-result-check.json --compact
- cat /tmp/content-kitchen-review-decision-result-check.json
- git diff --check -- package.json scripts/run-content-kitchen-review-decision.ts scripts/check-content-kitchen-contract.ts docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md docs/pinpoint-content-kitchen-pr10-review-routing-decision-2026-05-24.md lib/puzzles/content-kitchen/examples
- npm run typecheck
- npm run lint
- npm run validate:data
- npm run build