### PR TITLE
[codex] Add PR11 observed facts builder

### DIFF
--- a/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
+++ b/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
@@ -2367,6 +2367,17 @@ PR11 second implementation slice:
 - reject raw rendered HTML, model prompts, and obvious secrets in the runner input
 - keep this local-only; do not fetch public URLs, run a browser, read sitemap files, read production storage, write review queue storage, send Feishu messages, publish content, or run Worker cron yet
 
+PR11 third implementation slice:
+
+- add a local observed facts builder command
+- read `content-kitchen-post-publish-observed-facts-builder-input-v0` JSON from `--input`
+- read local `sources.htmlPath` and optional `sources.sitemapPath`
+- output `content-kitchen-post-publish-audit-runner-input-v0` JSON that can feed the PR11 audit runner
+- extract visible answer, visible L1 clues, canonical URL, robots noindex state, sitemap inclusion, sitemap `lastmod`, JSON-LD schema types, JSON-LD `dateModified`, and internal links
+- reject unsafe paths where `--output` equals `--input`, `sources.htmlPath`, or `sources.sitemapPath`
+- prove the output does not include raw rendered HTML
+- keep this local-only; do not fetch public URLs, run a browser, read production storage, write review queue storage, send Feishu messages, publish content, or run Worker cron yet
+
 
 ## Review UI Requirements
 

--- a/docs/pinpoint-content-kitchen-pr11-post-publish-audit-contract-2026-05-24.md
+++ b/docs/pinpoint-content-kitchen-pr11-post-publish-audit-contract-2026-05-24.md
@@ -161,3 +161,66 @@ Runner rules:
 - the runner does not send Feishu messages
 - the runner does not write review queue storage
 - the runner does not publish content
+
+## Observed Facts Builder
+
+PR11.3 adds a local observed facts builder.
+
+Input uses `content-kitchen-post-publish-observed-facts-builder-input-v0`.
+
+Builder result uses `content-kitchen-post-publish-observed-facts-builder-result-v0`.
+
+Run it with:
+
+```bash
+npm run content-kitchen:post-publish-observed-facts -- \
+  --input lib/puzzles/content-kitchen/examples/post-publish-observed-facts-pass.input.example.json \
+  --output /tmp/content-kitchen-post-publish-audit-input.json \
+  --pretty
+```
+
+The output file is audit runner input. It can be passed to:
+
+```bash
+npm run content-kitchen:post-publish-audit -- \
+  --input /tmp/content-kitchen-post-publish-audit-input.json \
+  --output /tmp/content-kitchen-post-publish-audit.json \
+  --pretty
+```
+
+Example files:
+
+- `post-publish-observed-facts-pass.input.example.json`
+- `post-publish-observed-facts-pass.html.example`
+- `post-publish-observed-facts-sitemap.xml.example`
+
+The builder reads local files only:
+
+- `sources.htmlPath`
+- `sources.sitemapPath` when provided
+
+It extracts:
+
+- public fetch status from the local builder input
+- visible answer
+- visible L1 clues
+- canonical URL
+- robots noindex state
+- sitemap inclusion and `lastmod`
+- JSON-LD schema types
+- JSON-LD `dateModified`
+- internal links
+
+Builder rules:
+
+- `--input` is required
+- `--output` is optional
+- `--output` must not equal `--input`
+- `--output` must not equal `sources.htmlPath`
+- `--output` must not equal `sources.sitemapPath`
+- output must not include raw HTML
+- the builder does not fetch public URLs
+- the builder does not run a browser
+- the builder does not send Feishu messages
+- the builder does not write review queue storage
+- the builder does not publish content

--- a/lib/puzzles/content-kitchen/examples/post-publish-observed-facts-pass.html.example
+++ b/lib/puzzles/content-kitchen/examples/post-publish-observed-facts-pass.html.example
@@ -1,0 +1,35 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <title>Pinpoint answer 925</title>
+  <link rel="canonical" href="https://example.com/linkedin-pinpoint-answers/pinpoint-answer-925/">
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Article",
+      "headline": "Pinpoint answer 925",
+      "dateModified": "2026-05-24"
+    }
+  </script>
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      "mainEntity": []
+    }
+  </script>
+</head>
+<body>
+  <main>
+    <h1>BASS</h1>
+    <ul>
+      <li>Low instrument</li>
+      <li>Fishing target</li>
+      <li>Deep voice</li>
+      <li>Speaker setting</li>
+      <li>Music section</li>
+    </ul>
+    <a href="/linkedin-pinpoint-answers/pinpoint-answer-924/">Previous puzzle</a>
+  </main>
+</body>
+</html>

