### PR TITLE
[codex] Add PR10 review UI input contract

### DIFF
--- a/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
+++ b/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
@@ -2299,6 +2299,16 @@ PR10 fifth implementation slice:
 - include the notification draft in the local review decision runner output only when one exists
 - keep this local-only; do not build Review UI, call a model, send Feishu messages, read Feishu webhook secrets, write review queue storage, attach production storage, publish content, or run Worker cron yet
 
+PR10 sixth implementation slice:
+
+- add a local `ReviewUiInput` contract for artifacts that still need review
+- include artifact summary, puzzle snapshot, revision ids, validation outcome, policy enums, issue groups by severity, route result, queue draft, notification draft, effect plan, evidence summary, URLs, recommended action, and allowed reviewer actions
+- make puzzle snapshot status explicit as `provided` or `missing`; do not invent answer or clue text when the snapshot is absent
+- mark every UI input as `localOnly: true`, `renderStatus: "not_rendered"`, and `safety.publishAllowed: false`
+- prove UI input does not include raw rendered HTML, model prompts, secrets, or production storage ids
+- include the UI input in the local review decision runner output only when a review queue draft exists
+- keep this local-only; do not build Review UI, call a model, send Feishu messages, read Feishu webhook secrets, write review queue storage, attach production storage, publish content, or run Worker cron yet
+
 ### PR11 — Post-Publish Content Audit
 
 Goal: verify what users and crawlers see after publish.

--- a/docs/pinpoint-content-kitchen-pr10-review-routing-decision-2026-05-24.md
+++ b/docs/pinpoint-content-kitchen-pr10-review-routing-decision-2026-05-24.md
@@ -173,6 +173,7 @@ The runner prints:
 - effect plan
 - review queue draft when review remains open
 - Feishu notification draft when a review queue draft exists
+- Review UI input when a review queue draft exists
 
 The effect plan explains the local consequence of the decision:
 
@@ -272,6 +273,49 @@ Rules:
 
 The local runner includes `reviewNotificationDraft` only when a review queue draft exists.
 
