### PR TITLE
[codex] Add PR11 post-publish audit runner

### DIFF
--- a/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
+++ b/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
@@ -2356,6 +2356,17 @@ PR11 first implementation slice:
 - mark audit artifacts with `rawRenderedHtmlIncluded: false`, `publicFetchPerformedByContract: false`, and `publishAllowed: false`
 - keep this local-only; do not fetch public URLs, run a browser, read sitemap files, read production storage, write review queue storage, send Feishu messages, publish content, or run Worker cron yet
 
+PR11 second implementation slice:
+
+- add a local post-publish audit runner command
+- read `content-kitchen-post-publish-audit-runner-input-v0` JSON from `--input`
+- write `content-kitchen-post-publish-audit-v0` artifact JSON to `--output` when provided
+- keep the output file as the audit artifact itself, not a production storage record
+- reject unsafe paths where `--output` equals `--input`
+- add example inputs for a passing full-analysis audit and an answer-first sitemap policy mismatch
+- reject raw rendered HTML, model prompts, and obvious secrets in the runner input
+- keep this local-only; do not fetch public URLs, run a browser, read sitemap files, read production storage, write review queue storage, send Feishu messages, publish content, or run Worker cron yet
+
 
 ## Review UI Requirements
 

--- a/docs/pinpoint-content-kitchen-pr11-post-publish-audit-contract-2026-05-24.md
+++ b/docs/pinpoint-content-kitchen-pr11-post-publish-audit-contract-2026-05-24.md
@@ -125,3 +125,39 @@ The content-kitchen contract test proves:
 - PR11 issue codes are registered with `phaseOwner: "PR11"`
 - audit artifacts do not include raw rendered HTML
 - PR11.1 does not fetch public URLs itself
+
+## Local Runner
+
+PR11.2 adds a local runner.
+
+Input uses `content-kitchen-post-publish-audit-runner-input-v0`.
+
+Runner result uses `content-kitchen-post-publish-audit-runner-result-v0`.
+
+Run it with:
+
+```bash
+npm run content-kitchen:post-publish-audit -- \
+  --input lib/puzzles/content-kitchen/examples/post-publish-audit-pass.input.example.json \
+  --output /tmp/content-kitchen-post-publish-audit.json \
+  --pretty
+```
+
+The output file is the audit artifact itself.
+
+Example inputs:
+
+- `post-publish-audit-pass.input.example.json`
+- `post-publish-audit-policy-mismatch.input.example.json`
+
+Runner rules:
+
+- `--input` is required
+- `--output` is optional
+- `--output` must not equal `--input`
+- the runner rejects raw rendered HTML, model prompts, and obvious secrets in the input file
+- the runner does not fetch public URLs
+- the runner does not run a browser
+- the runner does not send Feishu messages
+- the runner does not write review queue storage
+- the runner does not publish content

--- a/lib/puzzles/content-kitchen/examples/post-publish-audit-pass.input.example.json
+++ b/lib/puzzles/content-kitchen/examples/post-publish-audit-pass.input.example.json
@@ -1,0 +1,51 @@
+{
+  "schemaVersion": "content-kitchen-post-publish-audit-runner-input-v0",
+  "artifactId": "art_post_publish_audit_pass_example",
+  "checkedAt": "2026-05-24T10:00:00.000Z",
+  "expected": {
+    "puzzleId": "pinpoint-925-2026-05-24",
+    "canonicalUrl": "https://example.com/linkedin-pinpoint-answers/pinpoint-answer-925/",
+    "revisionId": "rev-full-analysis-925",
+    "contentMode": "full-analysis",
+    "answer": "BASS",
+    "clues": [
+      "Low instrument",
+      "Fishing target",
+      "Deep voice",
+      "Speaker setting",
+      "Music section"
+    ],
+    "policies": {
+      "indexPolicy": "index",
+      "sitemapPolicy": "include",
+      "schemaPolicy": "faq_allowed",
+      "internalLinkPolicy": "normal",
+      "requiredAction": "none"
+    },
+    "schemaTypes": ["Article", "FAQPage"],
+    "sitemapLastmod": "2026-05-24",
+    "schemaDateModified": "2026-05-24",
+    "expectedInternalLinks": ["/linkedin-pinpoint-answers/pinpoint-answer-924/"]
+  },
+  "observed": {
+    "fetchedUrl": "https://example.com/linkedin-pinpoint-answers/pinpoint-answer-925/",
+    "httpStatus": 200,
+    "fetchOk": true,
+    "renderOk": true,
+    "answerVisible": true,
+    "visibleClues": [
+      "Low instrument",
+      "Fishing target",
+      "Deep voice",
+      "Speaker setting",
+      "Music section"
+    ],
+    "canonicalUrl": "https://example.com/linkedin-pinpoint-answers/pinpoint-answer-925/",
+    "noindexPresent": false,
+    "sitemapIncluded": true,
+    "sitemapLastmod": "2026-05-24",
+    "schemaTypes": ["Article", "FAQPage"],
+    "schemaDateModified": "2026-05-24",
+    "internalLinks": ["/linkedin-pinpoint-answers/pinpoint-answer-924/"]
+  }
+}