--- a/lib/puzzles/content-kitchen/examples/post-publish-observed-facts-pass.input.example.json
+++ b/lib/puzzles/content-kitchen/examples/post-publish-observed-facts-pass.input.example.json
@@ -1,0 +1,36 @@
+{
+  "schemaVersion": "content-kitchen-post-publish-observed-facts-builder-input-v0",
+  "artifactId": "art_post_publish_observed_facts_pass_example",
+  "checkedAt": "2026-05-24T10:20:00.000Z",
+  "expected": {
+    "puzzleId": "pinpoint-925-2026-05-24",
+    "canonicalUrl": "https://example.com/linkedin-pinpoint-answers/pinpoint-answer-925/",
+    "revisionId": "rev-full-analysis-925",
+    "contentMode": "full-analysis",
+    "answer": "BASS",
+    "clues": [
+      "Low instrument",
+      "Fishing target",
+      "Deep voice",
+      "Speaker setting",
+      "Music section"
+    ],
+    "policies": {
+      "indexPolicy": "index",
+      "sitemapPolicy": "include",
+      "schemaPolicy": "faq_allowed",
+      "internalLinkPolicy": "normal",
+      "requiredAction": "none"
+    },
+    "schemaTypes": ["Article", "FAQPage"],
+    "sitemapLastmod": "2026-05-24",
+    "schemaDateModified": "2026-05-24",
+    "expectedInternalLinks": ["/linkedin-pinpoint-answers/pinpoint-answer-924/"]
+  },
+  "sources": {
+    "fetchedUrl": "https://example.com/linkedin-pinpoint-answers/pinpoint-answer-925/",
+    "httpStatus": 200,
+    "htmlPath": "post-publish-observed-facts-pass.html.example",
+    "sitemapPath": "post-publish-observed-facts-sitemap.xml.example"
+  }
+}

--- a/lib/puzzles/content-kitchen/examples/post-publish-observed-facts-sitemap.xml.example
+++ b/lib/puzzles/content-kitchen/examples/post-publish-observed-facts-sitemap.xml.example
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://example.com/linkedin-pinpoint-answers/pinpoint-answer-925/</loc>
+    <lastmod>2026-05-24</lastmod>
+  </url>
+</urlset>

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "content-kitchen:enrichment-dry-run": "tsx scripts/run-content-kitchen-enrichment-worker-dry-run.ts",
     "content-kitchen:review-decision": "tsx scripts/run-content-kitchen-review-decision.ts",
     "content-kitchen:post-publish-audit": "tsx scripts/run-content-kitchen-post-publish-audit.ts",
+    "content-kitchen:post-publish-observed-facts": "tsx scripts/run-content-kitchen-post-publish-observed-facts.ts",
     "test:pinpoint-seo": "tsx scripts/check-pinpoint-seo-builders.ts",
     "test:content-kitchen": "tsx scripts/check-content-kitchen-contract.ts",
     "test:pinpoint-routing": "tsx scripts/check-routing-regressions.ts",

--- a/scripts/check-content-kitchen-contract.ts
+++ b/scripts/check-content-kitchen-contract.ts
@@ -98,6 +98,12 @@ import {
   runContentKitchenPostPublishAuditFromFile,
 } from "./run-content-kitchen-post-publish-audit";
 import {
+  POST_PUBLISH_OBSERVED_FACTS_BUILDER_INPUT_VERSION,
+  POST_PUBLISH_OBSERVED_FACTS_BUILDER_RESULT_VERSION,
+  runCli as runContentKitchenPostPublishObservedFactsCli,
+  runContentKitchenPostPublishObservedFactsFromFile,
+} from "./run-content-kitchen-post-publish-observed-facts";
+import {
   REVIEW_UI_SURFACE_VERSION,
   renderReviewUiInputHtml,
 } from "./content-kitchen-review-ui-surface";
@@ -3637,6 +3643,20 @@ async function assertPostPublishAuditDoc() {
     "The output file is the audit artifact itself.",
     "post-publish-audit-pass.input.example.json",
     "post-publish-audit-policy-mismatch.input.example.json",
+    "Observed Facts Builder",
+    "content-kitchen-post-publish-observed-facts-builder-input-v0",
+    "content-kitchen-post-publish-observed-facts-builder-result-v0",
+    "npm run content-kitchen:post-publish-observed-facts",
+    "--input lib/puzzles/content-kitchen/examples/post-publish-observed-facts-pass.input.example.json",
+    "--output /tmp/content-kitchen-post-publish-audit-input.json",
+    "post-publish-observed-facts-pass.input.example.json",
+    "post-publish-observed-facts-pass.html.example",
+    "post-publish-observed-facts-sitemap.xml.example",
+    "`sources.htmlPath`",
+    "`sources.sitemapPath`",
+    "`--output` must not equal `sources.htmlPath`",
+    "`--output` must not equal `sources.sitemapPath`",
+    "output must not include raw HTML",
   ];
 
   for (const snippet of requiredSnippets) {
@@ -4355,6 +4375,144 @@ async function assertPostPublishAuditRunnerAndExamples() {
   );
 }
 