+## Review UI Input
+
+PR10.6 adds a local Review UI input contract.
+
+It uses `reviewUiInputVersion: "content-kitchen-review-ui-input-v0"`.
+
+It exists only when a review queue draft exists.
+
+It is not a real UI.
+
+Required safety fields:
+
+- `localOnly: true`
+- `renderStatus: "not_rendered"`
+- `safety.rawRenderedHtmlIncluded: false`
+- `safety.modelPromptIncluded: false`
+- `safety.secretsIncluded: false`
+- `safety.publishAllowed: false`
+
+The UI input groups together:
+
+- artifact id and artifact type
+- puzzle snapshot
+- candidate and published revision ids
+- validation outcome
+- validation policies
+- issue groups by severity
+- route result
+- review queue draft
+- notification draft when available
+- effect plan when available
+- evidence summary when available
+- public URL and rendered preview URL when available
+- review URL when available
+- recommended action
+- allowed reviewer actions
+
+Puzzle snapshot status is explicit: `provided` or `missing`.
+
+If a puzzle snapshot is missing, the UI input must not invent answer text or clue text.
+
+The local runner includes `reviewUiInput` only when a review queue draft exists.
+
 Write the result to a local file:
 
 ```bash
@@ -301,5 +345,6 @@ Rules:
 - the runner does not send Feishu messages
 - the runner does not read Feishu webhook secrets
 - the runner does not write review queue storage
+- the runner does not render Review UI
 - the runner does not touch production storage
 - the runner does not publish content

--- a/lib/puzzles/content-kitchen/review-decision.ts
+++ b/lib/puzzles/content-kitchen/review-decision.ts
@@ -8,6 +8,10 @@ import type {
   ReviewNotificationDraftV0,
   ReviewQueueDraftReason,
   ReviewQueueDraftV0,
+  ReviewUiActionButtonV0,
+  ReviewUiInputV0,
+  ReviewUiIssueGroupV0,
+  ReviewUiPuzzleSnapshotV0,
   ReviewRouteResult,
 } from "./types";
 
@@ -15,6 +19,7 @@ export const REVIEW_DECISION_VERSION = "content-kitchen-review-decision-v0";
 export const REVIEW_DECISION_EFFECT_PLAN_VERSION = "content-kitchen-review-decision-effect-plan-v0";
 export const REVIEW_QUEUE_DRAFT_VERSION = "content-kitchen-review-queue-draft-v0";
 export const REVIEW_NOTIFICATION_DRAFT_VERSION = "content-kitchen-review-notification-draft-v0";
+export const REVIEW_UI_INPUT_VERSION = "content-kitchen-review-ui-input-v0";
 export const MODEL_REVIEW_MIN_CONFIDENCE = 0.75;
 
 const HARD_RULE_AUTO_REJECT_ISSUES = new Set<ContentKitchenIssueCode>([
@@ -316,6 +321,11 @@ function logicalDateFromPuzzleId(puzzleId: string): string | undefined {
   return puzzleId.match(/\d{4}-\d{2}-\d{2}$/)?.[0];
 }
 
+function puzzleNumberFromPuzzleId(puzzleId: string): number | undefined {
+  const parsed = Number(puzzleId.match(/pinpoint-(\d+)/)?.[1]);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
 function reviewQueueReason(input: {
   route: ReviewRouteResult;
   effectPlan?: ReviewDecisionEffectPlanV0;
@@ -492,6 +502,141 @@ export function buildReviewNotificationDraft(input: {
       content: {
         text: lines.join("\n"),
       },
+    },
+  };
+}
+
+function issueGroupsForUi(artifact: ReviewArtifactV0): ReviewUiIssueGroupV0[] {
+  const severities = ["P0", "P1", "P2"] as const;
+
+  return severities.flatMap((severity) => {
+    const issues = artifact.validation.issues.filter((issue) => issue.severity === severity);
+    if (issues.length === 0) {
+      return [];
+    }
+
+    return [{
+      severity,
+      issueCodes: [...new Set(issues.map((issue) => issue.issueCode))],
+      issues,
+    }];
+  });
+}
+
+function actionButtonsForUi(artifact: ReviewArtifactV0, queueDraft: ReviewQueueDraftV0): ReviewUiActionButtonV0[] {
+  const allowed = new Set(artifact.allowedReviewerActions);
+  const isHumanReview = queueDraft.route === "human_review";
+
+  return [
+    {
+      action: "approve",
+      enabled: allowed.has("approve_candidate") || allowed.has("approve_downgrade"),
+      reason: "Allowed when the artifact permits candidate or downgrade approval.",
+    },
+    {
+      action: "reject",
+      enabled: allowed.has("reject_candidate"),
+      reason: "Allowed when the artifact permits candidate rejection.",
+    },
+    {
+      action: "request_regeneration",
+      enabled: allowed.has("request_full_analysis_fix") || queueDraft.recommendedAction === "enrich",
+      reason: "Allowed when full-analysis repair or enrichment is the next local action.",
+    },
+    {
+      action: "force_answer_first",
+      enabled: isHumanReview && artifact.contentMode === "full-analysis",
+      reason: "Only human review can request answer-first fallback for a full-analysis candidate.",
+    },
+    {
+      action: "override_issue",
+      enabled: isHumanReview && queueDraft.issueCodes.length > 0,
+      reason: "Only human review can override specific issue codes on this artifact.",
+    },
+    {
+      action: "add_human_note",
+      enabled: isHumanReview || queueDraft.route === "model_review",
+      reason: "Reviewers can add notes while an artifact remains in review.",
+    },
+  ];
+}
+
+function puzzleSnapshotForUi(input: {
+  artifact: ReviewArtifactV0;
+  puzzleSnapshot?: Omit<ReviewUiPuzzleSnapshotV0, "snapshotStatus" | "clueCount">;
+}): ReviewUiPuzzleSnapshotV0 {
+  const puzzleId = input.puzzleSnapshot?.puzzleId ?? input.artifact.puzzleId ?? "unknown";
+  const clues = input.puzzleSnapshot?.clues ?? [];
+
+  return {
+    snapshotStatus: input.puzzleSnapshot ? "provided" : "missing",
+    puzzleId,
+    ...(input.puzzleSnapshot?.puzzleNumber ?? puzzleNumberFromPuzzleId(puzzleId)
+      ? { puzzleNumber: input.puzzleSnapshot?.puzzleNumber ?? puzzleNumberFromPuzzleId(puzzleId) }
+      : {}),
+    ...(input.puzzleSnapshot?.logicalDate ?? logicalDateFromPuzzleId(puzzleId)
+      ? { logicalDate: input.puzzleSnapshot?.logicalDate ?? logicalDateFromPuzzleId(puzzleId) }
+      : {}),
+    ...(input.puzzleSnapshot?.answer ? { answer: input.puzzleSnapshot.answer } : {}),
+    clues: [...clues],
+    clueCount: clues.length,
+  };
+}
+
+export function buildReviewUiInput(input: {
+  artifact: ReviewArtifactV0;
+  queueDraft: ReviewQueueDraftV0;
+  route?: ReviewRouteResult;
+  notificationDraft?: ReviewNotificationDraftV0;
+  effectPlan?: ReviewDecisionEffectPlanV0;
+  puzzleSnapshot?: Omit<ReviewUiPuzzleSnapshotV0, "snapshotStatus" | "clueCount">;
+  reviewUrl?: string;
+  createdAt?: string;
+}): ReviewUiInputV0 {
+  const route = input.route ?? input.effectPlan?.decisionValidation.derivedRoute ?? deriveReviewRoute(input.artifact);
+  const createdAt = input.createdAt ?? new Date().toISOString();
+
+  return {
+    reviewUiInputVersion: REVIEW_UI_INPUT_VERSION,
+    inputId: `review-ui:${safeQueueIdPart(input.queueDraft.draftId)}`,
+    localOnly: true,
+    renderStatus: "not_rendered",
+    createdAt,
+    artifact: {
+      artifactId: input.artifact.artifactId,
+      artifactType: input.artifact.artifactType,
+      artifactCreatedAt: input.artifact.createdAt,
+    },
+    puzzle: puzzleSnapshotForUi({
+      artifact: input.artifact,
+      puzzleSnapshot: input.puzzleSnapshot,
+    }),
+    revisions: {
+      ...(input.artifact.contentMode ? { candidateAttemptedMode: input.artifact.contentMode } : {}),
+      ...(input.artifact.publishedRevisionId ? { publishedRevisionId: input.artifact.publishedRevisionId } : {}),
+      candidateRevisionId: input.queueDraft.candidateRevisionId,
+    },
+    validation: {
+      outcome: input.artifact.validation.outcome,
+      policies: input.artifact.validation.policies,
+      issueCodes: [...input.artifact.validation.issueCodes],
+      issueGroups: issueGroupsForUi(input.artifact),
+    },
+    route,
+    queueDraft: input.queueDraft,
+    ...(input.notificationDraft ? { notificationDraft: input.notificationDraft } : {}),
+    ...(input.effectPlan ? { effectPlan: input.effectPlan } : {}),
+    ...(input.artifact.evidenceSummary ? { evidenceSummary: input.artifact.evidenceSummary } : {}),
+    ...(input.artifact.canonicalUrl ? { publicUrl: input.artifact.canonicalUrl } : {}),
+    ...(input.artifact.renderedPreviewUrl ? { renderedPreviewUrl: input.artifact.renderedPreviewUrl } : {}),
+    ...(input.reviewUrl ? { reviewUrl: input.reviewUrl } : {}),
+    recommendedAction: input.queueDraft.recommendedAction,
+    allowedActions: actionButtonsForUi(input.artifact, input.queueDraft),
+    safety: {
+      rawRenderedHtmlIncluded: false,
+      modelPromptIncluded: false,
+      secretsIncluded: false,
+      publishAllowed: false,
     },
   };
 }

--- a/lib/puzzles/content-kitchen/types.ts
+++ b/lib/puzzles/content-kitchen/types.ts
@@ -848,3 +848,77 @@ export type ReviewNotificationDraftV0 = {
   lines: string[];
   payload: FeishuTextPayloadV0;
 };
+
+export type ReviewUiPuzzleClueSnapshotV0 = {
+  clueId?: string;
+  position: number;
+  text: string;
+};
+
+export type ReviewUiPuzzleSnapshotV0 = {
+  snapshotStatus: "provided" | "missing";
+  puzzleId: string;
+  puzzleNumber?: number;
+  logicalDate?: string;
+  answer?: string;
+  clues: ReviewUiPuzzleClueSnapshotV0[];
+  clueCount: number;
+};
+
+export type ReviewUiAction =
+  | ReviewDecisionAction
+  | "add_human_note";
+
+export type ReviewUiActionButtonV0 = {
+  action: ReviewUiAction;
+  enabled: boolean;
+  reason: string;
+};
+
+export type ReviewUiIssueGroupV0 = {
+  severity: ContentKitchenIssueSeverity;
+  issueCodes: ContentKitchenIssueCode[];
+  issues: ValidationIssue[];
+};
+
+export type ReviewUiInputV0 = {
+  reviewUiInputVersion: "content-kitchen-review-ui-input-v0";
+  inputId: string;
+  localOnly: true;
+  renderStatus: "not_rendered";
+  createdAt: string;
+  artifact: {
+    artifactId: string;
+    artifactType: ReviewArtifactType;
+    artifactCreatedAt: string;
+  };
+  puzzle: ReviewUiPuzzleSnapshotV0;
+  revisions: {
+    currentPublishedMode?: ContentMode;
+    candidateAttemptedMode?: ContentMode;
+    publishedRevisionId?: string;
+    candidateRevisionId: string;
+  };
+  validation: {
+    outcome: ValidationOutcome;
+    policies: ValidationPolicies;
+    issueCodes: ContentKitchenIssueCode[];
+    issueGroups: ReviewUiIssueGroupV0[];
+  };
+  route: ReviewRouteResult;
+  queueDraft: ReviewQueueDraftV0;
+  notificationDraft?: ReviewNotificationDraftV0;
+  effectPlan?: ReviewDecisionEffectPlanV0;
+  evidenceSummary?: ReviewArtifactEvidenceSummary;
+  publicUrl?: string;
+  renderedPreviewUrl?: string;
+  reviewUrl?: string;
+  recommendedAction: RequiredAction;
+  allowedActions: ReviewUiActionButtonV0[];
+  safety: {
+    rawRenderedHtmlIncluded: false;
+    modelPromptIncluded: false;
+    secretsIncluded: false;
+    publishAllowed: false;
+  };
+};

--- a/scripts/check-content-kitchen-contract.ts
+++ b/scripts/check-content-kitchen-contract.ts
@@ -57,9 +57,11 @@ import {
   REVIEW_DECISION_EFFECT_PLAN_VERSION,
   REVIEW_NOTIFICATION_DRAFT_VERSION,
   REVIEW_QUEUE_DRAFT_VERSION,
+  REVIEW_UI_INPUT_VERSION,
   REVIEW_DECISION_VERSION,
   buildReviewNotificationDraft,
   buildReviewQueueDraft,
+  buildReviewUiInput,
   buildReviewDecisionEffectPlan,
   deriveReviewRoute,
   validateReviewDecision,
@@ -481,6 +483,57 @@ function assertReviewRoutingAndDecisionContract() {
     !JSON.stringify(lowConfidenceNotificationDraft).includes("<main"),
     "review notification draft should not include raw rendered HTML",
   );
+  const lowConfidenceReviewUiInput = buildReviewUiInput({
+    artifact: softArtifact,
+    queueDraft: lowConfidenceQueueDraft,
+    route: lowConfidenceRoute,
+    notificationDraft: lowConfidenceNotificationDraft,
+    effectPlan: lowConfidenceEffectPlan,
+    reviewUrl: "https://example.com/admin/content-kitchen/review/art_review_decision_contract",
+    puzzleSnapshot: {
+      puzzleId: "pinpoint-916-2026-05-23",
+      puzzleNumber: 916,
+      logicalDate: "2026-05-23",
+      answer: "BASS",
+      clues: [
+        { clueId: "clue-1", position: 1, text: "Low instrument" },
+        { clueId: "clue-2", position: 2, text: "Fishing target" },
+        { clueId: "clue-3", position: 3, text: "Deep voice" },
+        { clueId: "clue-4", position: 4, text: "Speaker setting" },
+        { clueId: "clue-5", position: 5, text: "Music section" },
+      ],
+    },
+    createdAt: "2026-05-24T00:04:00.000Z",
+  });
+  assert.equal(
+    lowConfidenceReviewUiInput.reviewUiInputVersion,
+    REVIEW_UI_INPUT_VERSION,
+    "review UI input version should be stable",
+  );
+  assert.equal(lowConfidenceReviewUiInput.localOnly, true, "review UI input should stay local-only");
+  assert.equal(lowConfidenceReviewUiInput.renderStatus, "not_rendered", "PR10.6 should not build a real UI");
+  assert.equal(lowConfidenceReviewUiInput.puzzle.snapshotStatus, "provided", "provided puzzle snapshot should be marked");
+  assert.equal(lowConfidenceReviewUiInput.puzzle.clueCount, 5, "review UI input should carry five clue rows when provided");
+  assert.equal(lowConfidenceReviewUiInput.puzzle.answer, "BASS", "review UI input should carry the answer when provided");
+  assert.deepEqual(
+    lowConfidenceReviewUiInput.validation.issueGroups.map((group) => [group.severity, group.issueCodes]),
+    [["P1", ["GENERIC_REASONING_PATTERN"]]],
+    "review UI input should group issues by severity",
+  );
+  assert.equal(
+    lowConfidenceReviewUiInput.allowedActions.some((button) => button.action === "add_human_note" && button.enabled),
+    true,
+    "review UI input should expose the human note action while review is open",
+  );
+  assert.equal(
+    lowConfidenceReviewUiInput.safety.publishAllowed,
+    false,
+    "review UI input must not allow publishing",
+  );
+  assert.ok(
+    !JSON.stringify(lowConfidenceReviewUiInput).includes("<main"),
+    "review UI input should not include raw rendered HTML",
+  );
 
   const modelOverride = validateReviewDecision({
     artifact: hardRuleArtifact,
@@ -685,6 +738,23 @@ function assertReviewRoutingAndDecisionContract() {
   assert.ok(
     highPriorityNotificationDraft.dedupeKey.includes("review-notification:high_priority"),
     "notification dedupe key should include notification type and priority",
+  );
+  const missingSnapshotReviewUiInput = buildReviewUiInput({
+    artifact: highPriorityQueueArtifact,
+    queueDraft: highPriorityQueueDraft,
+    notificationDraft: highPriorityNotificationDraft,
+    createdAt: "2026-05-24T00:04:00.000Z",
+  });
+  assert.equal(
+    missingSnapshotReviewUiInput.puzzle.snapshotStatus,
+    "missing",
+    "review UI input should not pretend puzzle snapshot exists when it was not provided",
+  );
+  assert.equal(missingSnapshotReviewUiInput.puzzle.clueCount, 0, "missing puzzle snapshot should have zero clues");
+  assert.equal(
+    missingSnapshotReviewUiInput.notificationDraft?.dispatchStatus,
+    "not_sent",
+    "review UI input should preserve notification draft send status",
   );
 }
 
@@ -3425,6 +3495,12 @@ async function assertReviewRoutingDecisionDoc() {
     "`msg_type: \"text\"`",
     "Feishu notification drafts include puzzle id, logical date, current mode, issue severity, recommended action, public URL, and review URL when available.",
     "The local runner includes `reviewNotificationDraft` only when a review queue draft exists.",
