### PR TITLE
[codex] Add PR11 post-publish audit contract

### DIFF
--- a/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
+++ b/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
@@ -2346,6 +2346,16 @@ Acceptance:
 - P0 audit failures such as 404/500, hidden answer, missing clues, or broken canonical block or rollback the publish
 - P1/P2 audit failures create fix tasks or review states without always blocking the page
 
+PR11 first implementation slice:
+
+- add a local `PostPublishAudit` contract with `publish_failed`, `published_but_audit_failed`, and `published_and_audit_passed`
+- add `content-kitchen-post-publish-audit-v0` artifact output for observed post-publish facts
+- add checks for public fetch, render availability, answer visibility, clue visibility, canonical, robots/noindex policy, sitemap policy, sitemap `lastmod`, schema `dateModified`, schema mode, and internal links
+- add PR11 issue codes for public fetch/render, sitemap/schema date, sitemap/robots policy, date modified, and schema mode failures
+- map P0 audit failures to rollback or block-style policies; map non-P0 failures to fix task or degradation policies
+- mark audit artifacts with `rawRenderedHtmlIncluded: false`, `publicFetchPerformedByContract: false`, and `publishAllowed: false`
+- keep this local-only; do not fetch public URLs, run a browser, read sitemap files, read production storage, write review queue storage, send Feishu messages, publish content, or run Worker cron yet
+
 
 ## Review UI Requirements
 

--- a/docs/pinpoint-content-kitchen-pr11-post-publish-audit-contract-2026-05-24.md
+++ b/docs/pinpoint-content-kitchen-pr11-post-publish-audit-contract-2026-05-24.md
@@ -1,0 +1,127 @@
+# PR11 Post-Publish Audit Contract
+
+This is the local contract note for PR11.1.
+
+It defines the post-publish audit artifact shape and the first issue mapping.
+
+It is intentionally local-only:
+
+- it does not fetch public URLs
+- it does not run a browser
+- it does not read sitemap files
+- it does not read production storage
+- it does not write review queue storage
+- it does not send Feishu messages
+- it does not publish content
+- it does not run Worker cron
+
+## Artifact
+
+Every audit result uses `artifactVersion: "content-kitchen-post-publish-audit-v0"`.
+
+Every audit result uses `artifactType: "post_publish_audit"`.
+
+Required identity fields:
+
+- `artifactId`
+- `puzzleId`
+- `canonicalUrl`
+- `revisionId`
+- `contentMode`
+- `fetchedUrl`
+- `checkedAt`
+
+Safety fields:
+
+- `safety.rawRenderedHtmlIncluded: false`
+- `safety.publicFetchPerformedByContract: false`
+- `safety.publishAllowed: false`
+
+PR11.1 consumes observed facts. It does not create those facts by fetching or rendering the live page.
+
+## Outcomes
+
+`auditOutcome` has three values:
+
+- `publish_failed`: public fetch failed or returned a bad status
+- `published_but_audit_failed`: public page exists, but one or more audit checks failed
+- `published_and_audit_passed`: all checked facts match the expected published state
+
+## Checks
+
+The first local checks are:
+
+- `public_fetch`
+- `public_render`
+- `answer_visible`
+- `all_clues_visible`
+- `canonical_matches`
+- `robots_policy_matches`
+- `sitemap_policy_matches`
+- `sitemap_lastmod_matches`
+- `schema_date_modified_matches`
+- `schema_mode_matches`
+- `internal_links_valid`
+
+Each check returns `pass`, `fail`, or `not_checked`.
+
+`not_checked` is explicit. It means the current local input did not have enough observed facts for that check, or the check does not apply to that policy.
+
+## PR11 Issue Codes
+
+PR11 owns these new issue codes:
+
+- `PUBLIC_HTML_FETCH_FAILED`
+- `PUBLIC_HTML_RENDER_FAILED`
+- `SITEMAP_LASTMOD_MISSING`
+- `SCHEMA_DATE_MODIFIED_MISSING`
+- `SITEMAP_POLICY_MISMATCH`
+- `ROBOTS_POLICY_MISMATCH`
+- `DATE_MODIFIED_MISMATCH`
+- `SCHEMA_MODE_MISMATCH`
+
+PR11 can also reuse earlier issue codes when the public page proves the same problem:
+
+- `ANSWER_HIDDEN_FROM_RENDERED_HTML`
+- `MISSING_CLUE_ROW`
+- `CANONICAL_URL_MISMATCH`
+- `INTERNAL_LINK_BROKEN`
+
+## Policy Mapping
+
+P0 audit failures:
+
+- `auditOutcome` becomes `publish_failed` when public fetch failed
+- otherwise `auditOutcome` becomes `published_but_audit_failed`
+- `recommendedAction` becomes `rollback`
+- `recommendedPolicies.sitemapPolicy` becomes `remove_on_next_build`
+- `recommendedPolicies.schemaPolicy` becomes `block_schema`
+- `recommendedPolicies.internalLinkPolicy` becomes `hidden_from_recent`
+
+P1 and P2 audit failures:
+
+- `auditOutcome` becomes `published_but_audit_failed`
+- `recommendedAction` becomes `create_fix_task` by default
+- sitemap or robots policy mismatch can recommend `degrade`
+- non-P0 failures do not automatically publish, rollback, or write storage
+
+Clean audit:
+
+- `auditOutcome` becomes `published_and_audit_passed`
+- `issueCodes` is empty
+- `recommendedAction` is `none`
+- `recommendedPolicies` preserves the expected publish policies
+
+## Local Test Coverage
+
+The content-kitchen contract test proves:
+
+- clean full-analysis audit passes
+- public fetch failure becomes `publish_failed`
+- fetch failure skips render-only checks instead of guessing
+- answer-first sitemap mismatch becomes `published_but_audit_failed`
+- policy mismatch can recommend exact degradation actions
+- missing schema `dateModified` creates `SCHEMA_DATE_MODIFIED_MISSING`
+- PR11 issue codes are registered with `phaseOwner: "PR11"`
+- audit artifacts do not include raw rendered HTML
+- PR11.1 does not fetch public URLs itself