+async function assertPostPublishObservedFactsBuilderAndExamples() {
+  const packageJson = JSON.parse(await readFile(PACKAGE_JSON_PATH, "utf8")) as {
+    scripts?: Record<string, string>;
+  };
+  assert.ok(
+    packageJson.scripts?.["content-kitchen:post-publish-observed-facts"]?.includes(
+      "run-content-kitchen-post-publish-observed-facts.ts",
+    ),
+    "package.json should expose the content-kitchen post-publish observed facts builder",
+  );
+
+  const inputPath = resolve(EXAMPLE_DIR, "post-publish-observed-facts-pass.input.example.json");
+  const htmlPath = resolve(EXAMPLE_DIR, "post-publish-observed-facts-pass.html.example");
+  const sitemapPath = resolve(EXAMPLE_DIR, "post-publish-observed-facts-sitemap.xml.example");
+  const tmpDir = await mkdtemp(resolve(tmpdir(), "content-kitchen-observed-facts-"));
+  try {
+    const outputPath = resolve(tmpDir, "audit-runner-input.json");
+    const result = await runContentKitchenPostPublishObservedFactsFromFile({
+      inputPath,
+      outputPath,
+    });
+    const writtenInput = JSON.parse(await readFile(outputPath, "utf8")) as {
+      schemaVersion: string;
+      artifactId: string;
+      observed: {
+        fetchedUrl: string;
+        httpStatus: number;
+        fetchOk: boolean;
+        renderOk: boolean;
+        answerVisible: boolean;
+        visibleClues: string[];
+        canonicalUrl: string;
+        noindexPresent: boolean;
+        sitemapIncluded: boolean;
+        sitemapLastmod: string;
+        schemaTypes: string[];
+        schemaDateModified: string;
+        internalLinks: string[];
+      };
+    };
+
+    assert.equal(
+      result.schemaVersion,
+      POST_PUBLISH_OBSERVED_FACTS_BUILDER_RESULT_VERSION,
+      "observed facts builder result version should be stable",
+    );
+    assert.equal(result.dryRunOnly, true, "observed facts builder should stay dry-run only");
+    assert.equal(
+      result.auditRunnerInput.schemaVersion,
+      POST_PUBLISH_AUDIT_RUNNER_INPUT_VERSION,
+      "observed facts builder should output audit runner input",
+    );
+    assert.equal(
+      writtenInput.schemaVersion,
+      POST_PUBLISH_AUDIT_RUNNER_INPUT_VERSION,
+      "observed facts builder output file should be audit runner input",
+    );
+    assert.equal(
+      result.sourceFiles.htmlPath,
+      htmlPath,
+      "observed facts builder should resolve HTML path relative to input",
+    );
+    assert.equal(
+      result.sourceFiles.sitemapPath,
+      sitemapPath,
+      "observed facts builder should resolve sitemap path relative to input",
+    );
+    assert.equal(writtenInput.observed.fetchOk, true, "observed facts should mark local HTML fetch as ok");
+    assert.equal(writtenInput.observed.renderOk, true, "observed facts should mark local HTML render as ok");
+    assert.equal(writtenInput.observed.answerVisible, true, "observed facts should detect visible answer");
+    assert.deepEqual(
+      writtenInput.observed.visibleClues,
+      ["Low instrument", "Fishing target", "Deep voice", "Speaker setting", "Music section"],
+      "observed facts should list visible expected clues",
+    );
+    assert.equal(
+      writtenInput.observed.canonicalUrl,
+      "https://example.com/linkedin-pinpoint-answers/pinpoint-answer-925/",
+      "observed facts should extract canonical URL",
+    );
+    assert.equal(writtenInput.observed.noindexPresent, false, "observed facts should detect noindex absence");
+    assert.equal(writtenInput.observed.sitemapIncluded, true, "observed facts should detect sitemap inclusion");
+    assert.equal(writtenInput.observed.sitemapLastmod, "2026-05-24", "observed facts should extract sitemap lastmod");
+    assert.deepEqual(
+      writtenInput.observed.schemaTypes,
+      ["Article", "FAQPage"],
+      "observed facts should extract schema types",
+    );
+    assert.equal(
+      writtenInput.observed.schemaDateModified,
+      "2026-05-24",
+      "observed facts should extract schema dateModified",
+    );
+    assert.deepEqual(
+      writtenInput.observed.internalLinks,
+      ["/linkedin-pinpoint-answers/pinpoint-answer-924/"],
+      "observed facts should extract local internal links",
+    );
+    assert.ok(
+      !JSON.stringify(writtenInput).includes("<main"),
+      "observed facts output should not include raw rendered HTML",
+    );
+
+    const auditResult = await runContentKitchenPostPublishAuditFromFile({
+      inputPath: outputPath,
+    });
+    assert.equal(
+      auditResult.auditArtifact.auditOutcome,
+      "published_and_audit_passed",
+      "observed facts output should feed the audit runner",
+    );
+
+    await assert.rejects(
+      () => runContentKitchenPostPublishObservedFactsCli(["--input", inputPath, "--output", inputPath]),
+      /--output must be different from --input/,
+      "observed facts CLI should reject output paths that overwrite input",
+    );
+    await assert.rejects(
+      () => runContentKitchenPostPublishObservedFactsCli(["--input", inputPath, "--output", htmlPath]),
+      /--output must be different from sources.htmlPath/,
+      "observed facts CLI should reject output paths that overwrite HTML source",
+    );
+    await assert.rejects(
+      () => runContentKitchenPostPublishObservedFactsCli(["--input", inputPath, "--output", sitemapPath]),
+      /--output must be different from sources.sitemapPath/,
+      "observed facts CLI should reject output paths that overwrite sitemap source",
+    );
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+
+  const inputRaw = await readFile(inputPath, "utf8");
+  assert.ok(
+    inputRaw.includes(POST_PUBLISH_OBSERVED_FACTS_BUILDER_INPUT_VERSION),
+    "observed facts builder example should use stable input version",
+  );
+}
+
 async function main() {
   const fileNames = (await readdir(FIXTURE_DIR)).filter((fileName) => fileName.endsWith(".json")).sort();
   assert.ok(fileNames.length >= 6, "content kitchen should have at least 6 fixtures");
@@ -4407,6 +4565,7 @@ async function main() {
   await assertReviewDecisionExamplesAndRunner();
   assertPostPublishAuditContract();
   await assertPostPublishAuditRunnerAndExamples();
+  await assertPostPublishObservedFactsBuilderAndExamples();
   console.log(`content-kitchen contract fixtures passed (${fileNames.length} fixtures)`);
 }
 

--- a/scripts/run-content-kitchen-post-publish-observed-facts.ts
+++ b/scripts/run-content-kitchen-post-publish-observed-facts.ts
@@ -1,0 +1,540 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, isAbsolute, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import {
+  POST_PUBLISH_AUDIT_RUNNER_INPUT_VERSION,
+  type PostPublishAuditRunnerInput,
+} from "./run-content-kitchen-post-publish-audit";
+import type {
+  ContentMode,
+  IndexPolicy,
+  InternalLinkPolicy,
+  PostPublishAuditExpectedStateV0,
+  PostPublishAuditObservedStateV0,
+  RequiredAction,
+  SchemaPolicy,
+  SitemapPolicy,
+  ValidationPolicies,
+} from "../lib/puzzles/content-kitchen/types";
+
+export const POST_PUBLISH_OBSERVED_FACTS_BUILDER_INPUT_VERSION =
+  "content-kitchen-post-publish-observed-facts-builder-input-v0";
+export const POST_PUBLISH_OBSERVED_FACTS_BUILDER_RESULT_VERSION =
+  "content-kitchen-post-publish-observed-facts-builder-result-v0";
+
+export type PostPublishObservedFactsBuilderInput = {
+  schemaVersion?: typeof POST_PUBLISH_OBSERVED_FACTS_BUILDER_INPUT_VERSION;
+  artifactId: string;
+  checkedAt: string;
+  expected: PostPublishAuditExpectedStateV0;
+  sources: {
+    fetchedUrl: string;
+    httpStatus?: number;
+    htmlPath: string;
+    sitemapPath?: string;
+  };
+};
+
+export type ContentKitchenPostPublishObservedFactsBuilderResult = {
+  schemaVersion: typeof POST_PUBLISH_OBSERVED_FACTS_BUILDER_RESULT_VERSION;
+  dryRunOnly: true;
+  sourcePath: string;
+  outputPath?: string;
+  sourceFiles: {
+    htmlPath: string;
+    sitemapPath?: string;
+  };
+  auditRunnerInput: PostPublishAuditRunnerInput;
+};
+
+type ParsedArgs = {
+  inputPath: string;
+  outputPath?: string;
+  pretty: boolean;
+};
+
+function readArgValue(argv: string[], index: number, name: string): string {
+  const value = argv[index + 1];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${name} requires a value`);
+  }
+
+  return value;
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
+  let inputPath = "";
+  let outputPath: string | undefined;
+  let pretty = true;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--input") {
+      inputPath = resolve(readArgValue(argv, index, "--input"));
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--output") {
+      outputPath = resolve(readArgValue(argv, index, "--output"));
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--compact") {
+      pretty = false;
+      continue;
+    }
+
+    if (arg === "--pretty") {
+      pretty = true;
+      continue;
+    }
+
+    if (arg === "--help" || arg === "-h") {
+      throw new Error(
+        "Usage: npm run content-kitchen:post-publish-observed-facts -- --input <path> [--output <path>] [--pretty|--compact]",
+      );
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  if (!inputPath) {
+    throw new Error("Missing required --input <path>");
+  }
+  if (outputPath === inputPath) {
+    throw new Error("--output must be different from --input");
+  }
+
+  return {
+    inputPath,
+    outputPath,
+    pretty,
+  };
+}
+
+function requireObject(value: unknown, fieldPath: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${fieldPath} must be an object`);
+  }
+
+  return value as Record<string, unknown>;
+}
+
+function requireText(record: Record<string, unknown>, key: string, fieldPath: string): string {
+  const value = record[key];
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`${fieldPath}.${key} must be a non-empty string`);
+  }
+
+  return value;
+}
+
+function optionalText(record: Record<string, unknown>, key: string, fieldPath: string): string | undefined {
+  const value = record[key];
+  if (value === undefined) return undefined;
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`${fieldPath}.${key} must be a non-empty string`);
+  }
+
+  return value;
+}
+
+function optionalNumber(record: Record<string, unknown>, key: string, fieldPath: string): number | undefined {
+  const value = record[key];
+  if (value === undefined) return undefined;
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new Error(`${fieldPath}.${key} must be a finite number`);
+  }
+
+  return value;
+}
+
+function optionalTextArray(record: Record<string, unknown>, key: string, fieldPath: string): string[] | undefined {
+  const value = record[key];
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value) || value.some((item) => typeof item !== "string" || !item.trim())) {
+    throw new Error(`${fieldPath}.${key} must be an array of non-empty strings`);
+  }
+
+  return [...value];
+}
+
+function requireTextArray(record: Record<string, unknown>, key: string, fieldPath: string): string[] {
+  const value = optionalTextArray(record, key, fieldPath);
+  if (!value) {
+    throw new Error(`${fieldPath}.${key} must be an array of non-empty strings`);
+  }
+
+  return value;
+}
+
+function requireEnum<T extends string>(
+  record: Record<string, unknown>,
+  key: string,
+  fieldPath: string,
+  values: readonly T[],
+): T {
+  const value = record[key];
+  if (typeof value !== "string" || !values.includes(value as T)) {
+    throw new Error(`${fieldPath}.${key} must be one of: ${values.join(", ")}`);
+  }
+
+  return value as T;
+}
+
+function parsePolicies(value: unknown): ValidationPolicies {
+  const policies = requireObject(value, "expected.policies");
+  return {
+    indexPolicy: requireEnum<IndexPolicy>(policies, "indexPolicy", "expected.policies", [
+      "index",
+      "noindex",
+      "review_required",
+      "block_publish",
+    ]),
+    sitemapPolicy: requireEnum<SitemapPolicy>(policies, "sitemapPolicy", "expected.policies", [
+      "include",
+      "exclude",
+      "remove_on_next_build",
+      "include_after_audit",
+    ]),
+    schemaPolicy: requireEnum<SchemaPolicy>(policies, "schemaPolicy", "expected.policies", [
+      "none",
+      "article_only",
+      "faq_allowed",
+      "block_schema",
+    ]),
+    internalLinkPolicy: requireEnum<InternalLinkPolicy>(policies, "internalLinkPolicy", "expected.policies", [
+      "normal",
+      "deemphasized",
+      "hidden_from_recent",
+    ]),
+    requiredAction: requireEnum<RequiredAction>(policies, "requiredAction", "expected.policies", [
+      "none",
+      "enrich",
+      "review",
+      "block_publish",
+      "upgrade",
+      "rollback",
+      "degrade",
+      "create_fix_task",
+      "dead_letter",
+      "keep_current",
+    ]),
+  };
+}
+
+function parseExpected(value: unknown): PostPublishAuditExpectedStateV0 {
+  const expected = requireObject(value, "expected");
+  return {
+    puzzleId: requireText(expected, "puzzleId", "expected"),
+    canonicalUrl: requireText(expected, "canonicalUrl", "expected"),
+    revisionId: requireText(expected, "revisionId", "expected"),
+    contentMode: requireEnum<ContentMode>(expected, "contentMode", "expected", ["answer-first", "full-analysis"]),
+    answer: requireText(expected, "answer", "expected"),
+    clues: requireTextArray(expected, "clues", "expected"),
+    policies: parsePolicies(expected.policies),
+    ...(optionalTextArray(expected, "schemaTypes", "expected") ? { schemaTypes: optionalTextArray(expected, "schemaTypes", "expected") } : {}),
+    ...(optionalText(expected, "sitemapLastmod", "expected") ? { sitemapLastmod: optionalText(expected, "sitemapLastmod", "expected") } : {}),
+    ...(optionalText(expected, "schemaDateModified", "expected") ? { schemaDateModified: optionalText(expected, "schemaDateModified", "expected") } : {}),
+    ...(optionalTextArray(expected, "expectedInternalLinks", "expected") ? { expectedInternalLinks: optionalTextArray(expected, "expectedInternalLinks", "expected") } : {}),
+  };
+}
+
+function resolveInputRelativePath(inputPath: string, value: string): string {
+  return isAbsolute(value) ? value : resolve(dirname(inputPath), value);
+}
+
+function parseBuilderInput(raw: string): Omit<PostPublishObservedFactsBuilderInput, "sources"> & {
+  sources: PostPublishObservedFactsBuilderInput["sources"];
+} {
+  const record = requireObject(JSON.parse(raw) as unknown, "input");
+  const schemaVersion = record.schemaVersion;
+  if (schemaVersion !== undefined && schemaVersion !== POST_PUBLISH_OBSERVED_FACTS_BUILDER_INPUT_VERSION) {
+    throw new Error(`schemaVersion must be ${POST_PUBLISH_OBSERVED_FACTS_BUILDER_INPUT_VERSION}`);
+  }
+  const checkedAt = requireText(record, "checkedAt", "input");
+  if (!Number.isFinite(Date.parse(checkedAt))) {
+    throw new Error("input.checkedAt must be a valid timestamp");
+  }
+  const sources = requireObject(record.sources, "sources");
+
+  return {
+    ...(schemaVersion ? { schemaVersion: schemaVersion as typeof POST_PUBLISH_OBSERVED_FACTS_BUILDER_INPUT_VERSION } : {}),
+    artifactId: requireText(record, "artifactId", "input"),
+    checkedAt,
+    expected: parseExpected(record.expected),
+    sources: {
+      fetchedUrl: requireText(sources, "fetchedUrl", "sources"),
+      ...(optionalNumber(sources, "httpStatus", "sources") !== undefined ? { httpStatus: optionalNumber(sources, "httpStatus", "sources") } : {}),
+      htmlPath: requireText(sources, "htmlPath", "sources"),
+      ...(optionalText(sources, "sitemapPath", "sources") ? { sitemapPath: optionalText(sources, "sitemapPath", "sources") } : {}),
+    },
+  };
+}
+
+function decodeHtmlEntities(value: string): string {
+  const named: Record<string, string> = {
+    amp: "&",
+    apos: "'",
+    gt: ">",
+    lt: "<",
+    nbsp: " ",
+    quot: '"',
+    "#x27": "'",
+  };
+  return value
+    .replace(/&#(\d+);/g, (_, code: string) => String.fromCodePoint(Number.parseInt(code, 10)))
+    .replace(/&#x([0-9a-f]+);/gi, (_, code: string) => String.fromCodePoint(Number.parseInt(code, 16)))
+    .replace(/&([a-zA-Z][a-zA-Z0-9]+|#x27);/g, (match, code: string) => named[code] ?? match);
+}
+
+function stripHiddenHtml(html: string): string {
+  return html
+    .replace(/<script\b[\s\S]*?<\/script>/gi, " ")
+    .replace(/<style\b[\s\S]*?<\/style>/gi, " ")
+    .replace(/<noscript\b[\s\S]*?<\/noscript>/gi, " ");
+}
+
+function visibleTextFromHtml(html: string): string {
+  return decodeHtmlEntities(stripHiddenHtml(html).replace(/<[^>]*>/g, " "))
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function normalizeForMatch(value: string): string {
+  return decodeHtmlEntities(value)
+    .toLowerCase()
+    .replace(/["“”'`]/g, "")
+    .replace(/[^\p{L}\p{N}]+/gu, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function readAttribute(tag: string, name: string): string {
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const doubleQuoted = tag.match(new RegExp(`\\s${escaped}="([^"]*)"`, "i"))?.[1];
+  if (doubleQuoted !== undefined) return decodeHtmlEntities(doubleQuoted);
+  const singleQuoted = tag.match(new RegExp(`\\s${escaped}='([^']*)'`, "i"))?.[1];
+  return decodeHtmlEntities(singleQuoted ?? "");
+}
+
+function findLinkHref(html: string, rel: string): string | undefined {
+  const linkTags = html.match(/<link\b[^>]*>/gi) ?? [];
+  for (const tag of linkTags) {
+    const relValue = readAttribute(tag, "rel").toLowerCase().split(/\s+/);
+    if (relValue.includes(rel.toLowerCase())) return readAttribute(tag, "href") || undefined;
+  }
+  return undefined;
+}
+
+function findMetaContent(html: string, nameOrProperty: string): string | undefined {
+  const metaTags = html.match(/<meta\b[^>]*>/gi) ?? [];
+  for (const tag of metaTags) {
+    const name = readAttribute(tag, "name") || readAttribute(tag, "property");
+    if (name.toLowerCase() === nameOrProperty.toLowerCase()) return readAttribute(tag, "content") || undefined;
+  }
+  return undefined;
+}
+
+function extractHrefValues(html: string): string[] {
+  const anchors = html.match(/<a\b[^>]*>/gi) ?? [];
+  return [...new Set(anchors.flatMap((tag) => {
+    const href = readAttribute(tag, "href");
+    return href ? [href] : [];
+  }))];
+}
+
+function normalizeInternalLink(href: string, canonicalUrl: string): string | undefined {
+  if (href.startsWith("#") || href.startsWith("mailto:") || href.startsWith("tel:")) return undefined;
+  if (href.startsWith("/")) return href;
+  try {
+    const hrefUrl = new URL(href);
+    const canonical = new URL(canonicalUrl);
+    if (hrefUrl.origin !== canonical.origin) return undefined;
+    return `${hrefUrl.pathname}${hrefUrl.search}${hrefUrl.hash}`;
+  } catch {
+    return undefined;
+  }
+}
+
+function collectSchemaObjects(value: unknown): Record<string, unknown>[] {
+  if (!value || typeof value !== "object") return [];
+  if (Array.isArray(value)) {
+    return value.flatMap(collectSchemaObjects);
+  }
+  const record = value as Record<string, unknown>;
+  const graph = record["@graph"];
+  return [record, ...collectSchemaObjects(graph)];
+}
+
+function parseJsonLdObjects(html: string): Record<string, unknown>[] {
+  const scripts = html.matchAll(
+    /<script\b[^>]*type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi,
+  );
+  const objects: Record<string, unknown>[] = [];
+  for (const match of scripts) {
+    const raw = match[1]?.trim();
+    if (!raw) continue;
+    try {
+      objects.push(...collectSchemaObjects(JSON.parse(raw) as unknown));
+    } catch {
+      try {
+        objects.push(...collectSchemaObjects(JSON.parse(decodeHtmlEntities(raw)) as unknown));
+      } catch {
+        // Bad JSON-LD is a render/audit problem for later checks. This builder only records facts it can read.
+      }
+    }
+  }
+  return objects;
+}
+
+function schemaTypeNames(objects: Record<string, unknown>[]): string[] {
+  const types = objects.flatMap((object) => {
+    const value = object["@type"];
+    if (Array.isArray(value)) return value.filter((item): item is string => typeof item === "string");
+    return typeof value === "string" ? [value] : [];
+  });
+  return [...new Set(types)];
+}
+
+function schemaDateModified(objects: Record<string, unknown>[]): string | undefined {
+  for (const object of objects) {
+    const value = object.dateModified;
+    if (typeof value === "string" && value.trim()) return value;
+  }
+  return undefined;
+}
+
+function parseSitemap(xml: string, canonicalUrl: string): {
+  sitemapIncluded: boolean;
+  sitemapLastmod?: string;
+} {
+  const canonical = new URL(canonicalUrl);
+  const blocks = xml.matchAll(/<url>([\s\S]*?)<\/url>/gi);
+  for (const block of blocks) {
+    const text = block[1] ?? "";
+    const loc = decodeHtmlEntities(text.match(/<loc>([\s\S]*?)<\/loc>/i)?.[1]?.trim() ?? "");
+    if (!loc) continue;
+    let matches = loc === canonicalUrl;
+    try {
+      const locUrl = new URL(loc);
+      matches = matches || locUrl.pathname === canonical.pathname;
+    } catch {
+      matches = matches || loc === canonical.pathname;
+    }
+    if (!matches) continue;
+    const lastmod = decodeHtmlEntities(text.match(/<lastmod>([\s\S]*?)<\/lastmod>/i)?.[1]?.trim() ?? "");
+    return {
+      sitemapIncluded: true,
+      ...(lastmod ? { sitemapLastmod: lastmod } : {}),
+    };
+  }
+  return { sitemapIncluded: false };
+}
+
+export async function buildPostPublishObservedFacts(input: {
+  expected: PostPublishAuditExpectedStateV0;
+  sources: PostPublishObservedFactsBuilderInput["sources"];
+  htmlPath: string;
+  sitemapPath?: string;
+}): Promise<PostPublishAuditObservedStateV0> {
+  const html = await readFile(input.htmlPath, "utf8");
+  const visibleText = visibleTextFromHtml(html);
+  const normalizedVisibleText = normalizeForMatch(visibleText);
+  const schemaObjects = parseJsonLdObjects(html);
+  const internalLinks = [...new Set(
+    extractHrefValues(html)
+      .map((href) => normalizeInternalLink(href, input.expected.canonicalUrl))
+      .filter((href): href is string => Boolean(href)),
+  )];
+  const sitemapFacts = input.sitemapPath
+    ? parseSitemap(await readFile(input.sitemapPath, "utf8"), input.expected.canonicalUrl)
+    : {};
+  const statusOk =
+    input.sources.httpStatus === undefined ||
+    (input.sources.httpStatus >= 200 && input.sources.httpStatus < 400);
+
+  return {
+    fetchedUrl: input.sources.fetchedUrl,
+    ...(input.sources.httpStatus !== undefined ? { httpStatus: input.sources.httpStatus } : {}),
+    fetchOk: statusOk,
+    renderOk: html.trim().length > 0,
+    answerVisible: normalizedVisibleText.includes(normalizeForMatch(input.expected.answer)),
+    visibleClues: input.expected.clues.filter((clue) => normalizedVisibleText.includes(normalizeForMatch(clue))),
+    ...(findLinkHref(html, "canonical") ? { canonicalUrl: findLinkHref(html, "canonical") } : {}),
+    noindexPresent: (findMetaContent(html, "robots") ?? "").toLowerCase().includes("noindex"),
+    ...sitemapFacts,
+    schemaTypes: schemaTypeNames(schemaObjects),
+    ...(schemaDateModified(schemaObjects) ? { schemaDateModified: schemaDateModified(schemaObjects) } : {}),
+    internalLinks,
+  };
+}
+
+export async function runContentKitchenPostPublishObservedFactsFromFile(input: {
+  inputPath: string;
+  outputPath?: string;
+}): Promise<ContentKitchenPostPublishObservedFactsBuilderResult> {
+  const inputPath = resolve(input.inputPath);
+  const outputPath = input.outputPath ? resolve(input.outputPath) : undefined;
+  if (outputPath === inputPath) {
+    throw new Error("--output must be different from --input");
+  }
+  const parsed = parseBuilderInput(await readFile(inputPath, "utf8"));
+  const htmlPath = resolveInputRelativePath(inputPath, parsed.sources.htmlPath);
+  const sitemapPath = parsed.sources.sitemapPath
+    ? resolveInputRelativePath(inputPath, parsed.sources.sitemapPath)
+    : undefined;
+  if (outputPath === htmlPath) {
+    throw new Error("--output must be different from sources.htmlPath");
+  }
+  if (outputPath && sitemapPath === outputPath) {
+    throw new Error("--output must be different from sources.sitemapPath");
+  }
+
+  const observed = await buildPostPublishObservedFacts({
+    expected: parsed.expected,
+    sources: parsed.sources,
+    htmlPath,
+    ...(sitemapPath ? { sitemapPath } : {}),
+  });
+  const auditRunnerInput: PostPublishAuditRunnerInput = {
+    schemaVersion: POST_PUBLISH_AUDIT_RUNNER_INPUT_VERSION,
+    artifactId: parsed.artifactId,
+    checkedAt: parsed.checkedAt,
+    expected: parsed.expected,
+    observed,
+  };
+  const result: ContentKitchenPostPublishObservedFactsBuilderResult = {
+    schemaVersion: POST_PUBLISH_OBSERVED_FACTS_BUILDER_RESULT_VERSION,
+    dryRunOnly: true,
+    sourcePath: inputPath,
+    ...(outputPath ? { outputPath } : {}),
+    sourceFiles: {
+      htmlPath,
+      ...(sitemapPath ? { sitemapPath } : {}),
+    },
+    auditRunnerInput,
+  };
+
+  if (outputPath) {
+    await mkdir(dirname(outputPath), { recursive: true });
+    await writeFile(outputPath, `${JSON.stringify(auditRunnerInput, null, 2)}\n`, "utf8");
+  }
+
+  return result;
+}
+
+export async function runCli(argv: string[] = process.argv.slice(2)): Promise<void> {
+  const args = parseArgs(argv);
+  const result = await runContentKitchenPostPublishObservedFactsFromFile(args);
+  console.log(JSON.stringify(result, null, args.pretty ? 2 : 0));
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  runCli().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Summary
- add local observed facts builder for post-publish audit inputs
- extract visible answer, clues, canonical, noindex, sitemap, schema, dateModified, and internal links from local files
- add example HTML/sitemap/input and contract tests

## Verification
- npm run test:content-kitchen
- npm run typecheck
- npm run lint
- npm run content-kitchen:post-publish-observed-facts -- --input lib/puzzles/content-kitchen/examples/post-publish-observed-facts-pass.input.example.json --output /tmp/content-kitchen-post-publish-audit-input.json --compact
- npm run content-kitchen:post-publish-audit -- --input /tmp/content-kitchen-post-publish-audit-input.json --output /tmp/content-kitchen-post-publish-audit-from-facts.json --compact
- node output sanity check
- npm run build