--- a/lib/puzzles/content-kitchen/examples/post-publish-audit-policy-mismatch.input.example.json
+++ b/lib/puzzles/content-kitchen/examples/post-publish-audit-policy-mismatch.input.example.json
@@ -1,0 +1,43 @@
+{
+  "schemaVersion": "content-kitchen-post-publish-audit-runner-input-v0",
+  "artifactId": "art_post_publish_audit_policy_mismatch_example",
+  "checkedAt": "2026-05-24T10:10:00.000Z",
+  "expected": {
+    "puzzleId": "pinpoint-925-2026-05-24",
+    "canonicalUrl": "https://example.com/linkedin-pinpoint-answers/pinpoint-answer-925/",
+    "revisionId": "rev-answer-first-925",
+    "contentMode": "answer-first",
+    "answer": "BASS",
+    "clues": [
+      "Low instrument",
+      "Fishing target",
+      "Deep voice",
+      "Speaker setting",
+      "Music section"
+    ],
+    "policies": {
+      "indexPolicy": "noindex",
+      "sitemapPolicy": "exclude",
+      "schemaPolicy": "none",
+      "internalLinkPolicy": "hidden_from_recent",
+      "requiredAction": "enrich"
+    }
+  },
+  "observed": {
+    "fetchedUrl": "https://example.com/linkedin-pinpoint-answers/pinpoint-answer-925/",
+    "httpStatus": 200,
+    "fetchOk": true,
+    "renderOk": true,
+    "answerVisible": true,
+    "visibleClues": [
+      "Low instrument",
+      "Fishing target",
+      "Deep voice",
+      "Speaker setting",
+      "Music section"
+    ],
+    "canonicalUrl": "https://example.com/linkedin-pinpoint-answers/pinpoint-answer-925/",
+    "noindexPresent": true,
+    "sitemapIncluded": true
+  }
+}

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "gsc:pinpoint": "node scripts/gsc-pinpoint.mjs",
     "content-kitchen:enrichment-dry-run": "tsx scripts/run-content-kitchen-enrichment-worker-dry-run.ts",
     "content-kitchen:review-decision": "tsx scripts/run-content-kitchen-review-decision.ts",
+    "content-kitchen:post-publish-audit": "tsx scripts/run-content-kitchen-post-publish-audit.ts",
     "test:pinpoint-seo": "tsx scripts/check-pinpoint-seo-builders.ts",
     "test:content-kitchen": "tsx scripts/check-content-kitchen-contract.ts",
     "test:pinpoint-routing": "tsx scripts/check-routing-regressions.ts",

--- a/scripts/check-content-kitchen-contract.ts
+++ b/scripts/check-content-kitchen-contract.ts
@@ -91,6 +91,13 @@ import {
   runContentKitchenReviewDecisionFromFiles,
 } from "./run-content-kitchen-review-decision";
 import {
+  POST_PUBLISH_AUDIT_RUNNER_INPUT_VERSION,
+  POST_PUBLISH_AUDIT_RUNNER_RESULT_VERSION,
+  parsePostPublishAuditRunnerInput,
+  runCli as runContentKitchenPostPublishAuditCli,
+  runContentKitchenPostPublishAuditFromFile,
+} from "./run-content-kitchen-post-publish-audit";
+import {
   REVIEW_UI_SURFACE_VERSION,
   renderReviewUiInputHtml,
 } from "./content-kitchen-review-ui-surface";
