### PR TITLE
[codex] Add PR10 review queue draft envelope

### DIFF
--- a/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
+++ b/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
@@ -2275,6 +2275,18 @@ PR10 third implementation slice:
 - include the effect plan in the local review decision runner output
 - keep this local-only; do not build Review UI, call a model, send Feishu messages, write review queue storage, attach production storage, publish content, or run Worker cron yet
 
+PR10 fourth implementation slice:
+
+- add a local `ReviewQueueDraft` envelope for artifacts that still need model or human review
+- include `artifactId`, `puzzleId`, `candidateRevisionId`, route, route reason, priority, issue codes, recommended action, public URL when available, and human-readable lines
+- mark every draft as `draftOnly: true`, `persistenceStatus: "not_persisted"`, `queueName: "content-kitchen-review"`, and `publishAllowed: false`
+- create drafts for route-only `model_review` and `human_review`, model decisions that escalate to human, and partial human overrides with remaining issue codes
+- do not create drafts for `auto_approve`, `auto_reject`, or fully decided effects that no longer need review
+- make `ANSWER_FIRST_HIGH_PRIORITY_ALERT` create a `high_priority` review queue draft
+- prove queue drafts do not include raw rendered HTML, model prompts, secrets, or production storage ids
+- include the review queue draft in the local review decision runner output only when one exists
+- keep this local-only; do not build Review UI, call a model, send Feishu messages, write review queue storage, attach production storage, publish content, or run Worker cron yet
+
 ### PR11 — Post-Publish Content Audit
 
 Goal: verify what users and crawlers see after publish.

--- a/docs/pinpoint-content-kitchen-pr10-review-routing-decision-2026-05-24.md
+++ b/docs/pinpoint-content-kitchen-pr10-review-routing-decision-2026-05-24.md
@@ -1,6 +1,6 @@
 # PR10 Review Routing And Decision Contract
 
-This is the local contract note for PR10.1.
+This is the local contract note for PR10.1 through PR10.4.
 
 It defines how a review artifact is routed and how a final review decision is recorded.
 
@@ -171,6 +171,7 @@ The runner prints:
 - derived route
 - decision validation
 - effect plan
+- review queue draft when review remains open
 
 The effect plan explains the local consequence of the decision:
 
@@ -183,6 +184,51 @@ The effect plan explains the local consequence of the decision:
 - `invalid_decision`: do not apply any downstream action
 
 In PR10 v0, every effect plan has `publishAllowed: false`.
+
+## Review Queue Draft
+
+PR10.4 adds a local review queue draft envelope.
+
+It uses `queueDraftVersion: "content-kitchen-review-queue-draft-v0"`.
+
+It exists only when an artifact still needs model or human review.
+
+Examples:
+
+- route-only `model_review` artifacts create a model-review queue draft
+- route-only `human_review` artifacts create a human-review queue draft
+- model decisions with `human_escalation_required` create a human queue draft
+- partial human overrides create a queue draft for remaining issue codes
+- `auto_approve`, `auto_reject`, and fully decided effects do not create a queue draft
+
+Required fields:
+
+- `draftOnly: true`
+- `persistenceStatus: "not_persisted"`
+- `queueName: "content-kitchen-review"`
+- `artifactId`
+- `puzzleId`
+- `candidateRevisionId`
+- `route`
+- `routeReason`
+- `priority`
+- `reason`
+- `issueCodes`
+- `recommendedAction`
+- `publishAllowed: false`
+- `createdAt`
+- `lines`
+
+Priority rules:
+
+- `ANSWER_FIRST_HIGH_PRIORITY_ALERT` creates `high_priority`
+- all other PR10.4 review queue drafts use `normal`
+
+The queue draft may include `publicUrl` from the artifact canonical URL and `renderedPreviewUrl` from the artifact preview URL.
+
+It must not include raw rendered HTML, model prompts, secrets, or production storage ids.
+
+The local runner includes `reviewQueueDraft` only when the draft exists.
 
 Write the result to a local file:
 

--- a/lib/puzzles/content-kitchen/review-decision.ts
+++ b/lib/puzzles/content-kitchen/review-decision.ts
@@ -5,11 +5,14 @@ import type {
   ReviewDecisionV0,
   ReviewDecisionEffectPlanV0,
   ReviewDecisionValidationResult,
+  ReviewQueueDraftReason,
+  ReviewQueueDraftV0,
   ReviewRouteResult,
 } from "./types";
 
 export const REVIEW_DECISION_VERSION = "content-kitchen-review-decision-v0";
 export const REVIEW_DECISION_EFFECT_PLAN_VERSION = "content-kitchen-review-decision-effect-plan-v0";
