### PR TITLE
[codex] Add PR10 review decision effect plans

### DIFF
--- a/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
+++ b/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
@@ -2265,6 +2265,16 @@ PR10 second implementation slice:
 - make the contract test prove the examples validate, revision mismatch fails, model override fails, and override of an absent issue code fails
 - keep this local-only; do not build Review UI, call a model, send Feishu messages, write review queue storage, attach production storage, publish content, or run Worker cron yet
 
+PR10 third implementation slice:
+
+- add a local `ReviewDecisionEffectPlan` that turns a valid review decision into the next local consequence
+- map `approve` to `approved`, `reject` to `rejected`, `request_regeneration` to `regeneration_requested`, `force_answer_first` to `answer_first_forced`, `override_issue` to `issue_override_recorded`, and `escalate_to_human` to `human_escalation_required`
+- keep `publishAllowed: false` for every PR10 v0 effect plan; approval is not automatic publish
+- preserve override scope by listing overridden issue codes and remaining issue codes separately
+- make invalid decisions return `invalid_decision` with no downstream action allowed
+- include the effect plan in the local review decision runner output
+- keep this local-only; do not build Review UI, call a model, send Feishu messages, write review queue storage, attach production storage, publish content, or run Worker cron yet
+
 ### PR11 — Post-Publish Content Audit
 
 Goal: verify what users and crawlers see after publish.

--- a/docs/pinpoint-content-kitchen-pr10-review-routing-decision-2026-05-24.md
+++ b/docs/pinpoint-content-kitchen-pr10-review-routing-decision-2026-05-24.md
@@ -131,6 +131,9 @@ The content-kitchen contract test covers:
 - missing `artifactId` fails
 - revision mismatch fails
 - override of an absent issue code fails
+- valid decisions produce an effect plan
+- invalid decisions produce `invalid_decision`
+- `auto_approve` still does not allow automatic publish
 
 ## Example Files
 
