### PR TITLE
[codex] Add PR10 read-only review UI surface

### DIFF
--- a/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
+++ b/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
@@ -2309,6 +2309,19 @@ PR10 sixth implementation slice:
 - include the UI input in the local review decision runner output only when a review queue draft exists
 - keep this local-only; do not build Review UI, call a model, send Feishu messages, read Feishu webhook secrets, write review queue storage, attach production storage, publish content, or run Worker cron yet
 
+PR10 seventh implementation slice:
+
+- add a local read-only Review UI surface that renders `ReviewUiInput` into a static HTML file
+- add `--ui-output` to the local review decision runner
+- write the surface only when a review queue draft exists; reject `--ui-output` when no review UI input exists
+- reject unsafe paths where `--ui-output` equals `--artifact`, `--decision`, or `--output`
+- keep the surface as `content-kitchen-review-ui-surface-v0`
+- include no JavaScript, no form submit, no storage writes, no Feishu send, and no publish action
+- include `<meta name="robots" content="noindex, nofollow">`
+- prove the generated HTML shows issue codes, route state, policy output, queue draft, notification draft, safety flags, and allowed action readiness
+- verify the generated local file in a browser
+- keep this local-only; do not build a production Review UI route, add a sitemap entry, call a model, send Feishu messages, read Feishu webhook secrets, write review queue storage, attach production storage, publish content, or run Worker cron yet
+
 ### PR11 — Post-Publish Content Audit
 
 Goal: verify what users and crawlers see after publish.

--- a/docs/pinpoint-content-kitchen-pr10-review-routing-decision-2026-05-24.md
+++ b/docs/pinpoint-content-kitchen-pr10-review-routing-decision-2026-05-24.md
@@ -1,15 +1,17 @@
 # PR10 Review Routing And Decision Contract
 
-This is the local contract note for PR10.1 through PR10.4.
+This is the local contract note for PR10.1 through PR10.7.
 
 It defines how a review artifact is routed and how a final review decision is recorded.
 
 It is intentionally local-only:
 
-- it does not build Review UI
+- it does not build a production Review UI route
+- it does not add any sitemap entry
 - it does not call a model
 - it does not send Feishu messages
 - it does not write review queue storage
+- it does not render production content
 - it does not touch production storage
 - it does not publish content
 - it does not run Worker cron
@@ -316,6 +318,43 @@ If a puzzle snapshot is missing, the UI input must not invent answer text or clu
 
 The local runner includes `reviewUiInput` only when a review queue draft exists.
 
+## Review UI Read-only Local Surface
+
+PR10.7 adds a local static HTML surface for the Review UI input.
+
+It uses `content-kitchen-review-ui-surface-v0`.
+
+This is only a local file preview. It is not a Next route, not a production page, and not included in sitemap.
+
+Use `--ui-output` to write it:
+
+```bash
+npm run content-kitchen:review-decision -- \
+  --artifact lib/puzzles/content-kitchen/examples/review-decision-human-override.artifact.example.json \
+  --review-url https://example.com/admin/content-kitchen/review/art_review_human_override_example \
+  --ui-output /tmp/content-kitchen-review-ui.html \
+  --pretty
+```
+
+The generated HTML:
+
+- shows artifact id, puzzle id, revision id, route, policy output, issue groups, queue draft, notification draft, safety flags, and allowed actions
+- shows five L1 clues only when a puzzle snapshot is provided
+- does not invent answer text or clue text when the puzzle snapshot is missing
+- includes `<meta name="robots" content="noindex, nofollow">`
+- has no JavaScript
+- has no form submit
+- writes no storage
+- sends no Feishu message
+- publishes no content
+
+Rules:
+
+- `--ui-output` requires a review queue draft
+- `--ui-output` must not equal `--artifact`
+- `--ui-output` must not equal `--decision`
+- `--ui-output` must not equal `--output`
+
 Write the result to a local file:
 
 ```bash
@@ -324,6 +363,7 @@ npm run content-kitchen:review-decision -- \
   --decision lib/puzzles/content-kitchen/examples/review-decision-model-review.decision.example.json \
   --review-url https://example.com/admin/content-kitchen/review/art_review_human_override_example \
   --output /tmp/content-kitchen-review-decision-result.json \
+  --ui-output /tmp/content-kitchen-review-ui.html \
   --pretty
 ```
 