+    "Review UI Input",
+    "reviewUiInputVersion: \"content-kitchen-review-ui-input-v0\"",
+    "`localOnly: true`",
+    "`renderStatus: \"not_rendered\"`",
+    "Puzzle snapshot status is explicit: `provided` or `missing`.",
+    "The local runner includes `reviewUiInput` only when a review queue draft exists.",
     "review-decision-auto-approve.*.example.json",
     "review-decision-auto-reject.*.example.json",
     "review-decision-model-review.*.example.json",
@@ -3442,6 +3518,7 @@ async function assertReviewRoutingDecisionDoc() {
     "does not send Feishu messages",
     "does not read Feishu webhook secrets",
     "does not write review queue storage",
+    "does not render Review UI",
     "does not touch production storage",
     "does not publish content",
     "does not run Worker cron",
@@ -3538,11 +3615,32 @@ async function assertReviewDecisionExamplesAndRunner() {
         "text",
         `${baseName}: review notification draft should include a Feishu text payload`,
       );
+      assert.equal(
+        result.reviewUiInput?.reviewUiInputVersion,
+        REVIEW_UI_INPUT_VERSION,
+        `${baseName}: review UI input version should be stable`,
+      );
+      assert.equal(result.reviewUiInput?.localOnly, true, `${baseName}: review UI input should stay local-only`);
+      assert.equal(
+        result.reviewUiInput?.renderStatus,
+        "not_rendered",
+        `${baseName}: review decision runner should not render UI`,
+      );
+      assert.equal(
+        result.reviewUiInput?.puzzle.snapshotStatus,
+        "missing",
+        `${baseName}: runner should not pretend a puzzle snapshot was provided`,
+      );
     } else {
       assert.equal(
         result.reviewNotificationDraft,
         undefined,
         `${baseName}: runner should not include a notification draft without a queue draft`,
+      );
+      assert.equal(
+        result.reviewUiInput,
+        undefined,
+        `${baseName}: runner should not include UI input without a queue draft`,
       );
     }
   }