--- a/lib/puzzles/content-kitchen/issue-registry.ts
+++ b/lib/puzzles/content-kitchen/issue-registry.ts
@@ -217,6 +217,70 @@ export const CONTENT_KITCHEN_ISSUE_REGISTRY: IssueCodeDefinition[] = [
     defaultRequiredAction: "review",
     description: "An answer-first page is still unresolved at the high-priority alert deadline.",
   },
+  {
+    code: "PUBLIC_HTML_FETCH_FAILED",
+    phaseOwner: "PR11",
+    defaultSeverity: "P0",
+    defaultOutcome: "block_publish",
+    defaultRequiredAction: "rollback",
+    description: "The published public URL could not be fetched with a successful HTTP status.",
+  },
+  {
+    code: "PUBLIC_HTML_RENDER_FAILED",
+    phaseOwner: "PR11",
+    defaultSeverity: "P0",
+    defaultOutcome: "block_publish",
+    defaultRequiredAction: "rollback",
+    description: "The published public HTML could not be rendered or inspected after fetch.",
+  },
+  {
+    code: "SITEMAP_LASTMOD_MISSING",
+    phaseOwner: "PR11",
+    defaultSeverity: "P1",
+    defaultOutcome: "requires_review",
+    defaultRequiredAction: "create_fix_task",
+    description: "The published sitemap entry is missing an expected lastmod value.",
+  },
+  {
+    code: "SCHEMA_DATE_MODIFIED_MISSING",
+    phaseOwner: "PR11",
+    defaultSeverity: "P1",
+    defaultOutcome: "requires_review",
+    defaultRequiredAction: "create_fix_task",
+    description: "The published structured data is missing an expected dateModified value.",
+  },
+  {
+    code: "SITEMAP_POLICY_MISMATCH",
+    phaseOwner: "PR11",
+    defaultSeverity: "P1",
+    defaultOutcome: "requires_review",
+    defaultRequiredAction: "degrade",
+    description: "The published sitemap inclusion state does not match the expected policy.",
+  },
+  {
+    code: "ROBOTS_POLICY_MISMATCH",
+    phaseOwner: "PR11",
+    defaultSeverity: "P0",
+    defaultOutcome: "block_publish",
+    defaultRequiredAction: "rollback",
+    description: "The published noindex or indexable state does not match the expected policy.",
+  },
+  {
+    code: "DATE_MODIFIED_MISMATCH",
+    phaseOwner: "PR11",
+    defaultSeverity: "P1",
+    defaultOutcome: "requires_review",
+    defaultRequiredAction: "create_fix_task",
+    description: "The published sitemap lastmod or schema dateModified does not match the expected revision date.",
+  },
+  {
+    code: "SCHEMA_MODE_MISMATCH",
+    phaseOwner: "PR11",
+    defaultSeverity: "P1",
+    defaultOutcome: "requires_review",
+    defaultRequiredAction: "create_fix_task",
+    description: "The published structured-data schema types do not match the expected content mode.",
+  },
 ];
 
 export const CONTENT_KITCHEN_ISSUE_DEFINITIONS = new Map<ContentKitchenIssueCode, IssueCodeDefinition>(
@@ -242,5 +306,11 @@ export function getPr6P0IssueCodes(): ContentKitchenIssueCode[] {
 export function getPr7IssueCodes(): ContentKitchenIssueCode[] {
   return CONTENT_KITCHEN_ISSUE_REGISTRY
     .filter((definition) => definition.phaseOwner === "PR7")
+    .map((definition) => definition.code);
+}
+
+export function getPr11IssueCodes(): ContentKitchenIssueCode[] {
+  return CONTENT_KITCHEN_ISSUE_REGISTRY
+    .filter((definition) => definition.phaseOwner === "PR11")
     .map((definition) => definition.code);
 }

--- a/lib/puzzles/content-kitchen/post-publish-audit.ts
+++ b/lib/puzzles/content-kitchen/post-publish-audit.ts
@@ -1,0 +1,442 @@
+import { getIssueDefinition } from "./issue-registry";
+import type {
+  ContentKitchenIssueCode,
+  ContentKitchenIssueSeverity,
+  PostPublishAuditArtifactV0,
+  PostPublishAuditCheckName,
+  PostPublishAuditCheckV0,
+  PostPublishAuditExpectedStateV0,
+  PostPublishAuditObservedStateV0,
+  RequiredAction,
+  ValidationIssue,
+  ValidationPolicies,
+} from "./types";
+
+export const POST_PUBLISH_AUDIT_VERSION = "content-kitchen-post-publish-audit-v0";
+
+export type BuildPostPublishAuditInput = {
+  artifactId: string;
+  checkedAt: string;
+  expected: PostPublishAuditExpectedStateV0;
+  observed: PostPublishAuditObservedStateV0;
+};
+
+function textValue(value: unknown): string | undefined {
+  if (value === undefined || value === null) return undefined;
+  return String(value);
+}
+
+function checkPass(name: PostPublishAuditCheckName, message: string, details: {
+  expected?: unknown;
+  observed?: unknown;
+} = {}): PostPublishAuditCheckV0 {
+  return {
+    name,
+    status: "pass",
+    message,
+    ...(details.expected !== undefined ? { expected: textValue(details.expected) } : {}),
+    ...(details.observed !== undefined ? { observed: textValue(details.observed) } : {}),
+  };
+}
+
+function checkNotChecked(name: PostPublishAuditCheckName, message: string): PostPublishAuditCheckV0 {
+  return {
+    name,
+    status: "not_checked",
+    message,
+  };
+}
+
+function checkFail(name: PostPublishAuditCheckName, issueCode: ContentKitchenIssueCode, message: string, details: {
+  expected?: unknown;
+  observed?: unknown;
+} = {}): PostPublishAuditCheckV0 {
+  const definition = getIssueDefinition(issueCode);
+
+  return {
+    name,
+    status: "fail",
+    message,
+    issueCode,
+    severity: definition.defaultSeverity,
+    ...(details.expected !== undefined ? { expected: textValue(details.expected) } : {}),
+    ...(details.observed !== undefined ? { observed: textValue(details.observed) } : {}),
+  };
+}
+
+function checkPublicFetch(observed: PostPublishAuditObservedStateV0): PostPublishAuditCheckV0 {
+  const statusOk = observed.httpStatus === undefined || (observed.httpStatus >= 200 && observed.httpStatus < 400);
+
+  if (observed.fetchOk && statusOk) {
+    return checkPass("public_fetch", "Public URL fetched successfully.", {
+      observed: observed.httpStatus ?? "status_not_recorded",
+    });
+  }
+
+  return checkFail("public_fetch", "PUBLIC_HTML_FETCH_FAILED", "Public URL fetch failed or returned a bad status.", {
+    expected: "fetchOk=true and HTTP 2xx/3xx",
+    observed: observed.httpStatus ?? "missing_status",
+  });
+}
+
+function checkPublicRender(observed: PostPublishAuditObservedStateV0): PostPublishAuditCheckV0 {
+  if (!observed.fetchOk) {
+    return checkNotChecked("public_render", "Render check skipped because public fetch failed.");
+  }
+
+  if (observed.renderOk) {
+    return checkPass("public_render", "Public HTML render facts were available.");
+  }
+
+  return checkFail("public_render", "PUBLIC_HTML_RENDER_FAILED", "Public HTML render facts were not available.", {
+    expected: "renderOk=true",
+    observed: observed.renderOk,
+  });
+}
+
+function checkAnswerVisible(
+  expected: PostPublishAuditExpectedStateV0,
+  observed: PostPublishAuditObservedStateV0,
+): PostPublishAuditCheckV0 {
+  if (!observed.fetchOk || !observed.renderOk) {
+    return checkNotChecked("answer_visible", "Answer visibility skipped because render facts are unavailable.");
+  }
+
+  if (observed.answerVisible) {
+    return checkPass("answer_visible", "Published answer is visible.", {
+      expected: expected.answer,
+      observed: true,
+    });
+  }
+
+  return checkFail("answer_visible", "ANSWER_HIDDEN_FROM_RENDERED_HTML", "Published answer is not visible.", {
+    expected: expected.answer,
+    observed: false,
+  });
+}
+
+function checkCluesVisible(
+  expected: PostPublishAuditExpectedStateV0,
+  observed: PostPublishAuditObservedStateV0,
+): PostPublishAuditCheckV0 {
+  if (!observed.fetchOk || !observed.renderOk) {
+    return checkNotChecked("all_clues_visible", "Clue visibility skipped because render facts are unavailable.");
+  }
+
+  const visible = new Set(observed.visibleClues ?? []);
+  const missing = expected.clues.filter((clue) => !visible.has(clue));
+  if (missing.length === 0) {
+    return checkPass("all_clues_visible", "All expected L1 clues are visible.", {
+      expected: expected.clues.length,
+      observed: observed.visibleClues?.length ?? 0,
+    });
+  }
+
+  return checkFail("all_clues_visible", "MISSING_CLUE_ROW", "One or more expected L1 clues are missing from public HTML.", {
+    expected: expected.clues.join(" | "),
+    observed: `missing: ${missing.join(" | ")}`,
+  });
+}
+
+function checkCanonical(
+  expected: PostPublishAuditExpectedStateV0,
+  observed: PostPublishAuditObservedStateV0,
+): PostPublishAuditCheckV0 {
+  if (!observed.fetchOk || !observed.renderOk) {
+    return checkNotChecked("canonical_matches", "Canonical check skipped because render facts are unavailable.");
+  }
+
+  if (observed.canonicalUrl === expected.canonicalUrl) {
+    return checkPass("canonical_matches", "Canonical URL matches expected URL.", {
+      expected: expected.canonicalUrl,
+      observed: observed.canonicalUrl,
+    });
+  }
+
+  return checkFail("canonical_matches", "CANONICAL_URL_MISMATCH", "Canonical URL does not match expected URL.", {
+    expected: expected.canonicalUrl,
+    observed: observed.canonicalUrl ?? "missing",
+  });
+}
+
+function checkRobotsPolicy(
+  expected: PostPublishAuditExpectedStateV0,
+  observed: PostPublishAuditObservedStateV0,
+): PostPublishAuditCheckV0 {
+  if (!observed.fetchOk || !observed.renderOk) {
+    return checkNotChecked("robots_policy_matches", "Robots policy check skipped because render facts are unavailable.");
+  }
+
+  if (expected.policies.indexPolicy !== "index" && expected.policies.indexPolicy !== "noindex") {
+    return checkNotChecked("robots_policy_matches", "Robots policy check applies only to index or noindex policies.");
+  }
+
+  const expectedNoindex = expected.policies.indexPolicy === "noindex";
+  if (observed.noindexPresent === expectedNoindex) {
+    return checkPass("robots_policy_matches", "Robots noindex state matches expected policy.", {
+      expected: expected.policies.indexPolicy,
+      observed: observed.noindexPresent ? "noindex" : "index",
+    });
+  }
+
+  return checkFail("robots_policy_matches", "ROBOTS_POLICY_MISMATCH", "Robots noindex state does not match expected policy.", {
+    expected: expected.policies.indexPolicy,
+    observed: observed.noindexPresent ? "noindex" : "index",
+  });
+}
+
+function checkSitemapPolicy(
+  expected: PostPublishAuditExpectedStateV0,
+  observed: PostPublishAuditObservedStateV0,
+): PostPublishAuditCheckV0 {
+  if (expected.policies.sitemapPolicy === "include_after_audit") {
+    return checkNotChecked("sitemap_policy_matches", "Sitemap inclusion is waiting for audit decision.");
+  }
+  if (observed.sitemapIncluded === undefined) {
+    return checkNotChecked("sitemap_policy_matches", "Sitemap inclusion fact is unavailable.");
+  }
+
+  const expectedIncluded = expected.policies.sitemapPolicy === "include";
+  if (observed.sitemapIncluded === expectedIncluded) {
+    return checkPass("sitemap_policy_matches", "Sitemap inclusion matches expected policy.", {
+      expected: expected.policies.sitemapPolicy,
+      observed: observed.sitemapIncluded ? "included" : "excluded",
+    });
+  }
+
+  return checkFail("sitemap_policy_matches", "SITEMAP_POLICY_MISMATCH", "Sitemap inclusion does not match expected policy.", {
+    expected: expected.policies.sitemapPolicy,
+    observed: observed.sitemapIncluded ? "included" : "excluded",
+  });
+}
+
+function checkSitemapLastmod(
+  expected: PostPublishAuditExpectedStateV0,
+  observed: PostPublishAuditObservedStateV0,
+): PostPublishAuditCheckV0 {
+  if (observed.sitemapIncluded === undefined) {
+    return checkNotChecked("sitemap_lastmod_matches", "Sitemap lastmod skipped because sitemap inclusion is unavailable.");
+  }
+  if (!observed.sitemapIncluded) {
+    return checkNotChecked("sitemap_lastmod_matches", "Sitemap lastmod skipped because the URL is not in sitemap.");
+  }
+  if (!expected.sitemapLastmod) {
+    return checkNotChecked("sitemap_lastmod_matches", "Sitemap lastmod has no expected value yet.");
+  }
+  if (!observed.sitemapLastmod) {
+    return checkFail("sitemap_lastmod_matches", "SITEMAP_LASTMOD_MISSING", "Sitemap entry is missing lastmod.", {
+      expected: expected.sitemapLastmod,
+      observed: "missing",
+    });
+  }
+  if (observed.sitemapLastmod === expected.sitemapLastmod) {
+    return checkPass("sitemap_lastmod_matches", "Sitemap lastmod matches expected value.", {
+      expected: expected.sitemapLastmod,
+      observed: observed.sitemapLastmod,
+    });
+  }
+
+  return checkFail("sitemap_lastmod_matches", "DATE_MODIFIED_MISMATCH", "Sitemap lastmod differs from expected value.", {
+    expected: expected.sitemapLastmod,
+    observed: observed.sitemapLastmod,
+  });
+}
+
+function checkSchemaDateModified(
+  expected: PostPublishAuditExpectedStateV0,
+  observed: PostPublishAuditObservedStateV0,
+): PostPublishAuditCheckV0 {
+  if (!observed.fetchOk || !observed.renderOk) {
+    return checkNotChecked("schema_date_modified_matches", "Schema dateModified skipped because render facts are unavailable.");
+  }
+  if (!expected.schemaDateModified) {
+    return checkNotChecked("schema_date_modified_matches", "Schema dateModified has no expected value yet.");
+  }
+  if (!observed.schemaDateModified) {
+    return checkFail("schema_date_modified_matches", "SCHEMA_DATE_MODIFIED_MISSING", "Schema dateModified is missing.", {
+      expected: expected.schemaDateModified,
+      observed: "missing",
+    });
+  }
+  if (observed.schemaDateModified === expected.schemaDateModified) {
+    return checkPass("schema_date_modified_matches", "Schema dateModified matches expected value.", {
+      expected: expected.schemaDateModified,
+      observed: observed.schemaDateModified,
+    });
+  }
+
+  return checkFail("schema_date_modified_matches", "DATE_MODIFIED_MISMATCH", "Schema dateModified differs from expected value.", {
+    expected: expected.schemaDateModified,
+    observed: observed.schemaDateModified,
+  });
+}
+
+function checkSchemaMode(
+  expected: PostPublishAuditExpectedStateV0,
+  observed: PostPublishAuditObservedStateV0,
+): PostPublishAuditCheckV0 {
+  if (!observed.fetchOk || !observed.renderOk) {
+    return checkNotChecked("schema_mode_matches", "Schema mode skipped because render facts are unavailable.");
+  }
+  const expectedTypes = expected.schemaTypes ?? [];
+  if (expectedTypes.length === 0) {
+    return checkNotChecked("schema_mode_matches", "Schema mode has no expected schema types yet.");
+  }
+
+  const observedTypes = new Set(observed.schemaTypes ?? []);
+  const missing = expectedTypes.filter((schemaType) => !observedTypes.has(schemaType));
+  if (missing.length === 0) {
+    return checkPass("schema_mode_matches", "Schema types match expected content mode.", {
+      expected: expectedTypes.join(", "),
+      observed: (observed.schemaTypes ?? []).join(", "),
+    });
+  }
+
+  return checkFail("schema_mode_matches", "SCHEMA_MODE_MISMATCH", "Published schema types do not match expected content mode.", {
+    expected: expectedTypes.join(", "),
+    observed: (observed.schemaTypes ?? []).join(", "),
+  });
+}
+
+function checkInternalLinks(
+  expected: PostPublishAuditExpectedStateV0,
+  observed: PostPublishAuditObservedStateV0,
+): PostPublishAuditCheckV0 {
+  if (!observed.fetchOk || !observed.renderOk) {
+    return checkNotChecked("internal_links_valid", "Internal link audit skipped because render facts are unavailable.");
+  }
+  const expectedLinks = expected.expectedInternalLinks ?? [];
+  if (expectedLinks.length === 0) {
+    return checkNotChecked("internal_links_valid", "Internal link audit has no expected links yet.");
+  }
+
+  const observedLinks = new Set(observed.internalLinks ?? []);
+  const missing = expectedLinks.filter((link) => !observedLinks.has(link));
+  if (missing.length === 0) {
+    return checkPass("internal_links_valid", "Expected internal links are present.", {
+      expected: expectedLinks.length,
+      observed: observed.internalLinks?.length ?? 0,
+    });
+  }
+
+  return checkFail("internal_links_valid", "INTERNAL_LINK_BROKEN", "One or more expected internal links are missing.", {
+    expected: expectedLinks.join(" | "),
+    observed: `missing: ${missing.join(" | ")}`,
+  });
+}
+
+function buildChecks(input: BuildPostPublishAuditInput): PostPublishAuditCheckV0[] {
+  return [
+    checkPublicFetch(input.observed),
+    checkPublicRender(input.observed),
+    checkAnswerVisible(input.expected, input.observed),
+    checkCluesVisible(input.expected, input.observed),
+    checkCanonical(input.expected, input.observed),
+    checkRobotsPolicy(input.expected, input.observed),
+    checkSitemapPolicy(input.expected, input.observed),
+    checkSitemapLastmod(input.expected, input.observed),
+    checkSchemaDateModified(input.expected, input.observed),
+    checkSchemaMode(input.expected, input.observed),
+    checkInternalLinks(input.expected, input.observed),
+  ];
+}
+
+function uniqueIssueCodes(checks: PostPublishAuditCheckV0[]): ContentKitchenIssueCode[] {
+  return [...new Set(checks.flatMap((check) => (check.issueCode ? [check.issueCode] : [])))];
+}
+
+function maxSeverity(issueCodes: ContentKitchenIssueCode[]): ContentKitchenIssueSeverity | undefined {
+  const severities = issueCodes.map((issueCode) => getIssueDefinition(issueCode).defaultSeverity);
+  if (severities.includes("P0")) return "P0";
+  if (severities.includes("P1")) return "P1";
+  if (severities.includes("P2")) return "P2";
+  return undefined;
+}
+
+function recommendedAction(issueCodes: ContentKitchenIssueCode[]): RequiredAction {
+  if (issueCodes.length === 0) return "none";
+  if (maxSeverity(issueCodes) === "P0") return "rollback";
+  if (issueCodes.includes("ROBOTS_POLICY_MISMATCH") || issueCodes.includes("SITEMAP_POLICY_MISMATCH")) return "degrade";
+  return "create_fix_task";
+}
+
+function recommendedPolicies(issueCodes: ContentKitchenIssueCode[], expected: PostPublishAuditExpectedStateV0): ValidationPolicies {
+  const action = recommendedAction(issueCodes);
+  if (issueCodes.length === 0) {
+    return expected.policies;
+  }
+
+  if (maxSeverity(issueCodes) === "P0") {
+    return {
+      indexPolicy: "block_publish",
+      sitemapPolicy: "remove_on_next_build",
+      schemaPolicy: "block_schema",
+      internalLinkPolicy: "hidden_from_recent",
+      requiredAction: action,
+    };
+  }
+
+  return {
+    indexPolicy: "review_required",
+    sitemapPolicy: "include_after_audit",
+    schemaPolicy: expected.policies.schemaPolicy === "faq_allowed" && issueCodes.includes("SCHEMA_MODE_MISMATCH")
+      ? "article_only"
+      : expected.policies.schemaPolicy,
+    internalLinkPolicy: "deemphasized",
+    requiredAction: action,
+    ...(action === "degrade" ? { degradationActions: ["apply_noindex", "remove_from_sitemap", "hide_from_recent", "create_fix_task"] } : {}),
+  };
+}
+
+function buildIssues(checks: PostPublishAuditCheckV0[], revisionId: string): ValidationIssue[] {
+  return checks.flatMap((check) => {
+    if (!check.issueCode) return [];
+    const definition = getIssueDefinition(check.issueCode);
+    return [{
+      issueCode: check.issueCode,
+      severity: definition.defaultSeverity,
+      fieldPath: `postPublishAudit.checks.${check.name}`,
+      message: check.message,
+      suggestedAction: definition.defaultRequiredAction,
+      blocking: definition.defaultSeverity === "P0",
+      candidateRevisionId: revisionId,
+    }];
+  });
+}
+
+export function buildPostPublishAudit(input: BuildPostPublishAuditInput): PostPublishAuditArtifactV0 {
+  const checks = buildChecks(input);
+  const issueCodes = uniqueIssueCodes(checks);
+  const fetchFailed = issueCodes.includes("PUBLIC_HTML_FETCH_FAILED");
+  const auditOutcome = issueCodes.length === 0
+    ? "published_and_audit_passed"
+    : fetchFailed
+      ? "publish_failed"
+      : "published_but_audit_failed";
+  const action = recommendedAction(issueCodes);
+
+  return {
+    artifactVersion: POST_PUBLISH_AUDIT_VERSION,
+    artifactType: "post_publish_audit",
+    artifactId: input.artifactId,
+    createdAt: input.checkedAt,
+    checkedAt: input.checkedAt,
+    puzzleId: input.expected.puzzleId,
+    canonicalUrl: input.expected.canonicalUrl,
+    revisionId: input.expected.revisionId,
+    contentMode: input.expected.contentMode,
+    fetchedUrl: input.observed.fetchedUrl,
+    ...(input.observed.httpStatus !== undefined ? { httpStatus: input.observed.httpStatus } : {}),
+    auditOutcome,
+    issueCodes,
+    issues: buildIssues(checks, input.expected.revisionId),
+    checks,
+    recommendedPolicies: recommendedPolicies(issueCodes, input.expected),
+    recommendedAction: action,
+    safety: {
+      rawRenderedHtmlIncluded: false,
+      publicFetchPerformedByContract: false,
+      publishAllowed: false,
+    },
+  };
+}

--- a/lib/puzzles/content-kitchen/types.ts
+++ b/lib/puzzles/content-kitchen/types.ts
@@ -60,7 +60,15 @@ export type ContentKitchenIssueCode =
   | "ANSWER_FIRST_OVER_SLA"
   | "ANSWER_FIRST_REVIEW_REQUIRED"
   | "INDEXED_ANSWER_FIRST_STALE"
-  | "ANSWER_FIRST_HIGH_PRIORITY_ALERT";
+  | "ANSWER_FIRST_HIGH_PRIORITY_ALERT"
+  | "PUBLIC_HTML_FETCH_FAILED"
+  | "PUBLIC_HTML_RENDER_FAILED"
+  | "SITEMAP_LASTMOD_MISSING"
+  | "SCHEMA_DATE_MODIFIED_MISSING"
+  | "SITEMAP_POLICY_MISMATCH"
+  | "ROBOTS_POLICY_MISMATCH"
+  | "DATE_MODIFIED_MISMATCH"
+  | "SCHEMA_MODE_MISMATCH";
 
 export type Pr6aIssueCode = ContentKitchenIssueCode;
 
@@ -919,6 +927,94 @@ export type ReviewUiInputV0 = {
     rawRenderedHtmlIncluded: false;
     modelPromptIncluded: false;
     secretsIncluded: false;
+    publishAllowed: false;
+  };
+};
+
+export type PostPublishAuditOutcome =
+  | "publish_failed"
+  | "published_but_audit_failed"
+  | "published_and_audit_passed";
+
+export type PostPublishAuditCheckName =
+  | "public_fetch"
+  | "public_render"
+  | "answer_visible"
+  | "all_clues_visible"
+  | "canonical_matches"
+  | "robots_policy_matches"
+  | "sitemap_policy_matches"
+  | "sitemap_lastmod_matches"
+  | "schema_date_modified_matches"
+  | "schema_mode_matches"
+  | "internal_links_valid";
+
+export type PostPublishAuditCheckStatus =
+  | "pass"
+  | "fail"
+  | "not_checked";
+
+export type PostPublishAuditCheckV0 = {
+  name: PostPublishAuditCheckName;
+  status: PostPublishAuditCheckStatus;
+  message: string;
+  issueCode?: ContentKitchenIssueCode;
+  severity?: ContentKitchenIssueSeverity;
+  expected?: string;
+  observed?: string;
+};
+
+export type PostPublishAuditExpectedStateV0 = {
+  puzzleId: string;
+  canonicalUrl: string;
+  revisionId: string;
+  contentMode: ContentMode;
+  answer: string;
+  clues: string[];
+  policies: ValidationPolicies;
+  schemaTypes?: string[];
+  sitemapLastmod?: string;
+  schemaDateModified?: string;
+  expectedInternalLinks?: string[];
+};
+
+export type PostPublishAuditObservedStateV0 = {
+  fetchedUrl: string;
+  httpStatus?: number;
+  fetchOk: boolean;
+  renderOk: boolean;
+  answerVisible?: boolean;
+  visibleClues?: string[];
+  canonicalUrl?: string;
+  noindexPresent?: boolean;
+  sitemapIncluded?: boolean;
+  sitemapLastmod?: string;
+  schemaTypes?: string[];
+  schemaDateModified?: string;
+  internalLinks?: string[];
+};
+
+export type PostPublishAuditArtifactV0 = {
+  artifactVersion: "content-kitchen-post-publish-audit-v0";
+  artifactType: "post_publish_audit";
+  artifactId: string;
+  createdAt: string;
+  checkedAt: string;
+  puzzleId: string;
+  canonicalUrl: string;
+  revisionId: string;
+  contentMode: ContentMode;
+  fetchedUrl: string;
+  httpStatus?: number;
+  auditOutcome: PostPublishAuditOutcome;
+  issueCodes: ContentKitchenIssueCode[];
+  issues: ValidationIssue[];
+  checks: PostPublishAuditCheckV0[];
+  recommendedPolicies: ValidationPolicies;
+  recommendedAction: RequiredAction;
+  safety: {
+    rawRenderedHtmlIncluded: false;
+    publicFetchPerformedByContract: false;
     publishAllowed: false;
   };
 };

--- a/scripts/check-content-kitchen-contract.ts
+++ b/scripts/check-content-kitchen-contract.ts
@@ -49,9 +49,14 @@ import { generateFullAnalysisReasoning } from "../lib/puzzles/content-kitchen/re
 import {
   CONTENT_KITCHEN_ISSUE_REGISTRY,
   getIssueDefinition,
+  getPr11IssueCodes,
   getPr6P0IssueCodes,
   getPr7IssueCodes,
 } from "../lib/puzzles/content-kitchen/issue-registry";
+import {
+  POST_PUBLISH_AUDIT_VERSION,
+  buildPostPublishAudit,
+} from "../lib/puzzles/content-kitchen/post-publish-audit";
 import { buildReviewArtifactV0, shouldCreateReviewArtifact } from "../lib/puzzles/content-kitchen/review-artifact";
 import {
   REVIEW_DECISION_EFFECT_PLAN_VERSION,
@@ -97,6 +102,7 @@ import type {
   L1PuzzleInput,
   ReviewArtifactV0,
   ReviewDecisionV0,
+  PostPublishAuditExpectedStateV0,
   ValidateCandidateInput,
   ValidationOutcome,
   ValidationPolicies,
@@ -116,6 +122,11 @@ const PR10_REVIEW_ROUTING_DECISION_DOC_PATH = resolve(
   ROOT,
   "docs",
   "pinpoint-content-kitchen-pr10-review-routing-decision-2026-05-24.md",
+);
+const PR11_POST_PUBLISH_AUDIT_DOC_PATH = resolve(
+  ROOT,
+  "docs",
+  "pinpoint-content-kitchen-pr11-post-publish-audit-contract-2026-05-24.md",
 );
 
 type Fixture = {
@@ -3567,6 +3578,55 @@ async function assertReviewRoutingDecisionDoc() {
   }
 }
 
+async function assertPostPublishAuditDoc() {
+  const doc = await readFile(PR11_POST_PUBLISH_AUDIT_DOC_PATH, "utf8");
+  const requiredSnippets = [
+    "PR11 Post-Publish Audit Contract",
+    "artifactVersion: \"content-kitchen-post-publish-audit-v0\"",
+    "artifactType: \"post_publish_audit\"",
+    "`publish_failed`: public fetch failed or returned a bad status",
+    "`published_but_audit_failed`: public page exists, but one or more audit checks failed",
+    "`published_and_audit_passed`: all checked facts match the expected published state",
+    "`public_fetch`",
+    "`public_render`",
+    "`answer_visible`",
+    "`all_clues_visible`",
+    "`canonical_matches`",
+    "`robots_policy_matches`",
+    "`sitemap_policy_matches`",
+    "`sitemap_lastmod_matches`",
+    "`schema_date_modified_matches`",
+    "`schema_mode_matches`",
+    "`internal_links_valid`",
+    "`PUBLIC_HTML_FETCH_FAILED`",
+    "`PUBLIC_HTML_RENDER_FAILED`",
+    "`SITEMAP_LASTMOD_MISSING`",
+    "`SCHEMA_DATE_MODIFIED_MISSING`",
+    "`SITEMAP_POLICY_MISMATCH`",
+    "`ROBOTS_POLICY_MISMATCH`",
+    "`DATE_MODIFIED_MISMATCH`",
+    "`SCHEMA_MODE_MISMATCH`",
+    "`ANSWER_HIDDEN_FROM_RENDERED_HTML`",
+    "`MISSING_CLUE_ROW`",
+    "`CANONICAL_URL_MISMATCH`",
+    "`INTERNAL_LINK_BROKEN`",
+    "`recommendedAction` becomes `rollback`",
+    "`recommendedAction` becomes `create_fix_task` by default",
+    "sitemap or robots policy mismatch can recommend `degrade`",
+    "`safety.rawRenderedHtmlIncluded: false`",
+    "`safety.publicFetchPerformedByContract: false`",
+    "`safety.publishAllowed: false`",
+    "it does not fetch public URLs",
+    "it does not run a browser",
+    "it does not send Feishu messages",
+    "it does not publish content",
+  ];
+
+  for (const snippet of requiredSnippets) {
+    assert.ok(doc.includes(snippet), `PR11 post-publish audit doc should include: ${snippet}`);
+  }
+}
+
 async function assertReviewDecisionExamplesAndRunner() {
   const pairs = [
     ["review-decision-auto-approve", "auto_approve", "approved", false],
@@ -3938,6 +3998,228 @@ async function assertReviewDecisionExamplesAndRunner() {
   );
 }
 
+function makePostPublishExpectedState(
+  overrides: Partial<PostPublishAuditExpectedStateV0> = {},
+): PostPublishAuditExpectedStateV0 {
+  return {
+    puzzleId: "pinpoint-925-2026-05-24",
+    canonicalUrl: "https://example.com/linkedin-pinpoint-answers/pinpoint-answer-925/",
+    revisionId: "rev-full-analysis-925",
+    contentMode: "full-analysis",
+    answer: "BASS",
+    clues: ["Low instrument", "Fishing target", "Deep voice", "Speaker setting", "Music section"],
+    policies: {
+      indexPolicy: "index",
+      sitemapPolicy: "include",
+      schemaPolicy: "faq_allowed",
+      internalLinkPolicy: "normal",
+      requiredAction: "none",
+    },
+    schemaTypes: ["Article", "FAQPage"],
+    sitemapLastmod: "2026-05-24",
+    schemaDateModified: "2026-05-24",
+    expectedInternalLinks: ["/linkedin-pinpoint-answers/pinpoint-answer-924/"],
+    ...overrides,
+  };
+}
+
+function assertPostPublishAuditContract() {
+  const pr11IssueCodes = getPr11IssueCodes();
+  assert.deepEqual(
+    pr11IssueCodes,
+    [
+      "PUBLIC_HTML_FETCH_FAILED",
+      "PUBLIC_HTML_RENDER_FAILED",
+      "SITEMAP_LASTMOD_MISSING",
+      "SCHEMA_DATE_MODIFIED_MISSING",
+      "SITEMAP_POLICY_MISMATCH",
+      "ROBOTS_POLICY_MISMATCH",
+      "DATE_MODIFIED_MISMATCH",
+      "SCHEMA_MODE_MISMATCH",
+    ],
+    "PR11 issue code ownership should be explicit",
+  );
+  for (const issueCode of pr11IssueCodes) {
+    assert.equal(getIssueDefinition(issueCode).phaseOwner, "PR11", `${issueCode}: issue owner should be PR11`);
+  }
+
+  const expected = makePostPublishExpectedState();
+  const passedAudit = buildPostPublishAudit({
+    artifactId: "art_post_publish_audit_passed",
+    checkedAt: "2026-05-24T10:00:00.000Z",
+    expected,
+    observed: {
+      fetchedUrl: expected.canonicalUrl,
+      httpStatus: 200,
+      fetchOk: true,
+      renderOk: true,
+      answerVisible: true,
+      visibleClues: [...expected.clues],
+      canonicalUrl: expected.canonicalUrl,
+      noindexPresent: false,
+      sitemapIncluded: true,
+      sitemapLastmod: "2026-05-24",
+      schemaTypes: ["Article", "FAQPage"],
+      schemaDateModified: "2026-05-24",
+      internalLinks: ["/linkedin-pinpoint-answers/pinpoint-answer-924/"],
+    },
+  });
+  assert.equal(
+    passedAudit.artifactVersion,
+    POST_PUBLISH_AUDIT_VERSION,
+    "post-publish audit artifact version should be stable",
+  );
+  assert.equal(passedAudit.artifactType, "post_publish_audit", "post-publish audit artifact type should be stable");
+  assert.equal(
+    passedAudit.auditOutcome,
+    "published_and_audit_passed",
+    "clean observed state should pass post-publish audit",
+  );
+  assert.deepEqual(passedAudit.issueCodes, [], "clean post-publish audit should have no issue codes");
+  assert.equal(passedAudit.recommendedAction, "none", "clean post-publish audit should require no action");
+  assert.deepEqual(
+    passedAudit.recommendedPolicies,
+    expected.policies,
+    "clean post-publish audit should preserve expected policies",
+  );
+  assert.equal(
+    passedAudit.safety.rawRenderedHtmlIncluded,
+    false,
+    "post-publish audit artifact should not include raw rendered HTML",
+  );
+  assert.equal(
+    passedAudit.safety.publicFetchPerformedByContract,
+    false,
+    "PR11.1 audit contract should not fetch public URLs itself",
+  );
+  assert.equal(passedAudit.safety.publishAllowed, false, "post-publish audit must not publish content");
+  assert.ok(
+    passedAudit.checks.every((check) => check.status === "pass" || check.status === "not_checked"),
+    "clean audit checks should pass or be explicitly skipped",
+  );
+  assert.ok(
+    !JSON.stringify(passedAudit).includes("<main"),
+    "post-publish audit artifact should not include raw HTML",
+  );
+
+  const fetchFailedAudit = buildPostPublishAudit({
+    artifactId: "art_post_publish_audit_fetch_failed",
+    checkedAt: "2026-05-24T10:05:00.000Z",
+    expected,
+    observed: {
+      fetchedUrl: expected.canonicalUrl,
+      httpStatus: 500,
+      fetchOk: false,
+      renderOk: false,
+    },
+  });
+  assert.equal(fetchFailedAudit.auditOutcome, "publish_failed", "bad public fetch should be publish_failed");
+  assert.deepEqual(
+    fetchFailedAudit.issueCodes,
+    ["PUBLIC_HTML_FETCH_FAILED"],
+    "bad public fetch should create the fetch failure issue only",
+  );
+  assert.equal(fetchFailedAudit.recommendedAction, "rollback", "P0 post-publish failures should request rollback");
+  assert.equal(
+    fetchFailedAudit.recommendedPolicies.sitemapPolicy,
+    "remove_on_next_build",
+    "P0 post-publish failures should recommend sitemap removal",
+  );
+  assert.equal(
+    fetchFailedAudit.issues[0]?.blocking,
+    true,
+    "P0 post-publish audit issue should be blocking",
+  );
+  assert.equal(
+    fetchFailedAudit.checks.find((check) => check.name === "answer_visible")?.status,
+    "not_checked",
+    "render-only checks should be skipped when fetch fails",
+  );
+
+  const answerFirstExpected = makePostPublishExpectedState({
+    contentMode: "answer-first",
+    revisionId: "rev-answer-first-925",
+    policies: {
+      indexPolicy: "noindex",
+      sitemapPolicy: "exclude",
+      schemaPolicy: "none",
+      internalLinkPolicy: "hidden_from_recent",
+      requiredAction: "enrich",
+    },
+    schemaTypes: [],
+    schemaDateModified: undefined,
+    sitemapLastmod: undefined,
+    expectedInternalLinks: [],
+  });
+  const policyMismatchAudit = buildPostPublishAudit({
+    artifactId: "art_post_publish_audit_policy_mismatch",
+    checkedAt: "2026-05-24T10:10:00.000Z",
+    expected: answerFirstExpected,
+    observed: {
+      fetchedUrl: answerFirstExpected.canonicalUrl,
+      httpStatus: 200,
+      fetchOk: true,
+      renderOk: true,
+      answerVisible: true,
+      visibleClues: [...answerFirstExpected.clues],
+      canonicalUrl: answerFirstExpected.canonicalUrl,
+      noindexPresent: true,
+      sitemapIncluded: true,
+    },
+  });
+  assert.equal(
+    policyMismatchAudit.auditOutcome,
+    "published_but_audit_failed",
+    "non-P0 audit failure should keep page published but failed",
+  );
+  assert.deepEqual(
+    policyMismatchAudit.issueCodes,
+    ["SITEMAP_POLICY_MISMATCH"],
+    "answer-first sitemap mismatch should be captured separately",
+  );
+  assert.equal(policyMismatchAudit.recommendedAction, "degrade", "policy mismatch should recommend degrade");
+  assert.deepEqual(
+    policyMismatchAudit.recommendedPolicies.degradationActions,
+    ["apply_noindex", "remove_from_sitemap", "hide_from_recent", "create_fix_task"],
+    "degrade audit policy should name exact degradation actions",
+  );
+  assert.equal(
+    policyMismatchAudit.issues[0]?.blocking,
+    false,
+    "P1 post-publish audit issue should not be blocking",
+  );
+
+  const schemaMissingAudit = buildPostPublishAudit({
+    artifactId: "art_post_publish_audit_schema_missing",
+    checkedAt: "2026-05-24T10:15:00.000Z",
+    expected,
+    observed: {
+      fetchedUrl: expected.canonicalUrl,
+      httpStatus: 200,
+      fetchOk: true,
+      renderOk: true,
+      answerVisible: true,
+      visibleClues: [...expected.clues],
+      canonicalUrl: expected.canonicalUrl,
+      noindexPresent: false,
+      sitemapIncluded: true,
+      sitemapLastmod: "2026-05-24",
+      schemaTypes: ["Article", "FAQPage"],
+      internalLinks: ["/linkedin-pinpoint-answers/pinpoint-answer-924/"],
+    },
+  });
+  assert.equal(
+    schemaMissingAudit.issueCodes.includes("SCHEMA_DATE_MODIFIED_MISSING"),
+    true,
+    "missing schema dateModified should be a PR11 issue",
+  );
+  assert.equal(
+    schemaMissingAudit.recommendedAction,
+    "create_fix_task",
+    "missing schema dateModified should create a fix task",
+  );
+}
+
 async function main() {
   const fileNames = (await readdir(FIXTURE_DIR)).filter((fileName) => fileName.endsWith(".json")).sort();
   assert.ok(fileNames.length >= 6, "content kitchen should have at least 6 fixtures");
@@ -3986,7 +4268,9 @@ async function main() {
   await assertAnswerFirstEnrichmentWorkerHealthStatuses();
   await assertAnswerFirstEnrichmentDryRunUsageDoc();
   await assertReviewRoutingDecisionDoc();
+  await assertPostPublishAuditDoc();
   await assertReviewDecisionExamplesAndRunner();
+  assertPostPublishAuditContract();
   console.log(`content-kitchen contract fixtures passed (${fileNames.length} fixtures)`);
 }
 


### PR DESCRIPTION
## Summary
- add PR11 post-publish audit artifact and check contract
- register PR11 issue codes for public fetch/render, sitemap/schema, robots, and date mismatch failures
- document PR11.1 local-only boundaries and add contract tests

## Verification
- npm run test:content-kitchen
- npm run typecheck
- npm run lint
- npm run build