@@ -162,6 +165,24 @@ npm run content-kitchen:review-decision -- \
   --decision lib/puzzles/content-kitchen/examples/review-decision-model-review.decision.example.json \
   --pretty
 ```
+
+The runner prints:
+
+- derived route
+- decision validation
+- effect plan
+
+The effect plan explains the local consequence of the decision:
+
+- `approved`: reviewer approved this candidate revision
+- `rejected`: candidate revision must not publish
+- `regeneration_requested`: regenerate before continuing
+- `answer_first_forced`: record answer-first fallback request
+- `issue_override_recorded`: record a human-only issue override
+- `human_escalation_required`: keep the artifact in human review
+- `invalid_decision`: do not apply any downstream action
+
+In PR10 v0, every effect plan has `publishAllowed: false`.
 
 Write the result to a local file:
 

--- a/lib/puzzles/content-kitchen/review-decision.ts
+++ b/lib/puzzles/content-kitchen/review-decision.ts
@@ -3,11 +3,13 @@ import type {
   ContentKitchenIssueCode,
   ReviewArtifactV0,
   ReviewDecisionV0,
+  ReviewDecisionEffectPlanV0,
   ReviewDecisionValidationResult,
   ReviewRouteResult,
 } from "./types";
 
 export const REVIEW_DECISION_VERSION = "content-kitchen-review-decision-v0";
+export const REVIEW_DECISION_EFFECT_PLAN_VERSION = "content-kitchen-review-decision-effect-plan-v0";
 export const MODEL_REVIEW_MIN_CONFIDENCE = 0.75;
 
 const HARD_RULE_AUTO_REJECT_ISSUES = new Set<ContentKitchenIssueCode>([
@@ -275,5 +277,142 @@ export function validateReviewDecision(input: {
     valid: errors.length === 0,
     errors,
     derivedRoute,
+  };
+}
+
+function remainingIssueCodesAfterOverride(artifact: ReviewArtifactV0, decision: ReviewDecisionV0): ContentKitchenIssueCode[] {
+  const overriddenIssueCodes = new Set(decision.issueCodes);
+  return artifact.validation.issueCodes.filter((issueCode) => !overriddenIssueCodes.has(issueCode));
+}
+
+export function buildReviewDecisionEffectPlan(input: {
+  artifact: ReviewArtifactV0;
+  decision: ReviewDecisionV0;
+  modelConfidenceThreshold?: number;
+}): ReviewDecisionEffectPlanV0 {
+  const decisionValidation = validateReviewDecision(input);
+  if (!decisionValidation.valid) {
+    return {
+      effectPlanVersion: REVIEW_DECISION_EFFECT_PLAN_VERSION,
+      valid: false,
+      effect: "invalid_decision",
+      publishAllowed: false,
+      artifactStatus: "open",
+      nextRequiredAction: "review",
+      overriddenIssueCodes: [],
+      remainingIssueCodes: [...input.artifact.validation.issueCodes],
+      notes: [
+        "Decision is invalid; no downstream action is allowed.",
+        ...decisionValidation.errors,
+      ],
+      decisionValidation,
+    };
+  }
+
+  if (input.decision.action === "approve") {
+    return {
+      effectPlanVersion: REVIEW_DECISION_EFFECT_PLAN_VERSION,
+      valid: true,
+      effect: "approved",
+      publishAllowed: false,
+      artifactStatus: "decided",
+      nextRequiredAction: "none",
+      overriddenIssueCodes: [],
+      remainingIssueCodes: [],
+      notes: [
+        "Review decision approves this candidate revision.",
+        "PR10 v0 never publishes content; downstream publish gates must still run.",
+      ],
+      decisionValidation,
+    };
+  }
+
+  if (input.decision.action === "reject") {
+    return {
+      effectPlanVersion: REVIEW_DECISION_EFFECT_PLAN_VERSION,
+      valid: true,
+      effect: "rejected",
+      publishAllowed: false,
+      artifactStatus: "decided",
+      nextRequiredAction: "block_publish",
+      overriddenIssueCodes: [],
+      remainingIssueCodes: [...input.artifact.validation.issueCodes],
+      notes: [
+        "Review decision rejects this candidate revision.",
+        "The same candidate revision must not publish without a new review decision.",
+      ],
+      decisionValidation,
+    };
+  }
+
+  if (input.decision.action === "request_regeneration") {
+    return {
+      effectPlanVersion: REVIEW_DECISION_EFFECT_PLAN_VERSION,
+      valid: true,
+      effect: "regeneration_requested",
+      publishAllowed: false,
+      artifactStatus: "decided",
+      nextRequiredAction: "enrich",
+      overriddenIssueCodes: [],
+      remainingIssueCodes: [...input.artifact.validation.issueCodes],
+      notes: [
+        "Review decision requests a regenerated candidate.",
+        "The current candidate revision remains unpublished.",
+      ],
+      decisionValidation,
+    };
+  }
+
+  if (input.decision.action === "force_answer_first") {
+    return {
+      effectPlanVersion: REVIEW_DECISION_EFFECT_PLAN_VERSION,
+      valid: true,
+      effect: "answer_first_forced",
+      publishAllowed: false,
+      artifactStatus: "decided",
+      nextRequiredAction: "degrade",
+      overriddenIssueCodes: [],
+      remainingIssueCodes: [...input.artifact.validation.issueCodes],
+      notes: [
+        "Review decision requests answer-first fallback.",
+        "PR10 v0 records the requested effect only; it does not change production rendering.",
+      ],
+      decisionValidation,
+    };
+  }
+
+  if (input.decision.action === "override_issue") {
+    const remainingIssueCodes = remainingIssueCodesAfterOverride(input.artifact, input.decision);
+    return {
+      effectPlanVersion: REVIEW_DECISION_EFFECT_PLAN_VERSION,
+      valid: true,
+      effect: "issue_override_recorded",
+      publishAllowed: false,
+      artifactStatus: remainingIssueCodes.length > 0 ? "open" : "decided",
+      nextRequiredAction: remainingIssueCodes.length > 0 ? "review" : "none",
+      overriddenIssueCodes: [...input.decision.issueCodes],
+      remainingIssueCodes,
+      notes: [
+        "Human override is scoped to the named issue codes on this artifact only.",
+        "PR10 v0 records the override; it does not publish content.",
+      ],
+      decisionValidation,
+    };
+  }
+
+  return {
+    effectPlanVersion: REVIEW_DECISION_EFFECT_PLAN_VERSION,
+    valid: true,
+    effect: "human_escalation_required",
+    publishAllowed: false,
+    artifactStatus: "open",
+    nextRequiredAction: "review",
+    overriddenIssueCodes: [],
+    remainingIssueCodes: [...input.artifact.validation.issueCodes],
+    notes: [
+      "Decision escalates this artifact to human review.",
+      "No publish, regeneration, downgrade, or override action is applied in PR10 v0.",
+    ],
+    decisionValidation,
   };
 }

--- a/lib/puzzles/content-kitchen/types.ts
+++ b/lib/puzzles/content-kitchen/types.ts
@@ -754,3 +754,29 @@ export type ReviewDecisionValidationResult = {
   errors: string[];
   derivedRoute: ReviewRouteResult;
 };
+
+export type ReviewDecisionEffect =
+  | "approved"
+  | "rejected"
+  | "regeneration_requested"
+  | "answer_first_forced"
+  | "issue_override_recorded"
+  | "human_escalation_required"
+  | "invalid_decision";
+
+export type ReviewDecisionEffectArtifactStatus =
+  | "open"
+  | "decided";
+
+export type ReviewDecisionEffectPlanV0 = {
+  effectPlanVersion: "content-kitchen-review-decision-effect-plan-v0";
+  valid: boolean;
+  effect: ReviewDecisionEffect;
+  publishAllowed: false;
+  artifactStatus: ReviewDecisionEffectArtifactStatus;
+  nextRequiredAction: RequiredAction;
+  overriddenIssueCodes: ContentKitchenIssueCode[];
+  remainingIssueCodes: ContentKitchenIssueCode[];
+  notes: string[];
+  decisionValidation: ReviewDecisionValidationResult;
+};

--- a/scripts/check-content-kitchen-contract.ts
+++ b/scripts/check-content-kitchen-contract.ts
@@ -54,7 +54,9 @@ import {
 } from "../lib/puzzles/content-kitchen/issue-registry";
 import { buildReviewArtifactV0, shouldCreateReviewArtifact } from "../lib/puzzles/content-kitchen/review-artifact";
 import {
+  REVIEW_DECISION_EFFECT_PLAN_VERSION,
   REVIEW_DECISION_VERSION,
+  buildReviewDecisionEffectPlan,
   deriveReviewRoute,
   validateReviewDecision,
 } from "../lib/puzzles/content-kitchen/review-decision";
@@ -298,6 +300,13 @@ function assertReviewRoutingAndDecisionContract() {
     true,
     "rule engine should be able to approve a low-risk artifact locally",
   );
+  const lowRiskEffectPlan = buildReviewDecisionEffectPlan({
+    artifact: lowRiskArtifact,
+    decision: makeReviewDecisionForArtifact(lowRiskArtifact),
+  });
+  assert.equal(lowRiskEffectPlan.effect, "approved", "approved decisions should produce approved effect");
+  assert.equal(lowRiskEffectPlan.publishAllowed, false, "auto_approve must not mean automatic publish");
+  assert.equal(lowRiskEffectPlan.nextRequiredAction, "none", "approved effect should not request more local action");
 
   const hardRuleArtifact = makeReviewArtifactForDecision(["CANDIDATE_L1_MISMATCH"], {
     validation: {
@@ -328,6 +337,12 @@ function assertReviewRoutingAndDecisionContract() {
     true,
     "rule engine should be able to reject obvious hard-rule failures",
   );
+  const hardRuleEffectPlan = buildReviewDecisionEffectPlan({
+    artifact: hardRuleArtifact,
+    decision: makeReviewDecisionForArtifact(hardRuleArtifact),
+  });
+  assert.equal(hardRuleEffectPlan.effect, "rejected", "reject decisions should produce rejected effect");
+  assert.equal(hardRuleEffectPlan.nextRequiredAction, "block_publish", "rejected effect should block publish");
 
   const softArtifact = makeReviewArtifactForDecision(["GENERIC_REASONING_PATTERN"]);
   const softRoute = deriveReviewRoute(softArtifact);
@@ -352,6 +367,16 @@ function assertReviewRoutingAndDecisionContract() {
     true,
     "model reviewers should be able to recommend regeneration for soft issues",
   );
+  const modelEffectPlan = buildReviewDecisionEffectPlan({
+    artifact: softArtifact,
+    decision: modelDecision,
+  });
+  assert.equal(
+    modelEffectPlan.effect,
+    "regeneration_requested",
+    "request_regeneration decisions should produce regeneration_requested effect",
+  );
+  assert.equal(modelEffectPlan.nextRequiredAction, "enrich", "regeneration effect should request enrich");
 
   const lowConfidenceRoute = deriveReviewRoute(softArtifact, { modelConfidence: 0.4 });
   assert.equal(lowConfidenceRoute.route, "human_review", "low-confidence model review should route to human_review");
@@ -370,6 +395,16 @@ function assertReviewRoutingAndDecisionContract() {
     true,
     "low-confidence model decisions should be valid only when escalated to human",
   );
+  const lowConfidenceEffectPlan = buildReviewDecisionEffectPlan({
+    artifact: softArtifact,
+    decision: lowConfidenceDecision,
+  });
+  assert.equal(
+    lowConfidenceEffectPlan.effect,
+    "human_escalation_required",
+    "escalate_to_human decisions should keep the artifact in human review",
+  );
+  assert.equal(lowConfidenceEffectPlan.artifactStatus, "open", "human escalation should keep artifact open");
 
   const modelOverride = validateReviewDecision({
     artifact: hardRuleArtifact,
@@ -439,6 +474,67 @@ function assertReviewRoutingAndDecisionContract() {
     invalidOverride.errors.some((error) => error.includes("not in the review artifact")),
     "absent override issue codes should produce a specific validation error",
   );
+
+  const invalidEffectPlan = buildReviewDecisionEffectPlan({
+    artifact: softArtifact,
+    decision: {
+      ...modelDecision,
+      candidateRevisionId: "rev-other",
+    },
+  });
+  assert.equal(invalidEffectPlan.valid, false, "invalid decisions should produce invalid effect plans");
+  assert.equal(invalidEffectPlan.effect, "invalid_decision", "invalid decisions should not produce a passing effect");
+  assert.equal(invalidEffectPlan.publishAllowed, false, "invalid effect plans must never allow publish");
+
+  const forceAnswerFirstArtifact = makeReviewArtifactForDecision(["FULL_ANALYSIS_STRUCTURE_NOT_VALIDATED"]);
+  const forceAnswerFirstEffectPlan = buildReviewDecisionEffectPlan({
+    artifact: forceAnswerFirstArtifact,
+    decision: makeReviewDecisionForArtifact(forceAnswerFirstArtifact, {
+      route: "human_review",
+      reviewerType: "human",
+      reviewerId: "human-reviewer",
+      action: "force_answer_first",
+      note: "Human requests answer-first fallback for this candidate revision.",
+    }),
+  });
+  assert.equal(
+    forceAnswerFirstEffectPlan.effect,
+    "answer_first_forced",
+    "force_answer_first decisions should produce answer_first_forced effect",
+  );
+  assert.equal(forceAnswerFirstEffectPlan.nextRequiredAction, "degrade", "force answer-first should request degrade");
+
+  const partialOverrideArtifact = makeReviewArtifactForDecision([
+    "EVIDENCE_SOURCE_CONFLICT",
+    "ANSWER_FIRST_REVIEW_REQUIRED",
+  ]);
+  const partialOverrideEffectPlan = buildReviewDecisionEffectPlan({
+    artifact: partialOverrideArtifact,
+    decision: makeReviewDecisionForArtifact(partialOverrideArtifact, {
+      route: "human_review",
+      reviewerType: "human",
+      reviewerId: "human-reviewer",
+      action: "override_issue",
+      issueCodes: ["EVIDENCE_SOURCE_CONFLICT"],
+      note: "Human override applies only to the exact evidence conflict.",
+    }),
+  });
+  assert.equal(
+    partialOverrideEffectPlan.effect,
+    "issue_override_recorded",
+    "override_issue decisions should produce issue_override_recorded effect",
+  );
+  assert.deepEqual(
+    partialOverrideEffectPlan.overriddenIssueCodes,
+    ["EVIDENCE_SOURCE_CONFLICT"],
+    "override effect should name only overridden issue codes",
+  );
+  assert.deepEqual(
+    partialOverrideEffectPlan.remainingIssueCodes,
+    ["ANSWER_FIRST_REVIEW_REQUIRED"],
+    "override effect should preserve non-overridden issue codes",
+  );
+  assert.equal(partialOverrideEffectPlan.nextRequiredAction, "review", "remaining issues should keep review action");
 }
 
 function assertPr6P0Coverage(fixtures: Fixture[]) {
@@ -3151,6 +3247,18 @@ async function assertReviewRoutingDecisionDoc() {
     "model decisions cannot override issues",
     "model decisions below confidence threshold must escalate to human",
     "override of an absent issue code fails",
+    "valid decisions produce an effect plan",
+    "invalid decisions produce `invalid_decision`",
+    "`auto_approve` still does not allow automatic publish",
+    "effect plan",
+    "`approved`: reviewer approved this candidate revision",
+    "`rejected`: candidate revision must not publish",
+    "`regeneration_requested`: regenerate before continuing",
+    "`answer_first_forced`: record answer-first fallback request",
+    "`issue_override_recorded`: record a human-only issue override",
+    "`human_escalation_required`: keep the artifact in human review",
+    "`invalid_decision`: do not apply any downstream action",
+    "`publishAllowed: false`",
     "review-decision-auto-approve.*.example.json",
     "review-decision-auto-reject.*.example.json",
     "review-decision-model-review.*.example.json",
@@ -3178,11 +3286,11 @@ async function assertReviewRoutingDecisionDoc() {
 
 async function assertReviewDecisionExamplesAndRunner() {
   const pairs = [
-    ["review-decision-auto-approve", "auto_approve"],
-    ["review-decision-auto-reject", "auto_reject"],
-    ["review-decision-model-review", "model_review"],
-    ["review-decision-low-confidence-human", "human_review"],
-    ["review-decision-human-override", "human_review"],
+    ["review-decision-auto-approve", "auto_approve", "approved"],
+    ["review-decision-auto-reject", "auto_reject", "rejected"],
+    ["review-decision-model-review", "model_review", "regeneration_requested"],
+    ["review-decision-low-confidence-human", "human_review", "human_escalation_required"],
+    ["review-decision-human-override", "human_review", "issue_override_recorded"],
   ] as const;
 
   const packageJson = JSON.parse(await readFile(PACKAGE_JSON_PATH, "utf8")) as {
@@ -3195,7 +3303,7 @@ async function assertReviewDecisionExamplesAndRunner() {
     "package.json should expose the content-kitchen review decision runner",
   );
 
-  for (const [baseName, expectedRoute] of pairs) {
+  for (const [baseName, expectedRoute, expectedEffect] of pairs) {
     const artifactPath = resolve(EXAMPLE_DIR, `${baseName}.artifact.example.json`);
     const decisionPath = resolve(EXAMPLE_DIR, `${baseName}.decision.example.json`);
     const result = await runContentKitchenReviewDecisionFromFiles({
@@ -3217,6 +3325,14 @@ async function assertReviewDecisionExamplesAndRunner() {
       true,
       `${baseName}: example decision should validate`,
     );
+    assert.equal(
+      result.effectPlan?.effectPlanVersion,
+      REVIEW_DECISION_EFFECT_PLAN_VERSION,
+      `${baseName}: effect plan version should be stable`,
+    );
+    assert.equal(result.effectPlan?.valid, true, `${baseName}: effect plan should be valid`);
+    assert.equal(result.effectPlan?.effect, expectedEffect, `${baseName}: effect plan should match decision action`);
+    assert.equal(result.effectPlan?.publishAllowed, false, `${baseName}: effect plan must not allow direct publish`);
   }
 
   const tmpDir = await mkdtemp(resolve(tmpdir(), "content-kitchen-review-decision-"));
@@ -3235,6 +3351,13 @@ async function assertReviewDecisionExamplesAndRunner() {
       outputPath: string;
       route: { route: string };
       decisionValidation: { valid: boolean };
+      effectPlan: {
+        effectPlanVersion: string;
+        valid: boolean;
+        effect: string;
+        publishAllowed: boolean;
+        nextRequiredAction: string;
+      };
     };
 
     assert.equal(outputResult.outputPath, outputPath, "review decision runner should report output path");
@@ -3250,6 +3373,27 @@ async function assertReviewDecisionExamplesAndRunner() {
       writtenOutput.decisionValidation.valid,
       true,
       "review decision runner output should include decision validation",
+    );
+    assert.equal(
+      writtenOutput.effectPlan.effectPlanVersion,
+      REVIEW_DECISION_EFFECT_PLAN_VERSION,
+      "review decision runner output should include the stable effect plan version",
+    );
+    assert.equal(writtenOutput.effectPlan.valid, true, "review decision runner output should include a valid effect plan");
+    assert.equal(
+      writtenOutput.effectPlan.effect,
+      "regeneration_requested",
+      "review decision runner output should include the decision effect",
+    );
+    assert.equal(
+      writtenOutput.effectPlan.publishAllowed,
+      false,
+      "review decision runner output should not allow direct publish",
+    );
+    assert.equal(
+      writtenOutput.effectPlan.nextRequiredAction,
+      "enrich",
+      "review decision runner output should include the next required action",
     );
 
     await assert.rejects(

--- a/scripts/run-content-kitchen-review-decision.ts
+++ b/scripts/run-content-kitchen-review-decision.ts
@@ -2,11 +2,13 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import {
+  buildReviewDecisionEffectPlan,
   deriveReviewRoute,
   validateReviewDecision,
 } from "../lib/puzzles/content-kitchen/review-decision";
 import type {
   ReviewArtifactV0,
+  ReviewDecisionEffectPlanV0,
   ReviewDecisionV0,
   ReviewDecisionValidationResult,
   ReviewRouteResult,
@@ -24,6 +26,7 @@ export type ContentKitchenReviewDecisionRunnerResult = {
   route: ReviewRouteResult;
   decision?: ReviewDecisionV0;
   decisionValidation?: ReviewDecisionValidationResult;
+  effectPlan?: ReviewDecisionEffectPlanV0;
 };
 
 type ParsedArgs = {
@@ -146,6 +149,9 @@ export async function runContentKitchenReviewDecisionFromFiles(input: {
   const decisionValidation = decision
     ? validateReviewDecision({ artifact, decision })
     : undefined;
+  const effectPlan = decision
+    ? buildReviewDecisionEffectPlan({ artifact, decision })
+    : undefined;
   const result: ContentKitchenReviewDecisionRunnerResult = {
     schemaVersion: REVIEW_DECISION_RUNNER_RESULT_VERSION,
     dryRunOnly: true,
@@ -155,6 +161,7 @@ export async function runContentKitchenReviewDecisionFromFiles(input: {
     route,
     ...(decision ? { decision } : {}),
     ...(decisionValidation ? { decisionValidation } : {}),
+    ...(effectPlan ? { effectPlan } : {}),
   };
 
   if (outputPath) {


### PR DESCRIPTION
## Summary
- add local PR10 review decision effect plan types and builder
- map valid decisions to approved, rejected, regeneration, answer-first fallback, issue override, or human escalation effects
- keep publishAllowed false for every PR10 v0 effect plan and preserve override scope with remaining issue codes
- include effectPlan in the local review decision runner output and document the behavior

## Validation
- npm run test:content-kitchen
- npm run content-kitchen:review-decision -- --artifact lib/puzzles/content-kitchen/examples/review-decision-model-review.artifact.example.json --decision lib/puzzles/content-kitchen/examples/review-decision-model-review.decision.example.json --output /tmp/content-kitchen-review-decision-effect-plan-check.json --compact
- cat /tmp/content-kitchen-review-decision-effect-plan-check.json
- git diff --check -- lib/puzzles/content-kitchen/types.ts lib/puzzles/content-kitchen/review-decision.ts scripts/run-content-kitchen-review-decision.ts scripts/check-content-kitchen-contract.ts docs/pinpoint-content-kitchen-pr10-review-routing-decision-2026-05-24.md docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
- npm run typecheck
- npm run lint
- npm run validate:data
- npm run build