+export const REVIEW_QUEUE_DRAFT_VERSION = "content-kitchen-review-queue-draft-v0";
 export const MODEL_REVIEW_MIN_CONFIDENCE = 0.75;
 
 const HARD_RULE_AUTO_REJECT_ISSUES = new Set<ContentKitchenIssueCode>([
@@ -283,6 +286,127 @@ export function validateReviewDecision(input: {
 function remainingIssueCodesAfterOverride(artifact: ReviewArtifactV0, decision: ReviewDecisionV0): ContentKitchenIssueCode[] {
   const overriddenIssueCodes = new Set(decision.issueCodes);
   return artifact.validation.issueCodes.filter((issueCode) => !overriddenIssueCodes.has(issueCode));
+}
+
+function safeQueueIdPart(value: string | undefined): string {
+  const normalized = value?.trim().replace(/[^a-zA-Z0-9_-]+/g, "-").replace(/^-+|-+$/g, "");
+  return normalized && normalized.length > 0 ? normalized : "unknown";
+}
+
+function reviewQueuePriority(issueCodes: ContentKitchenIssueCode[]): ReviewQueueDraftV0["priority"] {
+  return issueCodes.includes("ANSWER_FIRST_HIGH_PRIORITY_ALERT") ? "high_priority" : "normal";
+}
+
+function reviewQueueReason(input: {
+  route: ReviewRouteResult;
+  effectPlan?: ReviewDecisionEffectPlanV0;
+}): ReviewQueueDraftReason | null {
+  if (input.effectPlan) {
+    if (input.effectPlan.effect === "human_escalation_required") {
+      return "decision_escalated_to_human";
+    }
+
+    if (
+      input.effectPlan.valid &&
+      input.effectPlan.artifactStatus === "open" &&
+      input.effectPlan.remainingIssueCodes.length > 0
+    ) {
+      return "remaining_issue_review_required";
+    }
+
+    return null;
+  }
+
+  if (input.route.route === "model_review") {
+    return "model_review_required";
+  }
+
+  if (input.route.route === "human_review") {
+    return "human_review_required";
+  }
+
+  return null;
+}
+
+function reviewQueueRecommendedAction(input: {
+  artifact: ReviewArtifactV0;
+  effectPlan?: ReviewDecisionEffectPlanV0;
+}): ReviewQueueDraftV0["recommendedAction"] {
+  if (!input.effectPlan) {
+    return input.artifact.recommendedAction;
+  }
+
+  if (input.effectPlan.nextRequiredAction === "none") {
+    return input.artifact.recommendedAction;
+  }
+
+  return input.effectPlan.nextRequiredAction;
+}
+
+export function buildReviewQueueDraft(input: {
+  artifact: ReviewArtifactV0;
+  route?: ReviewRouteResult;
+  effectPlan?: ReviewDecisionEffectPlanV0;
+  createdAt?: string;
+}): ReviewQueueDraftV0 | null {
+  const route = input.route ?? input.effectPlan?.decisionValidation.derivedRoute ?? deriveReviewRoute(input.artifact);
+  const reason = reviewQueueReason({ route, effectPlan: input.effectPlan });
+
+  if (!reason) {
+    return null;
+  }
+
+  const issueCodes =
+    input.effectPlan && input.effectPlan.remainingIssueCodes.length > 0
+      ? input.effectPlan.remainingIssueCodes
+      : route.issueCodes;
+  const createdAt = input.createdAt ?? new Date().toISOString();
+  const artifactId = input.artifact.artifactId;
+  const puzzleId = input.artifact.puzzleId ?? "unknown";
+  const candidateRevisionId = input.artifact.candidateRevisionId ?? "unknown";
+  const recommendedAction = reviewQueueRecommendedAction({
+    artifact: input.artifact,
+    effectPlan: input.effectPlan,
+  });
+
+  return {
+    queueDraftVersion: REVIEW_QUEUE_DRAFT_VERSION,
+    draftId: `review-queue:${safeQueueIdPart(artifactId)}:${safeQueueIdPart(candidateRevisionId)}:${route.route}`,
+    draftOnly: true,
+    persistenceStatus: "not_persisted",
+    queueName: "content-kitchen-review",
+    artifactId,
+    puzzleId,
+    candidateRevisionId,
+    route: route.route,
+    routeReason: route.reason,
+    priority: reviewQueuePriority(issueCodes),
+    reason,
+    issueCodes: [...issueCodes],
+    recommendedAction,
+    ...(input.effectPlan
+      ? {
+        effect: input.effectPlan.effect,
+        effectPlanVersion: input.effectPlan.effectPlanVersion,
+        effectPlanValid: input.effectPlan.valid,
+      }
+      : {}),
+    publishAllowed: false,
+    ...(input.artifact.canonicalUrl ? { publicUrl: input.artifact.canonicalUrl } : {}),
+    ...(input.artifact.renderedPreviewUrl ? { renderedPreviewUrl: input.artifact.renderedPreviewUrl } : {}),
+    createdAt,
+    lines: [
+      `Artifact: ${artifactId}`,
+      `Puzzle: ${puzzleId}`,
+      `Revision: ${candidateRevisionId}`,
+      `Route: ${route.route} (${route.reason})`,
+      `Priority: ${reviewQueuePriority(issueCodes)}`,
+      `Issue codes: ${issueCodes.length > 0 ? issueCodes.join(", ") : "none"}`,
+      `Recommended action: ${recommendedAction}`,
+      "Draft only: not written to review queue storage.",
+      "Publish allowed: false.",
+    ],
+  };
 }
 
 export function buildReviewDecisionEffectPlan(input: {

--- a/lib/puzzles/content-kitchen/types.ts
+++ b/lib/puzzles/content-kitchen/types.ts
@@ -780,3 +780,38 @@ export type ReviewDecisionEffectPlanV0 = {
   notes: string[];
   decisionValidation: ReviewDecisionValidationResult;
 };
+
+export type ReviewQueueDraftPriority =
+  | "normal"
+  | "high_priority";
+
+export type ReviewQueueDraftReason =
+  | "model_review_required"
+  | "human_review_required"
+  | "decision_escalated_to_human"
+  | "remaining_issue_review_required";
+
+export type ReviewQueueDraftV0 = {
+  queueDraftVersion: "content-kitchen-review-queue-draft-v0";
+  draftId: string;
+  draftOnly: true;
+  persistenceStatus: "not_persisted";
+  queueName: "content-kitchen-review";
+  artifactId: string;
+  puzzleId: string;
+  candidateRevisionId: string;
+  route: ReviewRoute;
+  routeReason: string;
+  priority: ReviewQueueDraftPriority;
+  reason: ReviewQueueDraftReason;
+  issueCodes: ContentKitchenIssueCode[];
+  recommendedAction: RequiredAction;
+  effect?: ReviewDecisionEffect;
+  effectPlanVersion?: "content-kitchen-review-decision-effect-plan-v0";
+  effectPlanValid?: boolean;
+  publishAllowed: false;
+  publicUrl?: string;
+  renderedPreviewUrl?: string;
+  createdAt: string;
+  lines: string[];
+};

--- a/scripts/check-content-kitchen-contract.ts
+++ b/scripts/check-content-kitchen-contract.ts
@@ -55,7 +55,9 @@ import {
 import { buildReviewArtifactV0, shouldCreateReviewArtifact } from "../lib/puzzles/content-kitchen/review-artifact";
 import {
   REVIEW_DECISION_EFFECT_PLAN_VERSION,
+  REVIEW_QUEUE_DRAFT_VERSION,
   REVIEW_DECISION_VERSION,
+  buildReviewQueueDraft,
   buildReviewDecisionEffectPlan,
   deriveReviewRoute,
   validateReviewDecision,
@@ -307,6 +309,16 @@ function assertReviewRoutingAndDecisionContract() {
   assert.equal(lowRiskEffectPlan.effect, "approved", "approved decisions should produce approved effect");
   assert.equal(lowRiskEffectPlan.publishAllowed, false, "auto_approve must not mean automatic publish");
   assert.equal(lowRiskEffectPlan.nextRequiredAction, "none", "approved effect should not request more local action");
+  assert.equal(
+    buildReviewQueueDraft({
+      artifact: lowRiskArtifact,
+      route: lowRiskRoute,
+      effectPlan: lowRiskEffectPlan,
+      createdAt: "2026-05-24T00:02:00.000Z",
+    }),
+    null,
+    "auto_approve decisions should not create a review queue draft",
+  );
 
   const hardRuleArtifact = makeReviewArtifactForDecision(["CANDIDATE_L1_MISMATCH"], {
     validation: {
@@ -405,6 +417,28 @@ function assertReviewRoutingAndDecisionContract() {
     "escalate_to_human decisions should keep the artifact in human review",
   );
   assert.equal(lowConfidenceEffectPlan.artifactStatus, "open", "human escalation should keep artifact open");
+  const lowConfidenceQueueDraft = buildReviewQueueDraft({
+    artifact: softArtifact,
+    route: lowConfidenceRoute,
+    effectPlan: lowConfidenceEffectPlan,
+    createdAt: "2026-05-24T00:02:00.000Z",
+  });
+  assert.ok(lowConfidenceQueueDraft, "human_review escalation should create a review queue draft");
+  assert.equal(
+    lowConfidenceQueueDraft.queueDraftVersion,
+    REVIEW_QUEUE_DRAFT_VERSION,
+    "review queue draft version should be stable",
+  );
+  assert.equal(lowConfidenceQueueDraft.draftOnly, true, "review queue draft should stay draft-only");
+  assert.equal(
+    lowConfidenceQueueDraft.persistenceStatus,
+    "not_persisted",
+    "review queue draft should not pretend it was written to storage",
+  );
+  assert.equal(lowConfidenceQueueDraft.queueName, "content-kitchen-review", "review queue draft should name the queue");
+  assert.equal(lowConfidenceQueueDraft.reason, "decision_escalated_to_human", "model escalation should explain why it is queued");
+  assert.equal(lowConfidenceQueueDraft.effect, "human_escalation_required", "queue draft should carry the effect");
+  assert.equal(lowConfidenceQueueDraft.publishAllowed, false, "queue draft must not allow direct publish");
 
   const modelOverride = validateReviewDecision({
     artifact: hardRuleArtifact,
@@ -503,6 +537,23 @@ function assertReviewRoutingAndDecisionContract() {
     "force_answer_first decisions should produce answer_first_forced effect",
   );
   assert.equal(forceAnswerFirstEffectPlan.nextRequiredAction, "degrade", "force answer-first should request degrade");
+  const humanReviewQueueDraft = buildReviewQueueDraft({
+    artifact: forceAnswerFirstArtifact,
+    route: deriveReviewRoute(forceAnswerFirstArtifact),
+    createdAt: "2026-05-24T00:02:00.000Z",
+  });
+  assert.ok(humanReviewQueueDraft, "human_review artifacts should create a local review queue draft before decision");
+  assert.equal(humanReviewQueueDraft.reason, "human_review_required", "human review queue draft should explain the route");
+  assert.equal(humanReviewQueueDraft.priority, "normal", "normal human review issues should create normal priority drafts");
+  assert.equal(
+    humanReviewQueueDraft.publicUrl,
+    forceAnswerFirstArtifact.canonicalUrl,
+    "review queue draft should carry the public canonical URL when available",
+  );
+  assert.ok(
+    !JSON.stringify(humanReviewQueueDraft).includes("<main"),
+    "review queue draft should not include raw rendered HTML",
+  );
 
   const partialOverrideArtifact = makeReviewArtifactForDecision([
     "EVIDENCE_SOURCE_CONFLICT",
@@ -535,6 +586,45 @@ function assertReviewRoutingAndDecisionContract() {
     "override effect should preserve non-overridden issue codes",
   );
   assert.equal(partialOverrideEffectPlan.nextRequiredAction, "review", "remaining issues should keep review action");
+  const partialOverrideQueueDraft = buildReviewQueueDraft({
+    artifact: partialOverrideArtifact,
+    effectPlan: partialOverrideEffectPlan,
+    createdAt: "2026-05-24T00:02:00.000Z",
+  });
+  assert.ok(partialOverrideQueueDraft, "partial overrides should keep a queue draft for remaining issues");
+  assert.equal(
+    partialOverrideQueueDraft.reason,
+    "remaining_issue_review_required",
+    "partial override queue draft should explain that issues remain",
+  );
+  assert.deepEqual(
+    partialOverrideQueueDraft.issueCodes,
+    ["ANSWER_FIRST_REVIEW_REQUIRED"],
+    "partial override queue draft should include only remaining issue codes",
+  );
+  assert.equal(
+    partialOverrideQueueDraft.recommendedAction,
+    "review",
+    "partial override queue draft should keep review as the next action",
+  );
+
+  const highPriorityQueueArtifact = makeReviewArtifactForDecision(["ANSWER_FIRST_HIGH_PRIORITY_ALERT"]);
+  const highPriorityQueueDraft = buildReviewQueueDraft({
+    artifact: highPriorityQueueArtifact,
+    route: deriveReviewRoute(highPriorityQueueArtifact),
+    createdAt: "2026-05-24T00:02:00.000Z",
+  });
+  assert.ok(highPriorityQueueDraft, "high-priority review issues should create a queue draft");
+  assert.equal(
+    highPriorityQueueDraft.priority,
+    "high_priority",
+    "ANSWER_FIRST_HIGH_PRIORITY_ALERT should create a high-priority review queue draft",
+  );
+  assert.equal(
+    highPriorityQueueDraft.persistenceStatus,
+    "not_persisted",
+    "high-priority queue drafts should still not write storage in PR10 v0",
+  );
 }
 
 function assertPr6P0Coverage(fixtures: Fixture[]) {
@@ -3259,6 +3349,14 @@ async function assertReviewRoutingDecisionDoc() {
     "`human_escalation_required`: keep the artifact in human review",
     "`invalid_decision`: do not apply any downstream action",
     "`publishAllowed: false`",
+    "Review Queue Draft",
+    "queueDraftVersion: \"content-kitchen-review-queue-draft-v0\"",
+    "`draftOnly: true`",
+    "`persistenceStatus: \"not_persisted\"`",
+    "`queueName: \"content-kitchen-review\"`",
+    "`ANSWER_FIRST_HIGH_PRIORITY_ALERT` creates `high_priority`",
+    "It must not include raw rendered HTML, model prompts, secrets, or production storage ids.",
+    "The local runner includes `reviewQueueDraft` only when the draft exists.",
     "review-decision-auto-approve.*.example.json",
     "review-decision-auto-reject.*.example.json",
     "review-decision-model-review.*.example.json",
@@ -3286,11 +3384,11 @@ async function assertReviewRoutingDecisionDoc() {
 
 async function assertReviewDecisionExamplesAndRunner() {
   const pairs = [
-    ["review-decision-auto-approve", "auto_approve", "approved"],
-    ["review-decision-auto-reject", "auto_reject", "rejected"],
-    ["review-decision-model-review", "model_review", "regeneration_requested"],
-    ["review-decision-low-confidence-human", "human_review", "human_escalation_required"],
-    ["review-decision-human-override", "human_review", "issue_override_recorded"],
+    ["review-decision-auto-approve", "auto_approve", "approved", false],
+    ["review-decision-auto-reject", "auto_reject", "rejected", false],
+    ["review-decision-model-review", "model_review", "regeneration_requested", false],
+    ["review-decision-low-confidence-human", "human_review", "human_escalation_required", true],
+    ["review-decision-human-override", "human_review", "issue_override_recorded", false],
   ] as const;
 
   const packageJson = JSON.parse(await readFile(PACKAGE_JSON_PATH, "utf8")) as {
@@ -3303,7 +3401,7 @@ async function assertReviewDecisionExamplesAndRunner() {
     "package.json should expose the content-kitchen review decision runner",
   );
 
-  for (const [baseName, expectedRoute, expectedEffect] of pairs) {
+  for (const [baseName, expectedRoute, expectedEffect, expectedQueueDraft] of pairs) {
     const artifactPath = resolve(EXAMPLE_DIR, `${baseName}.artifact.example.json`);
     const decisionPath = resolve(EXAMPLE_DIR, `${baseName}.decision.example.json`);
     const result = await runContentKitchenReviewDecisionFromFiles({
@@ -3333,6 +3431,29 @@ async function assertReviewDecisionExamplesAndRunner() {
     assert.equal(result.effectPlan?.valid, true, `${baseName}: effect plan should be valid`);
     assert.equal(result.effectPlan?.effect, expectedEffect, `${baseName}: effect plan should match decision action`);
     assert.equal(result.effectPlan?.publishAllowed, false, `${baseName}: effect plan must not allow direct publish`);
+    assert.equal(
+      Boolean(result.reviewQueueDraft),
+      expectedQueueDraft,
+      `${baseName}: runner should only include a review queue draft when review remains open`,
+    );
+    if (result.reviewQueueDraft) {
+      assert.equal(
+        result.reviewQueueDraft.queueDraftVersion,
+        REVIEW_QUEUE_DRAFT_VERSION,
+        `${baseName}: review queue draft version should be stable`,
+      );
+      assert.equal(result.reviewQueueDraft.draftOnly, true, `${baseName}: review queue draft should be draft-only`);
+      assert.equal(
+        result.reviewQueueDraft.persistenceStatus,
+        "not_persisted",
+        `${baseName}: review queue draft should not claim storage persistence`,
+      );
+      assert.equal(
+        result.reviewQueueDraft.publishAllowed,
+        false,
+        `${baseName}: review queue draft must not allow direct publish`,
+      );
+    }
   }
 
   const tmpDir = await mkdtemp(resolve(tmpdir(), "content-kitchen-review-decision-"));
@@ -3466,6 +3587,19 @@ async function assertReviewDecisionExamplesAndRunner() {
   assert.ok(
     absentIssueOverride.errors.some((error) => error.includes("not in the review artifact")),
     "example override for absent issue code should include a clear error",
+  );
+  const routeOnlyResult = await runContentKitchenReviewDecisionFromFiles({
+    artifactPath: resolve(EXAMPLE_DIR, "review-decision-human-override.artifact.example.json"),
+  });
+  assert.equal(
+    routeOnlyResult.reviewQueueDraft?.queueDraftVersion,
+    REVIEW_QUEUE_DRAFT_VERSION,
+    "route-only human review runner output should include a review queue draft",
+  );
+  assert.equal(
+    routeOnlyResult.reviewQueueDraft?.persistenceStatus,
+    "not_persisted",
+    "route-only review queue draft should not write storage",
   );
 }
 

--- a/scripts/run-content-kitchen-review-decision.ts
+++ b/scripts/run-content-kitchen-review-decision.ts
@@ -2,6 +2,7 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import {
+  buildReviewQueueDraft,
   buildReviewDecisionEffectPlan,
   deriveReviewRoute,
   validateReviewDecision,
@@ -11,6 +12,7 @@ import type {
   ReviewDecisionEffectPlanV0,
   ReviewDecisionV0,
   ReviewDecisionValidationResult,
+  ReviewQueueDraftV0,
   ReviewRouteResult,
 } from "../lib/puzzles/content-kitchen/types";
 
@@ -27,6 +29,7 @@ export type ContentKitchenReviewDecisionRunnerResult = {
   decision?: ReviewDecisionV0;
   decisionValidation?: ReviewDecisionValidationResult;
   effectPlan?: ReviewDecisionEffectPlanV0;
+  reviewQueueDraft?: ReviewQueueDraftV0;
 };
 
 type ParsedArgs = {
@@ -152,6 +155,11 @@ export async function runContentKitchenReviewDecisionFromFiles(input: {
   const effectPlan = decision
     ? buildReviewDecisionEffectPlan({ artifact, decision })
     : undefined;
+  const reviewQueueDraft = buildReviewQueueDraft({
+    artifact,
+    route,
+    ...(effectPlan ? { effectPlan } : {}),
+  });
   const result: ContentKitchenReviewDecisionRunnerResult = {
     schemaVersion: REVIEW_DECISION_RUNNER_RESULT_VERSION,
     dryRunOnly: true,
@@ -162,6 +170,7 @@ export async function runContentKitchenReviewDecisionFromFiles(input: {
     ...(decision ? { decision } : {}),
     ...(decisionValidation ? { decisionValidation } : {}),
     ...(effectPlan ? { effectPlan } : {}),
+    ...(reviewQueueDraft ? { reviewQueueDraft } : {}),
   };
 
   if (outputPath) {


### PR DESCRIPTION
## Summary
- add a local ReviewQueueDraft envelope for PR10 review artifacts that still need model or human review
- include the draft in the review-decision runner output only when review remains open
- document the PR10.4 slice and cover queue draft behavior in contract tests

## Validation
- npm run test:content-kitchen
- npm run typecheck
- npm run lint
- npm run content-kitchen:review-decision -- --artifact lib/puzzles/content-kitchen/examples/review-decision-human-override.artifact.example.json --compact
- npm run build

## Notes
- Local-only: no Review UI, no model call, no Feishu send, no review queue storage, no production publish.