### PR TITLE
[codex] Add PR10 Feishu notification draft

### DIFF
--- a/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
+++ b/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
@@ -2287,6 +2287,18 @@ PR10 fourth implementation slice:
 - include the review queue draft in the local review decision runner output only when one exists
 - keep this local-only; do not build Review UI, call a model, send Feishu messages, write review queue storage, attach production storage, publish content, or run Worker cron yet
 
+PR10 fifth implementation slice:
+
+- add a local Feishu-shaped `ReviewNotificationDraft` for review queue drafts
+- include `artifactId`, `puzzleId`, `candidateRevisionId`, route, priority, issue codes, issue severity, recommended action, public URL, and review URL when available
+- derive logical date from puzzle id when it has a date suffix
+- include a Feishu text payload with `msg_type: "text"` and human-readable lines
+- mark every notification draft as `draftOnly: true`, `dispatchStatus: "not_sent"`, `channel: "feishu"`, and never read webhook secrets
+- create normal notification drafts for normal review queue drafts and high-priority notification drafts for high-priority review queue drafts
+- do not create notification drafts when no review queue draft exists
+- include the notification draft in the local review decision runner output only when one exists
+- keep this local-only; do not build Review UI, call a model, send Feishu messages, read Feishu webhook secrets, write review queue storage, attach production storage, publish content, or run Worker cron yet
+
 ### PR11 — Post-Publish Content Audit
 
 Goal: verify what users and crawlers see after publish.

--- a/docs/pinpoint-content-kitchen-pr10-review-routing-decision-2026-05-24.md
+++ b/docs/pinpoint-content-kitchen-pr10-review-routing-decision-2026-05-24.md
@@ -172,6 +172,7 @@ The runner prints:
 - decision validation
 - effect plan
 - review queue draft when review remains open
+- Feishu notification draft when a review queue draft exists
 
 The effect plan explains the local consequence of the decision:
 
@@ -230,12 +231,54 @@ It must not include raw rendered HTML, model prompts, secrets, or production sto
 
 The local runner includes `reviewQueueDraft` only when the draft exists.
 
+## Review Notification Draft
+
+PR10.5 adds a local Feishu notification draft.
+
+It uses `notificationDraftVersion: "content-kitchen-review-notification-draft-v0"`.
+
+It exists only when a review queue draft exists.
+
+Required fields:
+
+- `draftOnly: true`
+- `dispatchStatus: "not_sent"`
+- `channel: "feishu"`
+- `priority`
+- `reason`
+- `artifactId`
+- `puzzleId`
+- `candidateRevisionId`
+- `issueSeverity`
+- `recommendedAction`
+- `dedupeKey`
+- `payload`
+
+Payload shape:
+
+- `msg_type: "text"`
+- `content.text` is built from the draft lines
+
+Feishu notification drafts include puzzle id, logical date, current mode, issue severity, recommended action, public URL, and review URL when available.
+
+Rules:
+
+- `normal` queue drafts create normal Feishu notification drafts
+- `high_priority` queue drafts create high-priority Feishu notification drafts
+- the draft may include `reviewUrl` when a later Review UI provides one
+- the draft never reads a webhook URL
+- the draft never sends a Feishu message
+- the draft must not include raw rendered HTML, model prompts, secrets, or production storage ids
+
+The local runner includes `reviewNotificationDraft` only when a review queue draft exists.
+
 Write the result to a local file:
 
 ```bash
 npm run content-kitchen:review-decision -- \
   --artifact lib/puzzles/content-kitchen/examples/review-decision-model-review.artifact.example.json \
   --decision lib/puzzles/content-kitchen/examples/review-decision-model-review.decision.example.json \
+  --review-url https://example.com/admin/content-kitchen/review/art_review_human_override_example \
   --output /tmp/content-kitchen-review-decision-result.json \
   --pretty
 ```
@@ -245,6 +288,7 @@ Route without a decision file:
 ```bash
 npm run content-kitchen:review-decision -- \
   --artifact lib/puzzles/content-kitchen/examples/review-decision-human-override.artifact.example.json \
+  --review-url https://example.com/admin/content-kitchen/review/art_review_human_override_example \
   --pretty
 ```
 