@@ -3620,6 +3627,16 @@ async function assertPostPublishAuditDoc() {
     "it does not run a browser",
     "it does not send Feishu messages",
     "it does not publish content",
+    "Local Runner",
+    "content-kitchen-post-publish-audit-runner-input-v0",
+    "content-kitchen-post-publish-audit-runner-result-v0",
+    "npm run content-kitchen:post-publish-audit",
+    "--input lib/puzzles/content-kitchen/examples/post-publish-audit-pass.input.example.json",
+    "--output /tmp/content-kitchen-post-publish-audit.json",
+    "`--output` must not equal `--input`",
+    "The output file is the audit artifact itself.",
+    "post-publish-audit-pass.input.example.json",
+    "post-publish-audit-policy-mismatch.input.example.json",
   ];
 
   for (const snippet of requiredSnippets) {
@@ -4220,6 +4237,124 @@ function assertPostPublishAuditContract() {
   );
 }
 
+async function assertPostPublishAuditRunnerAndExamples() {
+  const packageJson = JSON.parse(await readFile(PACKAGE_JSON_PATH, "utf8")) as {
+    scripts?: Record<string, string>;
+  };
+  assert.ok(
+    packageJson.scripts?.["content-kitchen:post-publish-audit"]?.includes(
+      "run-content-kitchen-post-publish-audit.ts",
+    ),
+    "package.json should expose the content-kitchen post-publish audit runner",
+  );
+
+  const passExamplePath = resolve(EXAMPLE_DIR, "post-publish-audit-pass.input.example.json");
+  const mismatchExamplePath = resolve(EXAMPLE_DIR, "post-publish-audit-policy-mismatch.input.example.json");
+  const passRaw = await readFile(passExamplePath, "utf8");
+  const parsedPassInput = parsePostPublishAuditRunnerInput(passRaw);
+  assert.equal(
+    parsedPassInput.schemaVersion,
+    POST_PUBLISH_AUDIT_RUNNER_INPUT_VERSION,
+    "post-publish audit runner input version should be stable",
+  );
+  assert.equal(parsedPassInput.expected.clues.length, 5, "post-publish audit example should include five clues");
+  assert.equal(
+    parsedPassInput.observed.fetchOk,
+    true,
+    "post-publish audit example should include fetch facts",
+  );
+
+  const tmpDir = await mkdtemp(resolve(tmpdir(), "content-kitchen-post-publish-audit-"));
+  try {
+    const outputPath = resolve(tmpDir, "post-publish-audit.json");
+    const passResult = await runContentKitchenPostPublishAuditFromFile({
+      inputPath: passExamplePath,
+      outputPath,
+    });
+    const writtenArtifact = JSON.parse(await readFile(outputPath, "utf8")) as {
+      artifactVersion: string;
+      artifactType: string;
+      auditOutcome: string;
+      issueCodes: string[];
+      safety: {
+        rawRenderedHtmlIncluded: boolean;
+        publicFetchPerformedByContract: boolean;
+        publishAllowed: boolean;
+      };
+    };
+
+    assert.equal(
+      passResult.schemaVersion,
+      POST_PUBLISH_AUDIT_RUNNER_RESULT_VERSION,
+      "post-publish audit runner result version should be stable",
+    );
+    assert.equal(passResult.dryRunOnly, true, "post-publish audit runner should stay dry-run only");
+    assert.equal(passResult.sourcePath, passExamplePath, "post-publish audit runner should record source path");
+    assert.equal(passResult.outputPath, outputPath, "post-publish audit runner should record output path");
+    assert.equal(
+      passResult.auditArtifact.auditOutcome,
+      "published_and_audit_passed",
+      "pass example should create passing audit artifact",
+    );
+    assert.equal(
+      writtenArtifact.artifactVersion,
+      POST_PUBLISH_AUDIT_VERSION,
+      "post-publish audit output file should be the audit artifact itself",
+    );
+    assert.equal(writtenArtifact.artifactType, "post_publish_audit", "post-publish audit output should be an artifact");
+    assert.equal(
+      writtenArtifact.auditOutcome,
+      "published_and_audit_passed",
+      "post-publish audit output should include audit outcome",
+    );
+    assert.deepEqual(writtenArtifact.issueCodes, [], "passing post-publish audit output should have no issues");
+    assert.equal(
+      writtenArtifact.safety.rawRenderedHtmlIncluded,
+      false,
+      "post-publish audit output should not include raw rendered HTML",
+    );
+    assert.equal(
+      writtenArtifact.safety.publicFetchPerformedByContract,
+      false,
+      "post-publish audit runner should not fetch public URLs itself",
+    );
+    assert.equal(writtenArtifact.safety.publishAllowed, false, "post-publish audit runner should not publish");
+
+    const mismatchResult = await runContentKitchenPostPublishAuditFromFile({
+      inputPath: mismatchExamplePath,
+    });
+    assert.equal(
+      mismatchResult.auditArtifact.auditOutcome,
+      "published_but_audit_failed",
+      "policy mismatch example should fail audit without marking fetch failed",
+    );
+    assert.deepEqual(
+      mismatchResult.auditArtifact.issueCodes,
+      ["SITEMAP_POLICY_MISMATCH"],
+      "policy mismatch example should expose sitemap policy issue",
+    );
+    assert.equal(
+      mismatchResult.auditArtifact.recommendedAction,
+      "degrade",
+      "policy mismatch example should recommend degrade",
+    );
+
+    await assert.rejects(
+      () => runContentKitchenPostPublishAuditCli(["--input", passExamplePath, "--output", passExamplePath]),
+      /--output must be different from --input/,
+      "post-publish audit CLI should reject output paths that would overwrite input",
+    );
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+
+  assert.throws(
+    () => parsePostPublishAuditRunnerInput(passRaw.replace('"observed": {', '"rawRenderedHtml": "<main></main>", "observed": {')),
+    /must not include raw HTML, model prompts, or secrets/,
+    "post-publish audit parser should reject raw rendered HTML",
+  );
+}
+
 async function main() {
   const fileNames = (await readdir(FIXTURE_DIR)).filter((fileName) => fileName.endsWith(".json")).sort();
   assert.ok(fileNames.length >= 6, "content kitchen should have at least 6 fixtures");
@@ -4271,6 +4406,7 @@ async function main() {
   await assertPostPublishAuditDoc();
   await assertReviewDecisionExamplesAndRunner();
   assertPostPublishAuditContract();
+  await assertPostPublishAuditRunnerAndExamples();
   console.log(`content-kitchen contract fixtures passed (${fileNames.length} fixtures)`);
 }
 

--- a/scripts/run-content-kitchen-post-publish-audit.ts
+++ b/scripts/run-content-kitchen-post-publish-audit.ts
@@ -1,0 +1,362 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import {
+  buildPostPublishAudit,
+  type BuildPostPublishAuditInput,
+} from "../lib/puzzles/content-kitchen/post-publish-audit";
+import type {
+  ContentMode,
+  IndexPolicy,
+  InternalLinkPolicy,
+  PostPublishAuditArtifactV0,
+  PostPublishAuditExpectedStateV0,
+  PostPublishAuditObservedStateV0,
+  RequiredAction,
+  SchemaPolicy,
+  SitemapPolicy,
+  ValidationPolicies,
+} from "../lib/puzzles/content-kitchen/types";
+
+export const POST_PUBLISH_AUDIT_RUNNER_INPUT_VERSION =
+  "content-kitchen-post-publish-audit-runner-input-v0";
+export const POST_PUBLISH_AUDIT_RUNNER_RESULT_VERSION =
+  "content-kitchen-post-publish-audit-runner-result-v0";
+
+export type PostPublishAuditRunnerInput = {
+  schemaVersion?: typeof POST_PUBLISH_AUDIT_RUNNER_INPUT_VERSION;
+  artifactId: string;
+  checkedAt: string;
+  expected: PostPublishAuditExpectedStateV0;
+  observed: PostPublishAuditObservedStateV0;
+};
+
+export type ContentKitchenPostPublishAuditRunnerResult = {
+  schemaVersion: typeof POST_PUBLISH_AUDIT_RUNNER_RESULT_VERSION;
+  dryRunOnly: true;
+  sourcePath: string;
+  outputPath?: string;
+  auditArtifact: PostPublishAuditArtifactV0;
+};
+
+type ParsedArgs = {
+  inputPath: string;
+  outputPath?: string;
+  pretty: boolean;
+};
+
+function readArgValue(argv: string[], index: number, name: string): string {
+  const value = argv[index + 1];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${name} requires a value`);
+  }
+
+  return value;
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
+  let inputPath = "";
+  let outputPath: string | undefined;
+  let pretty = true;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--input") {
+      inputPath = resolve(readArgValue(argv, index, "--input"));
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--output") {
+      outputPath = resolve(readArgValue(argv, index, "--output"));
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--compact") {
+      pretty = false;
+      continue;
+    }
+
+    if (arg === "--pretty") {
+      pretty = true;
+      continue;
+    }
+
+    if (arg === "--help" || arg === "-h") {
+      throw new Error(
+        "Usage: npm run content-kitchen:post-publish-audit -- --input <path> [--output <path>] [--pretty|--compact]",
+      );
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  if (!inputPath) {
+    throw new Error("Missing required --input <path>");
+  }
+  if (outputPath === inputPath) {
+    throw new Error("--output must be different from --input");
+  }
+
+  return {
+    inputPath,
+    outputPath,
+    pretty,
+  };
+}
+
+function requireObject(value: unknown, fieldPath: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${fieldPath} must be an object`);
+  }
+
+  return value as Record<string, unknown>;
+}
+
+function requireText(record: Record<string, unknown>, key: string, fieldPath: string): string {
+  const value = record[key];
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`${fieldPath}.${key} must be a non-empty string`);
+  }
+
+  return value;
+}
+
+function optionalText(record: Record<string, unknown>, key: string, fieldPath: string): string | undefined {
+  const value = record[key];
+  if (value === undefined) return undefined;
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`${fieldPath}.${key} must be a non-empty string`);
+  }
+
+  return value;
+}
+
+function optionalNumber(record: Record<string, unknown>, key: string, fieldPath: string): number | undefined {
+  const value = record[key];
+  if (value === undefined) return undefined;
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new Error(`${fieldPath}.${key} must be a finite number`);
+  }
+
+  return value;
+}
+
+function optionalBoolean(record: Record<string, unknown>, key: string, fieldPath: string): boolean | undefined {
+  const value = record[key];
+  if (value === undefined) return undefined;
+  if (typeof value !== "boolean") {
+    throw new Error(`${fieldPath}.${key} must be a boolean`);
+  }
+
+  return value;
+}
+
+function requireBoolean(record: Record<string, unknown>, key: string, fieldPath: string): boolean {
+  const value = record[key];
+  if (typeof value !== "boolean") {
+    throw new Error(`${fieldPath}.${key} must be a boolean`);
+  }
+
+  return value;
+}
+
+function optionalTextArray(record: Record<string, unknown>, key: string, fieldPath: string): string[] | undefined {
+  const value = record[key];
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value) || value.some((item) => typeof item !== "string" || !item.trim())) {
+    throw new Error(`${fieldPath}.${key} must be an array of non-empty strings`);
+  }
+
+  return [...value];
+}
+
+function requireTextArray(record: Record<string, unknown>, key: string, fieldPath: string): string[] {
+  const value = optionalTextArray(record, key, fieldPath);
+  if (!value) {
+    throw new Error(`${fieldPath}.${key} must be an array of non-empty strings`);
+  }
+
+  return value;
+}
+
+function requireEnum<T extends string>(
+  record: Record<string, unknown>,
+  key: string,
+  fieldPath: string,
+  values: readonly T[],
+): T {
+  const value = record[key];
+  if (typeof value !== "string" || !values.includes(value as T)) {
+    throw new Error(`${fieldPath}.${key} must be one of: ${values.join(", ")}`);
+  }
+
+  return value as T;
+}
+
+function parsePolicies(value: unknown): ValidationPolicies {
+  const policies = requireObject(value, "expected.policies");
+  return {
+    indexPolicy: requireEnum<IndexPolicy>(policies, "indexPolicy", "expected.policies", [
+      "index",
+      "noindex",
+      "review_required",
+      "block_publish",
+    ]),
+    sitemapPolicy: requireEnum<SitemapPolicy>(policies, "sitemapPolicy", "expected.policies", [
+      "include",
+      "exclude",
+      "remove_on_next_build",
+      "include_after_audit",
+    ]),
+    schemaPolicy: requireEnum<SchemaPolicy>(policies, "schemaPolicy", "expected.policies", [
+      "none",
+      "article_only",
+      "faq_allowed",
+      "block_schema",
+    ]),
+    internalLinkPolicy: requireEnum<InternalLinkPolicy>(policies, "internalLinkPolicy", "expected.policies", [
+      "normal",
+      "deemphasized",
+      "hidden_from_recent",
+    ]),
+    requiredAction: requireEnum<RequiredAction>(policies, "requiredAction", "expected.policies", [
+      "none",
+      "enrich",
+      "review",
+      "block_publish",
+      "upgrade",
+      "rollback",
+      "degrade",
+      "create_fix_task",
+      "dead_letter",
+      "keep_current",
+    ]),
+  };
+}
+
+function parseExpected(value: unknown): PostPublishAuditExpectedStateV0 {
+  const expected = requireObject(value, "expected");
+  return {
+    puzzleId: requireText(expected, "puzzleId", "expected"),
+    canonicalUrl: requireText(expected, "canonicalUrl", "expected"),
+    revisionId: requireText(expected, "revisionId", "expected"),
+    contentMode: requireEnum<ContentMode>(expected, "contentMode", "expected", ["answer-first", "full-analysis"]),
+    answer: requireText(expected, "answer", "expected"),
+    clues: requireTextArray(expected, "clues", "expected"),
+    policies: parsePolicies(expected.policies),
+    ...(optionalTextArray(expected, "schemaTypes", "expected") ? { schemaTypes: optionalTextArray(expected, "schemaTypes", "expected") } : {}),
+    ...(optionalText(expected, "sitemapLastmod", "expected") ? { sitemapLastmod: optionalText(expected, "sitemapLastmod", "expected") } : {}),
+    ...(optionalText(expected, "schemaDateModified", "expected") ? { schemaDateModified: optionalText(expected, "schemaDateModified", "expected") } : {}),
+    ...(optionalTextArray(expected, "expectedInternalLinks", "expected") ? { expectedInternalLinks: optionalTextArray(expected, "expectedInternalLinks", "expected") } : {}),
+  };
+}
+
+function parseObserved(value: unknown): PostPublishAuditObservedStateV0 {
+  const observed = requireObject(value, "observed");
+  return {
+    fetchedUrl: requireText(observed, "fetchedUrl", "observed"),
+    ...(optionalNumber(observed, "httpStatus", "observed") !== undefined ? { httpStatus: optionalNumber(observed, "httpStatus", "observed") } : {}),
+    fetchOk: requireBoolean(observed, "fetchOk", "observed"),
+    renderOk: requireBoolean(observed, "renderOk", "observed"),
+    ...(optionalBoolean(observed, "answerVisible", "observed") !== undefined ? { answerVisible: optionalBoolean(observed, "answerVisible", "observed") } : {}),
+    ...(optionalTextArray(observed, "visibleClues", "observed") ? { visibleClues: optionalTextArray(observed, "visibleClues", "observed") } : {}),
+    ...(optionalText(observed, "canonicalUrl", "observed") ? { canonicalUrl: optionalText(observed, "canonicalUrl", "observed") } : {}),
+    ...(optionalBoolean(observed, "noindexPresent", "observed") !== undefined ? { noindexPresent: optionalBoolean(observed, "noindexPresent", "observed") } : {}),
+    ...(optionalBoolean(observed, "sitemapIncluded", "observed") !== undefined ? { sitemapIncluded: optionalBoolean(observed, "sitemapIncluded", "observed") } : {}),
+    ...(optionalText(observed, "sitemapLastmod", "observed") ? { sitemapLastmod: optionalText(observed, "sitemapLastmod", "observed") } : {}),
+    ...(optionalTextArray(observed, "schemaTypes", "observed") ? { schemaTypes: optionalTextArray(observed, "schemaTypes", "observed") } : {}),
+    ...(optionalText(observed, "schemaDateModified", "observed") ? { schemaDateModified: optionalText(observed, "schemaDateModified", "observed") } : {}),
+    ...(optionalTextArray(observed, "internalLinks", "observed") ? { internalLinks: optionalTextArray(observed, "internalLinks", "observed") } : {}),
+  };
+}
+
+function rejectUnsafePayload(raw: string): void {
+  const unsafeSnippets = [
+    "rawRenderedHtml",
+    "renderedHtml",
+    "modelPrompt",
+    "<main",
+    "<html",
+    "<script",
+    "\"secret",
+    "\"secrets",
+    "\"apiKey",
+    "\"token",
+  ];
+  const lowerRaw = raw.toLowerCase();
+  const found = unsafeSnippets.find((snippet) => lowerRaw.includes(snippet.toLowerCase()));
+  if (found) {
+    throw new Error(`audit input must not include raw HTML, model prompts, or secrets (${found})`);
+  }
+}
+
+export function parsePostPublishAuditRunnerInput(raw: string): PostPublishAuditRunnerInput {
+  rejectUnsafePayload(raw);
+  const value = JSON.parse(raw) as unknown;
+  const record = requireObject(value, "input");
+  const schemaVersion = record.schemaVersion;
+  if (schemaVersion !== undefined && schemaVersion !== POST_PUBLISH_AUDIT_RUNNER_INPUT_VERSION) {
+    throw new Error(`schemaVersion must be ${POST_PUBLISH_AUDIT_RUNNER_INPUT_VERSION}`);
+  }
+  const checkedAt = requireText(record, "checkedAt", "input");
+  if (!Number.isFinite(Date.parse(checkedAt))) {
+    throw new Error("input.checkedAt must be a valid timestamp");
+  }
+
+  return {
+    ...(schemaVersion ? { schemaVersion: schemaVersion as typeof POST_PUBLISH_AUDIT_RUNNER_INPUT_VERSION } : {}),
+    artifactId: requireText(record, "artifactId", "input"),
+    checkedAt,
+    expected: parseExpected(record.expected),
+    observed: parseObserved(record.observed),
+  };
+}
+
+export function runContentKitchenPostPublishAuditJson(
+  input: PostPublishAuditRunnerInput,
+): PostPublishAuditArtifactV0 {
+  return buildPostPublishAudit(input as BuildPostPublishAuditInput);
+}
+
+export async function runContentKitchenPostPublishAuditFromFile(input: {
+  inputPath: string;
+  outputPath?: string;
+}): Promise<ContentKitchenPostPublishAuditRunnerResult> {
+  const inputPath = resolve(input.inputPath);
+  const outputPath = input.outputPath ? resolve(input.outputPath) : undefined;
+  if (outputPath === inputPath) {
+    throw new Error("--output must be different from --input");
+  }
+
+  const parsedInput = parsePostPublishAuditRunnerInput(await readFile(inputPath, "utf8"));
+  const auditArtifact = runContentKitchenPostPublishAuditJson(parsedInput);
+  const result: ContentKitchenPostPublishAuditRunnerResult = {
+    schemaVersion: POST_PUBLISH_AUDIT_RUNNER_RESULT_VERSION,
+    dryRunOnly: true,
+    sourcePath: inputPath,
+    ...(outputPath ? { outputPath } : {}),
+    auditArtifact,
+  };
+
+  if (outputPath) {
+    await mkdir(dirname(outputPath), { recursive: true });
+    await writeFile(outputPath, `${JSON.stringify(auditArtifact, null, 2)}\n`, "utf8");
+  }
+
+  return result;
+}
+
+export async function runCli(argv: string[] = process.argv.slice(2)): Promise<void> {
+  const args = parseArgs(argv);
+  const result = await runContentKitchenPostPublishAuditFromFile(args);
+  console.log(JSON.stringify(result, null, args.pretty ? 2 : 0));
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  runCli().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Summary
- add local post-publish audit runner command
- add pass and policy-mismatch example inputs
- write audit artifact JSON to --output with path and raw-HTML safety checks

## Verification
- npm run test:content-kitchen
- npm run typecheck
- npm run lint
- npm run content-kitchen:post-publish-audit -- --input lib/puzzles/content-kitchen/examples/post-publish-audit-policy-mismatch.input.example.json --output /tmp/content-kitchen-post-publish-audit.json --compact
- node output artifact sanity check
- npm run build