@@ -3707,6 +3805,21 @@ async function assertReviewDecisionExamplesAndRunner() {
     routeOnlyResult.reviewNotificationDraft?.reviewUrl,
     "https://example.com/admin/content-kitchen/review/art_review_human_override_example",
     "route-only notification draft should include review URL when provided",
+  );
+  assert.equal(
+    routeOnlyResult.reviewUiInput?.reviewUiInputVersion,
+    REVIEW_UI_INPUT_VERSION,
+    "route-only human review runner output should include review UI input",
+  );
+  assert.equal(
+    routeOnlyResult.reviewUiInput?.reviewUrl,
+    "https://example.com/admin/content-kitchen/review/art_review_human_override_example",
+    "route-only UI input should include review URL when provided",
+  );
+  assert.equal(
+    routeOnlyResult.reviewUiInput?.safety.rawRenderedHtmlIncluded,
+    false,
+    "route-only UI input should not include raw rendered HTML",
   );
 }
 

--- a/scripts/run-content-kitchen-review-decision.ts
+++ b/scripts/run-content-kitchen-review-decision.ts
@@ -2,6 +2,7 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import {
+  buildReviewUiInput,
   buildReviewNotificationDraft,
   buildReviewQueueDraft,
   buildReviewDecisionEffectPlan,
@@ -15,6 +16,7 @@ import type {
   ReviewDecisionValidationResult,
   ReviewNotificationDraftV0,
   ReviewQueueDraftV0,
+  ReviewUiInputV0,
   ReviewRouteResult,
 } from "../lib/puzzles/content-kitchen/types";
 
@@ -33,6 +35,7 @@ export type ContentKitchenReviewDecisionRunnerResult = {
   effectPlan?: ReviewDecisionEffectPlanV0;
   reviewQueueDraft?: ReviewQueueDraftV0;
   reviewNotificationDraft?: ReviewNotificationDraftV0;
+  reviewUiInput?: ReviewUiInputV0;
 };
 
 type ParsedArgs = {
@@ -180,6 +183,16 @@ export async function runContentKitchenReviewDecisionFromFiles(input: {
       ...(input.reviewUrl ? { reviewUrl: input.reviewUrl } : {}),
     })
     : undefined;
+  const reviewUiInput = reviewQueueDraft
+    ? buildReviewUiInput({
+      artifact,
+      queueDraft: reviewQueueDraft,
+      route,
+      ...(effectPlan ? { effectPlan } : {}),
+      ...(reviewNotificationDraft ? { notificationDraft: reviewNotificationDraft } : {}),
+      ...(input.reviewUrl ? { reviewUrl: input.reviewUrl } : {}),
+    })
+    : undefined;
   const result: ContentKitchenReviewDecisionRunnerResult = {
     schemaVersion: REVIEW_DECISION_RUNNER_RESULT_VERSION,
     dryRunOnly: true,
@@ -192,6 +205,7 @@ export async function runContentKitchenReviewDecisionFromFiles(input: {
     ...(effectPlan ? { effectPlan } : {}),
     ...(reviewQueueDraft ? { reviewQueueDraft } : {}),
     ...(reviewNotificationDraft ? { reviewNotificationDraft } : {}),
+    ...(reviewUiInput ? { reviewUiInput } : {}),
   };
 
   if (outputPath) {


### PR DESCRIPTION
## Summary
- add a local ReviewUiInput contract for review queue drafts
- include puzzle snapshot status, revision summary, issue groups, policies, route, queue draft, notification draft, effect plan, and safety flags
- include reviewUiInput in the local review-decision runner output only when a queue draft exists
- document the PR10.6 slice and cover provided/missing puzzle snapshot behavior in contract tests

## Validation
- npm run test:content-kitchen
- npm run typecheck
- npm run lint
- npm run content-kitchen:review-decision -- --artifact lib/puzzles/content-kitchen/examples/review-decision-human-override.artifact.example.json --review-url https://example.com/admin/content-kitchen/review/art_review_human_override_example --compact
- npm run build

## Notes
- Local-only: no Review UI rendering, no model call, no Feishu send, no webhook secret read, no review queue storage, no production publish.