@@ -255,6 +299,7 @@ Rules:
 - the runner is for local inspection only
 - the runner does not call a model
 - the runner does not send Feishu messages
+- the runner does not read Feishu webhook secrets
 - the runner does not write review queue storage
 - the runner does not touch production storage
 - the runner does not publish content

--- a/lib/puzzles/content-kitchen/review-decision.ts
+++ b/lib/puzzles/content-kitchen/review-decision.ts
@@ -5,6 +5,7 @@ import type {
   ReviewDecisionV0,
   ReviewDecisionEffectPlanV0,
   ReviewDecisionValidationResult,
+  ReviewNotificationDraftV0,
   ReviewQueueDraftReason,
   ReviewQueueDraftV0,
   ReviewRouteResult,
@@ -13,6 +14,7 @@ import type {
 export const REVIEW_DECISION_VERSION = "content-kitchen-review-decision-v0";
 export const REVIEW_DECISION_EFFECT_PLAN_VERSION = "content-kitchen-review-decision-effect-plan-v0";
 export const REVIEW_QUEUE_DRAFT_VERSION = "content-kitchen-review-queue-draft-v0";
+export const REVIEW_NOTIFICATION_DRAFT_VERSION = "content-kitchen-review-notification-draft-v0";
 export const MODEL_REVIEW_MIN_CONFIDENCE = 0.75;
 
 const HARD_RULE_AUTO_REJECT_ISSUES = new Set<ContentKitchenIssueCode>([
@@ -297,6 +299,23 @@ function reviewQueuePriority(issueCodes: ContentKitchenIssueCode[]): ReviewQueue
   return issueCodes.includes("ANSWER_FIRST_HIGH_PRIORITY_ALERT") ? "high_priority" : "normal";
 }
 
+function maxIssueSeverity(issueCodes: ContentKitchenIssueCode[]): ReviewNotificationDraftV0["issueSeverity"] {
+  const severities = issueCodes.map((issueCode) => getIssueDefinition(issueCode).defaultSeverity);
+
+  if (severities.includes("P0")) {
+    return "P0";
+  }
+  if (severities.includes("P1")) {
+    return "P1";
+  }
+
+  return "P2";
+}
+
+function logicalDateFromPuzzleId(puzzleId: string): string | undefined {
+  return puzzleId.match(/\d{4}-\d{2}-\d{2}$/)?.[0];
+}
+
 function reviewQueueReason(input: {
   route: ReviewRouteResult;
   effectPlan?: ReviewDecisionEffectPlanV0;
@@ -406,6 +425,74 @@ export function buildReviewQueueDraft(input: {
       "Draft only: not written to review queue storage.",
       "Publish allowed: false.",
     ],
+  };
+}
+
+export function buildReviewNotificationDraft(input: {
+  artifact: ReviewArtifactV0;
+  queueDraft: ReviewQueueDraftV0;
+  reviewUrl?: string;
+  createdAt?: string;
+}): ReviewNotificationDraftV0 {
+  const createdAt = input.createdAt ?? new Date().toISOString();
+  const title =
+    input.queueDraft.priority === "high_priority"
+      ? "Content Kitchen high-priority review alert"
+      : "Content Kitchen review alert";
+  const issueSeverity = maxIssueSeverity(input.queueDraft.issueCodes);
+  const logicalDate = logicalDateFromPuzzleId(input.queueDraft.puzzleId);
+  const lines = [
+    title,
+    `Artifact: ${input.queueDraft.artifactId}`,
+    `Puzzle: ${input.queueDraft.puzzleId}`,
+    `Logical date: ${logicalDate ?? "unknown"}`,
+    `Mode: ${input.artifact.contentMode ?? "unknown"}`,
+    `Severity: ${issueSeverity}`,
+    `Route: ${input.queueDraft.route} (${input.queueDraft.routeReason})`,
+    `Priority: ${input.queueDraft.priority}`,
+    `Issue codes: ${input.queueDraft.issueCodes.length > 0 ? input.queueDraft.issueCodes.join(", ") : "none"}`,
+    `Recommended action: ${input.queueDraft.recommendedAction}`,
+    `Public URL: ${input.queueDraft.publicUrl ?? "unavailable"}`,
+    `Review URL: ${input.reviewUrl ?? "unavailable"}`,
+    "Draft only: not sent to Feishu.",
+  ];
+
+  return {
+    notificationDraftVersion: REVIEW_NOTIFICATION_DRAFT_VERSION,
+    draftId: `feishu:${safeQueueIdPart(input.queueDraft.draftId)}`,
+    draftOnly: true,
+    dispatchStatus: "not_sent",
+    channel: "feishu",
+    priority: input.queueDraft.priority,
+    reason: input.queueDraft.reason,
+    title,
+    artifactId: input.queueDraft.artifactId,
+    puzzleId: input.queueDraft.puzzleId,
+    candidateRevisionId: input.queueDraft.candidateRevisionId,
+    ...(input.artifact.contentMode ? { contentMode: input.artifact.contentMode } : {}),
+    ...(logicalDate ? { logicalDate } : {}),
+    issueSeverity,
+    route: input.queueDraft.route,
+    issueCodes: [...input.queueDraft.issueCodes],
+    recommendedAction: input.queueDraft.recommendedAction,
+    ...(input.queueDraft.publicUrl ? { publicUrl: input.queueDraft.publicUrl } : {}),
+    ...(input.reviewUrl ? { reviewUrl: input.reviewUrl } : {}),
+    dedupeKey: [
+      "content-kitchen",
+      "review-notification",
+      input.queueDraft.priority,
+      input.queueDraft.artifactId,
+      input.queueDraft.candidateRevisionId,
+      input.queueDraft.reason,
+    ].join(":"),
+    createdAt,
+    lines,
+    payload: {
+      msg_type: "text",
+      content: {
+        text: lines.join("\n"),
+      },
+    },
   };
 }
 

--- a/lib/puzzles/content-kitchen/types.ts
+++ b/lib/puzzles/content-kitchen/types.ts
@@ -815,3 +815,36 @@ export type ReviewQueueDraftV0 = {
   createdAt: string;
   lines: string[];
 };
+
+export type FeishuTextPayloadV0 = {
+  msg_type: "text";
+  content: {
+    text: string;
+  };
+};
+
+export type ReviewNotificationDraftV0 = {
+  notificationDraftVersion: "content-kitchen-review-notification-draft-v0";
+  draftId: string;
+  draftOnly: true;
+  dispatchStatus: "not_sent";
+  channel: "feishu";
+  priority: ReviewQueueDraftPriority;
+  reason: ReviewQueueDraftReason;
+  title: string;
+  artifactId: string;
+  puzzleId: string;
+  candidateRevisionId: string;
+  contentMode?: ContentMode;
+  logicalDate?: string;
+  issueSeverity: ContentKitchenIssueSeverity;
+  route: ReviewRoute;
+  issueCodes: ContentKitchenIssueCode[];
+  recommendedAction: RequiredAction;
+  publicUrl?: string;
+  reviewUrl?: string;
+  dedupeKey: string;
+  createdAt: string;
+  lines: string[];
+  payload: FeishuTextPayloadV0;
+};

--- a/scripts/check-content-kitchen-contract.ts
+++ b/scripts/check-content-kitchen-contract.ts
@@ -55,8 +55,10 @@ import {
 import { buildReviewArtifactV0, shouldCreateReviewArtifact } from "../lib/puzzles/content-kitchen/review-artifact";
 import {
   REVIEW_DECISION_EFFECT_PLAN_VERSION,
+  REVIEW_NOTIFICATION_DRAFT_VERSION,
   REVIEW_QUEUE_DRAFT_VERSION,
   REVIEW_DECISION_VERSION,
+  buildReviewNotificationDraft,
   buildReviewQueueDraft,
   buildReviewDecisionEffectPlan,
   deriveReviewRoute,
@@ -439,6 +441,46 @@ function assertReviewRoutingAndDecisionContract() {
   assert.equal(lowConfidenceQueueDraft.reason, "decision_escalated_to_human", "model escalation should explain why it is queued");
   assert.equal(lowConfidenceQueueDraft.effect, "human_escalation_required", "queue draft should carry the effect");
   assert.equal(lowConfidenceQueueDraft.publishAllowed, false, "queue draft must not allow direct publish");
+  const lowConfidenceNotificationDraft = buildReviewNotificationDraft({
+    artifact: softArtifact,
+    queueDraft: lowConfidenceQueueDraft,
+    reviewUrl: "https://example.com/admin/content-kitchen/review/art_review_decision_contract",
+    createdAt: "2026-05-24T00:03:00.000Z",
+  });
+  assert.equal(
+    lowConfidenceNotificationDraft.notificationDraftVersion,
+    REVIEW_NOTIFICATION_DRAFT_VERSION,
+    "review notification draft version should be stable",
+  );
+  assert.equal(lowConfidenceNotificationDraft.draftOnly, true, "review notification draft should stay draft-only");
+  assert.equal(
+    lowConfidenceNotificationDraft.dispatchStatus,
+    "not_sent",
+    "review notification draft should not pretend it was sent",
+  );
+  assert.equal(lowConfidenceNotificationDraft.channel, "feishu", "review notification draft should target Feishu");
+  assert.equal(lowConfidenceNotificationDraft.priority, "normal", "normal queue drafts should create normal notifications");
+  assert.equal(lowConfidenceNotificationDraft.logicalDate, "2026-05-23", "notification draft should derive the logical date");
+  assert.equal(lowConfidenceNotificationDraft.contentMode, "full-analysis", "notification draft should include current content mode");
+  assert.equal(lowConfidenceNotificationDraft.issueSeverity, "P1", "notification draft should include issue severity");
+  assert.equal(
+    lowConfidenceNotificationDraft.reviewUrl,
+    "https://example.com/admin/content-kitchen/review/art_review_decision_contract",
+    "notification draft should include review URL when available",
+  );
+  assert.equal(
+    lowConfidenceNotificationDraft.payload.msg_type,
+    "text",
+    "notification draft should create a Feishu text payload",
+  );
+  assert.ok(
+    lowConfidenceNotificationDraft.payload.content.text.includes("Draft only: not sent to Feishu."),
+    "notification payload should clearly say it was not sent",
+  );
+  assert.ok(
+    !JSON.stringify(lowConfidenceNotificationDraft).includes("<main"),
+    "review notification draft should not include raw rendered HTML",
+  );
 
   const modelOverride = validateReviewDecision({
     artifact: hardRuleArtifact,
@@ -624,6 +666,25 @@ function assertReviewRoutingAndDecisionContract() {
     highPriorityQueueDraft.persistenceStatus,
     "not_persisted",
     "high-priority queue drafts should still not write storage in PR10 v0",
+  );
+  const highPriorityNotificationDraft = buildReviewNotificationDraft({
+    artifact: highPriorityQueueArtifact,
+    queueDraft: highPriorityQueueDraft,
+    createdAt: "2026-05-24T00:03:00.000Z",
+  });
+  assert.equal(
+    highPriorityNotificationDraft.priority,
+    "high_priority",
+    "high-priority queue drafts should create high-priority Feishu notification drafts",
+  );
+  assert.equal(
+    highPriorityNotificationDraft.dispatchStatus,
+    "not_sent",
+    "high-priority notification drafts should still not send Feishu in PR10 v0",
+  );
+  assert.ok(
+    highPriorityNotificationDraft.dedupeKey.includes("review-notification:high_priority"),
+    "notification dedupe key should include notification type and priority",
   );
 }
 
@@ -3357,6 +3418,13 @@ async function assertReviewRoutingDecisionDoc() {
     "`ANSWER_FIRST_HIGH_PRIORITY_ALERT` creates `high_priority`",
     "It must not include raw rendered HTML, model prompts, secrets, or production storage ids.",
     "The local runner includes `reviewQueueDraft` only when the draft exists.",
+    "Review Notification Draft",
+    "notificationDraftVersion: \"content-kitchen-review-notification-draft-v0\"",
+    "`dispatchStatus: \"not_sent\"`",
+    "`channel: \"feishu\"`",
+    "`msg_type: \"text\"`",
+    "Feishu notification drafts include puzzle id, logical date, current mode, issue severity, recommended action, public URL, and review URL when available.",
+    "The local runner includes `reviewNotificationDraft` only when a review queue draft exists.",
     "review-decision-auto-approve.*.example.json",
     "review-decision-auto-reject.*.example.json",
     "review-decision-model-review.*.example.json",
@@ -3365,12 +3433,14 @@ async function assertReviewRoutingDecisionDoc() {
     "npm run content-kitchen:review-decision",
     "--artifact lib/puzzles/content-kitchen/examples/review-decision-model-review.artifact.example.json",
     "--decision lib/puzzles/content-kitchen/examples/review-decision-model-review.decision.example.json",
+    "--review-url https://example.com/admin/content-kitchen/review/art_review_human_override_example",
     "--output /tmp/content-kitchen-review-decision-result.json",
     "`--output` must not equal `--artifact`",
     "`--output` must not equal `--decision`",
     "does not build Review UI",
     "does not call a model",
     "does not send Feishu messages",
+    "does not read Feishu webhook secrets",
     "does not write review queue storage",
     "does not touch production storage",
     "does not publish content",
@@ -3452,6 +3522,27 @@ async function assertReviewDecisionExamplesAndRunner() {
         result.reviewQueueDraft.publishAllowed,
         false,
         `${baseName}: review queue draft must not allow direct publish`,
+      );
+      assert.equal(
+        result.reviewNotificationDraft?.notificationDraftVersion,
+        REVIEW_NOTIFICATION_DRAFT_VERSION,
+        `${baseName}: review notification draft version should be stable`,
+      );
+      assert.equal(
+        result.reviewNotificationDraft?.dispatchStatus,
+        "not_sent",
+        `${baseName}: review notification draft should not send Feishu`,
+      );
+      assert.equal(
+        result.reviewNotificationDraft?.payload.msg_type,
+        "text",
+        `${baseName}: review notification draft should include a Feishu text payload`,
+      );
+    } else {
+      assert.equal(
+        result.reviewNotificationDraft,
+        undefined,
+        `${baseName}: runner should not include a notification draft without a queue draft`,
       );
     }
   }
@@ -3590,6 +3681,7 @@ async function assertReviewDecisionExamplesAndRunner() {
   );
   const routeOnlyResult = await runContentKitchenReviewDecisionFromFiles({
     artifactPath: resolve(EXAMPLE_DIR, "review-decision-human-override.artifact.example.json"),
+    reviewUrl: "https://example.com/admin/content-kitchen/review/art_review_human_override_example",
   });
   assert.equal(
     routeOnlyResult.reviewQueueDraft?.queueDraftVersion,
@@ -3600,6 +3692,21 @@ async function assertReviewDecisionExamplesAndRunner() {
     routeOnlyResult.reviewQueueDraft?.persistenceStatus,
     "not_persisted",
     "route-only review queue draft should not write storage",
+  );
+  assert.equal(
+    routeOnlyResult.reviewNotificationDraft?.notificationDraftVersion,
+    REVIEW_NOTIFICATION_DRAFT_VERSION,
+    "route-only human review runner output should include a Feishu notification draft",
+  );
+  assert.equal(
+    routeOnlyResult.reviewNotificationDraft?.dispatchStatus,
+    "not_sent",
+    "route-only Feishu notification draft should not send",
+  );
+  assert.equal(
+    routeOnlyResult.reviewNotificationDraft?.reviewUrl,
+    "https://example.com/admin/content-kitchen/review/art_review_human_override_example",
+    "route-only notification draft should include review URL when provided",
   );
 }
 

--- a/scripts/run-content-kitchen-review-decision.ts
+++ b/scripts/run-content-kitchen-review-decision.ts
@@ -2,6 +2,7 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import {
+  buildReviewNotificationDraft,
   buildReviewQueueDraft,
   buildReviewDecisionEffectPlan,
   deriveReviewRoute,
@@ -12,6 +13,7 @@ import type {
   ReviewDecisionEffectPlanV0,
   ReviewDecisionV0,
   ReviewDecisionValidationResult,
+  ReviewNotificationDraftV0,
   ReviewQueueDraftV0,
   ReviewRouteResult,
 } from "../lib/puzzles/content-kitchen/types";
@@ -30,6 +32,7 @@ export type ContentKitchenReviewDecisionRunnerResult = {
   decisionValidation?: ReviewDecisionValidationResult;
   effectPlan?: ReviewDecisionEffectPlanV0;
   reviewQueueDraft?: ReviewQueueDraftV0;
+  reviewNotificationDraft?: ReviewNotificationDraftV0;
 };
 
 type ParsedArgs = {
@@ -37,6 +40,7 @@ type ParsedArgs = {
   decisionPath?: string;
   outputPath?: string;
   modelConfidence?: number;
+  reviewUrl?: string;
   pretty: boolean;
 };
 
@@ -63,6 +67,7 @@ function parseArgs(argv: string[]): ParsedArgs {
   let decisionPath: string | undefined;
   let outputPath: string | undefined;
   let modelConfidence: number | undefined;
+  let reviewUrl: string | undefined;
   let pretty = true;
 
   for (let index = 0; index < argv.length; index += 1) {
@@ -91,6 +96,12 @@ function parseArgs(argv: string[]): ParsedArgs {
       continue;
     }
 
+    if (arg === "--review-url") {
+      reviewUrl = readArgValue(argv, index, "--review-url");
+      index += 1;
+      continue;
+    }
+
     if (arg === "--compact") {
       pretty = false;
       continue;
@@ -103,7 +114,7 @@ function parseArgs(argv: string[]): ParsedArgs {
 
     if (arg === "--help" || arg === "-h") {
       throw new Error(
-        "Usage: npm run content-kitchen:review-decision -- --artifact <path> [--decision <path>] [--output <path>] [--model-confidence <0..1>] [--pretty|--compact]",
+        "Usage: npm run content-kitchen:review-decision -- --artifact <path> [--decision <path>] [--output <path>] [--model-confidence <0..1>] [--review-url <url>] [--pretty|--compact]",
       );
     }
 
@@ -125,6 +136,7 @@ function parseArgs(argv: string[]): ParsedArgs {
     decisionPath,
     outputPath,
     modelConfidence,
+    reviewUrl,
     pretty,
   };
 }
@@ -138,6 +150,7 @@ export async function runContentKitchenReviewDecisionFromFiles(input: {
   decisionPath?: string;
   outputPath?: string;
   modelConfidence?: number;
+  reviewUrl?: string;
 }): Promise<ContentKitchenReviewDecisionRunnerResult> {
   const artifactPath = resolve(input.artifactPath);
   const decisionPath = input.decisionPath ? resolve(input.decisionPath) : undefined;
@@ -160,6 +173,13 @@ export async function runContentKitchenReviewDecisionFromFiles(input: {
     route,
     ...(effectPlan ? { effectPlan } : {}),
   });
+  const reviewNotificationDraft = reviewQueueDraft
+    ? buildReviewNotificationDraft({
+      artifact,
+      queueDraft: reviewQueueDraft,
+      ...(input.reviewUrl ? { reviewUrl: input.reviewUrl } : {}),
+    })
+    : undefined;
   const result: ContentKitchenReviewDecisionRunnerResult = {
     schemaVersion: REVIEW_DECISION_RUNNER_RESULT_VERSION,
     dryRunOnly: true,
@@ -171,6 +191,7 @@ export async function runContentKitchenReviewDecisionFromFiles(input: {
     ...(decisionValidation ? { decisionValidation } : {}),
     ...(effectPlan ? { effectPlan } : {}),
     ...(reviewQueueDraft ? { reviewQueueDraft } : {}),
+    ...(reviewNotificationDraft ? { reviewNotificationDraft } : {}),
   };
 
   if (outputPath) {


### PR DESCRIPTION
## Summary
- add a local ReviewNotificationDraft contract for review queue drafts
- include Feishu text payload shape with dispatchStatus not_sent and no webhook access
- include notification drafts in the review-decision runner output only when a queue draft exists
- document the PR10.5 slice and cover normal/high-priority notification behavior in contract tests

## Validation
- npm run test:content-kitchen
- npm run typecheck
- npm run lint
- npm run content-kitchen:review-decision -- --artifact lib/puzzles/content-kitchen/examples/review-decision-human-override.artifact.example.json --review-url https://example.com/admin/content-kitchen/review/art_review_human_override_example --compact
- npm run build

## Notes
- Local-only: no Review UI, no model call, no Feishu send, no webhook secret read, no review queue storage, no production publish.