@@ -340,11 +380,15 @@ Rules:
 
 - `--output` must not equal `--artifact`
 - `--output` must not equal `--decision`
+- `--ui-output` must not equal `--artifact`
+- `--ui-output` must not equal `--decision`
+- `--ui-output` must not equal `--output`
 - the runner is for local inspection only
 - the runner does not call a model
 - the runner does not send Feishu messages
 - the runner does not read Feishu webhook secrets
 - the runner does not write review queue storage
-- the runner does not render Review UI
+- the runner does not build a production Review UI route
+- the runner does not render production content
 - the runner does not touch production storage
 - the runner does not publish content

--- a/scripts/check-content-kitchen-contract.ts
+++ b/scripts/check-content-kitchen-contract.ts
@@ -85,6 +85,10 @@ import {
   runCli as runContentKitchenReviewDecisionCli,
   runContentKitchenReviewDecisionFromFiles,
 } from "./run-content-kitchen-review-decision";
+import {
+  REVIEW_UI_SURFACE_VERSION,
+  renderReviewUiInputHtml,
+} from "./content-kitchen-review-ui-surface";
 import type {
   ContentKitchenDictionaries,
   ContentKitchenIssueCode,
@@ -534,6 +538,33 @@ function assertReviewRoutingAndDecisionContract() {
     !JSON.stringify(lowConfidenceReviewUiInput).includes("<main"),
     "review UI input should not include raw rendered HTML",
   );
+  const lowConfidenceReviewUiHtml = renderReviewUiInputHtml(lowConfidenceReviewUiInput);
+  assert.ok(
+    lowConfidenceReviewUiHtml.includes(REVIEW_UI_SURFACE_VERSION),
+    "review UI local surface should include its stable version",
+  );
+  assert.ok(
+    lowConfidenceReviewUiHtml.includes("Content Kitchen Review"),
+    "review UI local surface should include a clear title",
+  );
+  assert.ok(
+    lowConfidenceReviewUiHtml.includes("GENERIC_REASONING_PATTERN"),
+    "review UI local surface should show issue codes",
+  );
+  assert.ok(
+    lowConfidenceReviewUiHtml.includes("Draft only: not sent to Feishu."),
+    "review UI local surface should show notification drafts are not sent",
+  );
+  assert.ok(
+    lowConfidenceReviewUiHtml.includes("Raw HTML included: false"),
+    "review UI local surface should expose the raw HTML safety flag",
+  );
+  assert.ok(
+    !lowConfidenceReviewUiHtml.includes("raw model prompt"),
+    "review UI local surface should not include model prompts",
+  );
+  assert.ok(!lowConfidenceReviewUiHtml.includes("<script"), "review UI local surface should not include scripts");
+  assert.ok(!lowConfidenceReviewUiHtml.includes("<form"), "review UI local surface should not include forms");
 
   const modelOverride = validateReviewDecision({
     artifact: hardRuleArtifact,
@@ -3501,6 +3532,13 @@ async function assertReviewRoutingDecisionDoc() {
     "`renderStatus: \"not_rendered\"`",
     "Puzzle snapshot status is explicit: `provided` or `missing`.",
     "The local runner includes `reviewUiInput` only when a review queue draft exists.",
+    "Review UI Read-only Local Surface",
+    "content-kitchen-review-ui-surface-v0",
+    "--ui-output /tmp/content-kitchen-review-ui.html",
+    "`--ui-output` must not equal `--artifact`",
+    "`--ui-output` must not equal `--decision`",
+    "`--ui-output` must not equal `--output`",
+    "`--ui-output` requires a review queue draft",
     "review-decision-auto-approve.*.example.json",
     "review-decision-auto-reject.*.example.json",
     "review-decision-model-review.*.example.json",
@@ -3513,12 +3551,12 @@ async function assertReviewRoutingDecisionDoc() {
     "--output /tmp/content-kitchen-review-decision-result.json",
     "`--output` must not equal `--artifact`",
     "`--output` must not equal `--decision`",
-    "does not build Review UI",
+    "does not build a production Review UI route",
     "does not call a model",
     "does not send Feishu messages",
     "does not read Feishu webhook secrets",
     "does not write review queue storage",
-    "does not render Review UI",
+    "does not render production content",
     "does not touch production storage",
     "does not publish content",
     "does not run Worker cron",
@@ -3706,6 +3744,46 @@ async function assertReviewDecisionExamplesAndRunner() {
       "review decision runner output should include the next required action",
     );
 
+    const humanReviewArtifactPath = resolve(EXAMPLE_DIR, "review-decision-human-override.artifact.example.json");
+    const uiOutputPath = resolve(tmpDir, "review-ui.html");
+    const uiOutputResult = await runContentKitchenReviewDecisionFromFiles({
+      artifactPath: humanReviewArtifactPath,
+      reviewUrl: "https://example.com/admin/content-kitchen/review/art_review_human_override_example",
+      uiOutputPath,
+    });
+    const writtenUiOutput = await readFile(uiOutputPath, "utf8");
+    assert.equal(
+      uiOutputResult.reviewUiOutputPath,
+      uiOutputPath,
+      "review decision runner should report review UI output path",
+    );
+    assert.ok(
+      writtenUiOutput.includes(REVIEW_UI_SURFACE_VERSION),
+      "review UI output file should include the stable surface version",
+    );
+    assert.ok(
+      writtenUiOutput.includes("Content Kitchen Review"),
+      "review UI output file should include the local page title",
+    );
+    assert.ok(
+      writtenUiOutput.includes("EVIDENCE_SOURCE_CONFLICT"),
+      "review UI output file should include human review issue codes",
+    );
+    assert.ok(
+      writtenUiOutput.includes("not_rendered"),
+      "review UI output file should keep renderStatus explicit",
+    );
+    assert.ok(
+      writtenUiOutput.includes("Draft only: not sent to Feishu."),
+      "review UI output file should show notifications are draft-only",
+    );
+    assert.ok(
+      writtenUiOutput.includes("Raw HTML included: false"),
+      "review UI output file should show raw HTML is not included",
+    );
+    assert.ok(!writtenUiOutput.includes("<script"), "review UI output file should not include scripts");
+    assert.ok(!writtenUiOutput.includes("<form"), "review UI output file should not include forms");
+
     await assert.rejects(
       () => runContentKitchenReviewDecisionCli(["--artifact", artifactPath, "--output", artifactPath]),
       /--output must be different from --artifact/,
@@ -3722,6 +3800,43 @@ async function assertReviewDecisionExamplesAndRunner() {
       ]),
       /--output must be different from --decision/,
       "review decision CLI should reject output paths that would overwrite the decision",
+    );
+    await assert.rejects(
+      () => runContentKitchenReviewDecisionCli(["--artifact", humanReviewArtifactPath, "--ui-output", humanReviewArtifactPath]),
+      /--ui-output must be different from --artifact/,
+      "review decision CLI should reject UI output paths that would overwrite the artifact",
+    );
+    await assert.rejects(
+      () => runContentKitchenReviewDecisionCli([
+        "--artifact",
+        humanReviewArtifactPath,
+        "--decision",
+        decisionPath,
+        "--ui-output",
+        decisionPath,
+      ]),
+      /--ui-output must be different from --decision/,
+      "review decision CLI should reject UI output paths that would overwrite the decision",
+    );
+    await assert.rejects(
+      () => runContentKitchenReviewDecisionCli([
+        "--artifact",
+        humanReviewArtifactPath,
+        "--output",
+        outputPath,
+        "--ui-output",
+        outputPath,
+      ]),
+      /--ui-output must be different from --output/,
+      "review decision CLI should reject UI output paths that would overwrite the JSON output",
+    );
+    await assert.rejects(
+      () => runContentKitchenReviewDecisionFromFiles({
+        artifactPath: resolve(EXAMPLE_DIR, "review-decision-auto-approve.artifact.example.json"),
+        uiOutputPath: resolve(tmpDir, "auto-approve-ui.html"),
+      }),
+      /--ui-output requires a review queue draft/,
+      "review decision runner should only write UI when a review queue draft exists",
     );
   } finally {
     await rm(tmpDir, { recursive: true, force: true });

--- a/scripts/content-kitchen-review-ui-surface.ts
+++ b/scripts/content-kitchen-review-ui-surface.ts
@@ -1,0 +1,321 @@
+import type {
+  ReviewUiActionButtonV0,
+  ReviewUiInputV0,
+  ReviewUiIssueGroupV0,
+} from "../lib/puzzles/content-kitchen/types";
+
+export const REVIEW_UI_SURFACE_VERSION = "content-kitchen-review-ui-surface-v0";
+
+function escapeHtml(value: unknown): string {
+  return String(value ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+function renderField(label: string, value: unknown): string {
+  return `
+    <div class="field">
+      <dt>${escapeHtml(label)}</dt>
+      <dd>${escapeHtml(value ?? "n/a")}</dd>
+    </div>`;
+}
+
+function renderIssueGroup(group: ReviewUiIssueGroupV0): string {
+  const issues = group.issues.map((issue) => `
+    <li>
+      <strong>${escapeHtml(issue.issueCode)}</strong>
+      <span>${escapeHtml(issue.message)}</span>
+      <small>${escapeHtml(issue.fieldPath)} | ${escapeHtml(issue.suggestedAction)}</small>
+    </li>`).join("");
+
+  return `
+    <section class="band">
+      <h2>${escapeHtml(group.severity)} issues</h2>
+      <ul class="issue-list">${issues}</ul>
+    </section>`;
+}
+
+function renderAction(action: ReviewUiActionButtonV0): string {
+  return `
+    <li class="action ${action.enabled ? "enabled" : "disabled"}">
+      <span>${escapeHtml(action.action)}</span>
+      <small>${escapeHtml(action.enabled ? "available" : "disabled")} - ${escapeHtml(action.reason)}</small>
+    </li>`;
+}
+
+function renderClues(input: ReviewUiInputV0): string {
+  if (input.puzzle.snapshotStatus === "missing") {
+    return `
+      <section class="band warning">
+        <h2>Puzzle snapshot missing</h2>
+        <p>This local surface does not invent answer or clue text. Provide a puzzle snapshot before a real review UI shows clue rows.</p>
+      </section>`;
+  }
+
+  const clues = input.puzzle.clues.map((clue) => `
+    <li>
+      <span>${escapeHtml(clue.position)}</span>
+      <strong>${escapeHtml(clue.text)}</strong>
+      <small>${escapeHtml(clue.clueId || "no clue id")}</small>
+    </li>`).join("");
+
+  return `
+    <section class="band">
+      <h2>Five L1 clues</h2>
+      <ol class="clue-list">${clues}</ol>
+    </section>`;
+}
+
+function renderQueueAndNotification(input: ReviewUiInputV0): string {
+  const queueLines = input.queueDraft.lines.map((line) => `<li>${escapeHtml(line)}</li>`).join("");
+  const notificationLines = input.notificationDraft?.lines.map((line) => `<li>${escapeHtml(line)}</li>`).join("");
+
+  return `
+    <section class="band">
+      <h2>Queue draft</h2>
+      <dl>
+        ${renderField("Draft id", input.queueDraft.draftId)}
+        ${renderField("Draft only", input.queueDraft.draftOnly)}
+        ${renderField("Persistence", input.queueDraft.persistenceStatus)}
+        ${renderField("Reason", input.queueDraft.reason)}
+      </dl>
+      <ul class="plain-list">${queueLines}</ul>
+    </section>
+
+    <section class="band">
+      <h2>Notification draft</h2>
+      <dl>
+        ${renderField("Channel", input.notificationDraft?.channel)}
+        ${renderField("Dispatch", input.notificationDraft?.dispatchStatus)}
+        ${renderField("Title", input.notificationDraft?.title)}
+      </dl>
+      <p>Draft only: not sent to Feishu.</p>
+      ${notificationLines ? `<ul class="plain-list">${notificationLines}</ul>` : ""}
+    </section>`;
+}
+
+export function renderReviewUiInputHtml(input: ReviewUiInputV0): string {
+  const issueGroups = input.validation.issueGroups.length > 0
+    ? input.validation.issueGroups.map(renderIssueGroup).join("")
+    : '<section class="band"><h2>Issues</h2><p>No issue rows.</p></section>';
+  const actions = input.allowedActions.map(renderAction).join("");
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="robots" content="noindex, nofollow">
+  <title>Content Kitchen Review - ${escapeHtml(input.artifact.artifactId)}</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --ink: #182026;
+      --muted: #5e6a72;
+      --line: #d9e1e7;
+      --soft: #f5f8fa;
+      --warn: #fff7e0;
+      --accent: #126c6a;
+      --danger: #b42318;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: Arial, Helvetica, sans-serif;
+      color: var(--ink);
+      background: #ffffff;
+      line-height: 1.45;
+    }
+    main {
+      max-width: 1180px;
+      margin: 0 auto;
+      padding: 24px;
+    }
+    header {
+      border-bottom: 1px solid var(--line);
+      padding-bottom: 18px;
+      margin-bottom: 18px;
+    }
+    h1 {
+      font-size: 30px;
+      margin: 0 0 8px;
+      letter-spacing: 0;
+    }
+    h2 {
+      font-size: 18px;
+      margin: 0 0 12px;
+      letter-spacing: 0;
+    }
+    p { margin: 0; color: var(--muted); }
+    .status-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-top: 14px;
+    }
+    .pill {
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      padding: 6px 10px;
+      background: var(--soft);
+      font-size: 13px;
+      color: var(--ink);
+    }
+    .pill.danger { border-color: #f2b8b5; color: var(--danger); background: #fff4f2; }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 16px;
+      align-items: start;
+    }
+    .band {
+      border-top: 1px solid var(--line);
+      padding: 18px 0;
+    }
+    .warning {
+      background: var(--warn);
+      border: 1px solid #ecdca8;
+      padding: 16px;
+      border-radius: 6px;
+    }
+    dl {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 10px 16px;
+      margin: 0;
+    }
+    .field dt {
+      font-size: 12px;
+      text-transform: uppercase;
+      color: var(--muted);
+      margin-bottom: 4px;
+    }
+    .field dd {
+      margin: 0;
+      font-weight: 700;
+      overflow-wrap: anywhere;
+    }
+    ul, ol {
+      margin: 0;
+      padding-left: 20px;
+    }
+    li { margin: 8px 0; }
+    .plain-list {
+      margin-top: 12px;
+    }
+    .issue-list li,
+    .action {
+      border-left: 3px solid var(--accent);
+      padding-left: 10px;
+      list-style: none;
+    }
+    .issue-list small,
+    .action small,
+    .clue-list small {
+      display: block;
+      color: var(--muted);
+      font-size: 12px;
+      margin-top: 2px;
+    }
+    .action.disabled {
+      border-left-color: var(--line);
+      color: var(--muted);
+    }
+    .safety {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 8px;
+    }
+    .safety span {
+      border: 1px solid var(--line);
+      border-radius: 6px;
+      padding: 10px;
+      background: var(--soft);
+      font-size: 13px;
+    }
+    @media (max-width: 760px) {
+      main { padding: 16px; }
+      .grid, dl, .safety { grid-template-columns: 1fr; }
+      h1 { font-size: 24px; }
+    }
+  </style>
+</head>
+<body data-surface-version="${REVIEW_UI_SURFACE_VERSION}">
+  <main>
+    <header>
+      <h1>Content Kitchen Review</h1>
+      <p>Read-only local surface. It does not render production content, send Feishu messages, write storage, or publish.</p>
+      <div class="status-row">
+        <span class="pill">${escapeHtml(input.reviewUiInputVersion)}</span>
+        <span class="pill">${escapeHtml(REVIEW_UI_SURFACE_VERSION)}</span>
+        <span class="pill">${escapeHtml(input.route.route)}</span>
+        <span class="pill ${input.queueDraft.priority === "high_priority" ? "danger" : ""}">${escapeHtml(input.queueDraft.priority)}</span>
+        <span class="pill">${escapeHtml(input.renderStatus)}</span>
+      </div>
+    </header>
+
+    <section class="band">
+      <h2>Review target</h2>
+      <dl>
+        ${renderField("Artifact", input.artifact.artifactId)}
+        ${renderField("Puzzle", input.puzzle.puzzleId)}
+        ${renderField("Puzzle number", input.puzzle.puzzleNumber)}
+        ${renderField("Logical date", input.puzzle.logicalDate)}
+        ${renderField("Candidate revision", input.revisions.candidateRevisionId)}
+        ${renderField("Published revision", input.revisions.publishedRevisionId)}
+        ${renderField("Candidate mode", input.revisions.candidateAttemptedMode)}
+        ${renderField("Validation outcome", input.validation.outcome)}
+        ${renderField("Recommended action", input.recommendedAction)}
+        ${renderField("Public URL", input.publicUrl)}
+        ${renderField("Review URL", input.reviewUrl)}
+        ${renderField("Rendered preview URL", input.renderedPreviewUrl)}
+      </dl>
+    </section>
+
+    <div class="grid">
+      <section class="band">
+        <h2>Policy output</h2>
+        <dl>
+          ${renderField("Index", input.validation.policies.indexPolicy)}
+          ${renderField("Sitemap", input.validation.policies.sitemapPolicy)}
+          ${renderField("Schema", input.validation.policies.schemaPolicy)}
+          ${renderField("Internal links", input.validation.policies.internalLinkPolicy)}
+          ${renderField("Required action", input.validation.policies.requiredAction)}
+        </dl>
+      </section>
+
+      <section class="band">
+        <h2>Evidence summary</h2>
+        <dl>
+          ${renderField("Evidence refs", input.evidenceSummary?.evidenceRefCount)}
+          ${renderField("Source levels", input.evidenceSummary?.sourceLevels?.join(", "))}
+          ${renderField("Notes", input.evidenceSummary?.notes?.join(" | "))}
+        </dl>
+      </section>
+    </div>
+
+    ${renderClues(input)}
+    ${issueGroups}
+    ${renderQueueAndNotification(input)}
+
+    <section class="band">
+      <h2>Read-only action readiness</h2>
+      <ul>${actions}</ul>
+    </section>
+
+    <section class="band">
+      <h2>Safety flags</h2>
+      <div class="safety">
+        <span>Raw HTML included: ${input.safety.rawRenderedHtmlIncluded}</span>
+        <span>Model prompt included: ${input.safety.modelPromptIncluded}</span>
+        <span>Secrets included: ${input.safety.secretsIncluded}</span>
+        <span>Publish allowed: ${input.safety.publishAllowed}</span>
+      </div>
+    </section>
+  </main>
+</body>
+</html>`;
+}

--- a/scripts/run-content-kitchen-review-decision.ts
+++ b/scripts/run-content-kitchen-review-decision.ts
@@ -1,6 +1,7 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
+import { renderReviewUiInputHtml } from "./content-kitchen-review-ui-surface";
 import {
   buildReviewUiInput,
   buildReviewNotificationDraft,
@@ -29,6 +30,7 @@ export type ContentKitchenReviewDecisionRunnerResult = {
   sourceArtifactPath: string;
   sourceDecisionPath?: string;
   outputPath?: string;
+  reviewUiOutputPath?: string;
   route: ReviewRouteResult;
   decision?: ReviewDecisionV0;
   decisionValidation?: ReviewDecisionValidationResult;
@@ -42,6 +44,7 @@ type ParsedArgs = {
   artifactPath: string;
   decisionPath?: string;
   outputPath?: string;
+  uiOutputPath?: string;
   modelConfidence?: number;
   reviewUrl?: string;
   pretty: boolean;
@@ -69,6 +72,7 @@ function parseArgs(argv: string[]): ParsedArgs {
   let artifactPath = "";
   let decisionPath: string | undefined;
   let outputPath: string | undefined;
+  let uiOutputPath: string | undefined;
   let modelConfidence: number | undefined;
   let reviewUrl: string | undefined;
   let pretty = true;
@@ -89,6 +93,12 @@ function parseArgs(argv: string[]): ParsedArgs {
 
     if (arg === "--output") {
       outputPath = resolve(readArgValue(argv, index, "--output"));
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--ui-output") {
+      uiOutputPath = resolve(readArgValue(argv, index, "--ui-output"));
       index += 1;
       continue;
     }
@@ -117,7 +127,7 @@ function parseArgs(argv: string[]): ParsedArgs {
 
     if (arg === "--help" || arg === "-h") {
       throw new Error(
-        "Usage: npm run content-kitchen:review-decision -- --artifact <path> [--decision <path>] [--output <path>] [--model-confidence <0..1>] [--review-url <url>] [--pretty|--compact]",
+        "Usage: npm run content-kitchen:review-decision -- --artifact <path> [--decision <path>] [--output <path>] [--ui-output <path>] [--model-confidence <0..1>] [--review-url <url>] [--pretty|--compact]",
       );
     }
 
@@ -133,11 +143,21 @@ function parseArgs(argv: string[]): ParsedArgs {
   if (outputPath && decisionPath === outputPath) {
     throw new Error("--output must be different from --decision");
   }
+  if (uiOutputPath === artifactPath) {
+    throw new Error("--ui-output must be different from --artifact");
+  }
+  if (uiOutputPath && decisionPath === uiOutputPath) {
+    throw new Error("--ui-output must be different from --decision");
+  }
+  if (uiOutputPath && outputPath === uiOutputPath) {
+    throw new Error("--ui-output must be different from --output");
+  }
 
   return {
     artifactPath,
     decisionPath,
     outputPath,
+    uiOutputPath,
     modelConfidence,
     reviewUrl,
     pretty,
@@ -152,12 +172,29 @@ export async function runContentKitchenReviewDecisionFromFiles(input: {
   artifactPath: string;
   decisionPath?: string;
   outputPath?: string;
+  uiOutputPath?: string;
   modelConfidence?: number;
   reviewUrl?: string;
 }): Promise<ContentKitchenReviewDecisionRunnerResult> {
   const artifactPath = resolve(input.artifactPath);
   const decisionPath = input.decisionPath ? resolve(input.decisionPath) : undefined;
   const outputPath = input.outputPath ? resolve(input.outputPath) : undefined;
+  const uiOutputPath = input.uiOutputPath ? resolve(input.uiOutputPath) : undefined;
+  if (outputPath === artifactPath) {
+    throw new Error("--output must be different from --artifact");
+  }
+  if (outputPath && decisionPath === outputPath) {
+    throw new Error("--output must be different from --decision");
+  }
+  if (uiOutputPath === artifactPath) {
+    throw new Error("--ui-output must be different from --artifact");
+  }
+  if (uiOutputPath && decisionPath === uiOutputPath) {
+    throw new Error("--ui-output must be different from --decision");
+  }
+  if (uiOutputPath && outputPath === uiOutputPath) {
+    throw new Error("--ui-output must be different from --output");
+  }
   const artifact = await readJsonFile<ReviewArtifactV0>(artifactPath);
   const decision = decisionPath ? await readJsonFile<ReviewDecisionV0>(decisionPath) : undefined;
   const routeModelConfidence =
@@ -199,6 +236,7 @@ export async function runContentKitchenReviewDecisionFromFiles(input: {
     sourceArtifactPath: artifactPath,
     ...(decisionPath ? { sourceDecisionPath: decisionPath } : {}),
     ...(outputPath ? { outputPath } : {}),
+    ...(uiOutputPath ? { reviewUiOutputPath: uiOutputPath } : {}),
     route,
     ...(decision ? { decision } : {}),
     ...(decisionValidation ? { decisionValidation } : {}),
@@ -211,6 +249,14 @@ export async function runContentKitchenReviewDecisionFromFiles(input: {
   if (outputPath) {
     await mkdir(dirname(outputPath), { recursive: true });
     await writeFile(outputPath, `${JSON.stringify(result, null, 2)}\n`, "utf8");
+  }
+
+  if (uiOutputPath) {
+    if (!reviewUiInput) {
+      throw new Error("--ui-output requires a review queue draft");
+    }
+    await mkdir(dirname(uiOutputPath), { recursive: true });
+    await writeFile(uiOutputPath, renderReviewUiInputHtml(reviewUiInput), "utf8");
   }
 
   return result;


### PR DESCRIPTION
## Summary
- add a local static Review UI surface for reviewUiInput
- add --ui-output to the review decision runner with unsafe path guards
- document PR10.7 and extend contract tests for generated HTML safety

## Verification
- npm run test:content-kitchen
- npm run typecheck
- npm run lint
- npm run content-kitchen:review-decision -- --artifact lib/puzzles/content-kitchen/examples/review-decision-human-override.artifact.example.json --review-url https://example.com/admin/content-kitchen/review/art_review_human_override_example --ui-output /tmp/content-kitchen-review-ui.html --compact
- node static HTML check for title, issue code, not_rendered, Feishu draft text, safety flag, no script, no form
- npm run build

Note: Browser plugin refused file:// verification because of its URL safety policy, so I did not bypass it.