### PR TITLE
[codex] Add PR11 build output adapter

### DIFF
--- a/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
+++ b/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
@@ -2378,6 +2378,18 @@ PR11 third implementation slice:
 - prove the output does not include raw rendered HTML
 - keep this local-only; do not fetch public URLs, run a browser, read production storage, write review queue storage, send Feishu messages, publish content, or run Worker cron yet
 
+PR11 fourth implementation slice:
+
+- add a local build output adapter command
+- read `content-kitchen-post-publish-build-output-adapter-input-v0` JSON from `--input`
+- read local `buildOutput.appDir`, usually `.next/server/app`
+- locate the built detail page HTML from `expected.canonicalUrl`
+- locate `sitemap.xml.body` or `sitemap.xml` from the local build output, unless `buildOutput.sitemapPath` is provided
+- output `content-kitchen-post-publish-observed-facts-builder-input-v0` JSON that can feed the observed facts builder
+- reject unsafe paths where `--output` equals `--input`, the resolved HTML source, or the resolved sitemap source
+- prove the output does not include raw rendered HTML
+- keep this local-only; do not fetch public URLs, run a browser, read production storage, write review queue storage, send Feishu messages, publish content, or run Worker cron yet
+
 
 ## Review UI Requirements
 

--- a/docs/pinpoint-content-kitchen-pr11-post-publish-audit-contract-2026-05-24.md
+++ b/docs/pinpoint-content-kitchen-pr11-post-publish-audit-contract-2026-05-24.md
@@ -224,3 +224,69 @@ Builder rules:
 - the builder does not send Feishu messages
 - the builder does not write review queue storage
 - the builder does not publish content
+
+## Build Output Adapter
+
+PR11.4 adds a local build output adapter.
+
+Input uses `content-kitchen-post-publish-build-output-adapter-input-v0`.
+
+Adapter result uses `content-kitchen-post-publish-build-output-adapter-result-v0`.
+
+Run it after a local build with:
+
+```bash
+npm run content-kitchen:post-publish-build-output-adapter -- \
+  --input lib/puzzles/content-kitchen/examples/post-publish-build-output-adapter.input.example.json \
+  --output /tmp/content-kitchen-post-publish-observed-facts-input.json \
+  --pretty
+```
+
+The output file is observed facts builder input. It can be passed to:
+
+```bash
+npm run content-kitchen:post-publish-observed-facts -- \
+  --input /tmp/content-kitchen-post-publish-observed-facts-input.json \
+  --output /tmp/content-kitchen-post-publish-audit-input.json \
+  --pretty
+```
+
+Then pass that file to the audit runner:
+
+```bash
+npm run content-kitchen:post-publish-audit -- \
+  --input /tmp/content-kitchen-post-publish-audit-input.json \
+  --output /tmp/content-kitchen-post-publish-audit.json \
+  --pretty
+```
+
+Example file:
+
+- `post-publish-build-output-adapter.input.example.json`
+
+The adapter reads local files only:
+
+- `buildOutput.appDir`, usually `.next/server/app`
+- `buildOutput.sitemapPath` when provided
+- otherwise it tries `sitemap.xml.body` and then `sitemap.xml` inside `buildOutput.appDir`
+
+It uses `buildOutput.siteBaseUrl` only to make sure the expected canonical URL belongs to the same site origin.
+
+It finds the detail page HTML from `expected.canonicalUrl`. For `/linkedin-pinpoint-answers/pinpoint-answer-925/`, it checks:
+
+- `.next/server/app/linkedin-pinpoint-answers/pinpoint-answer-925.html`
+- `.next/server/app/linkedin-pinpoint-answers/pinpoint-answer-925/index.html`
+
+Adapter rules:
+
+- `--input` is required
+- `--output` is optional
+- `--output` must not equal `--input`
+- `--output` must not equal the resolved HTML source
+- `--output` must not equal the resolved sitemap source
+- output must not include raw HTML
+- the adapter does not fetch public URLs
+- the adapter does not run a browser
+- the adapter does not send Feishu messages
+- the adapter does not write review queue storage
+- the adapter does not publish content

--- a/lib/puzzles/content-kitchen/examples/post-publish-build-output-adapter.input.example.json
+++ b/lib/puzzles/content-kitchen/examples/post-publish-build-output-adapter.input.example.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "content-kitchen-post-publish-build-output-adapter-input-v0",
+  "artifactId": "art_post_publish_build_output_adapter_example",
+  "checkedAt": "2026-05-24T10:30:00.000Z",
+  "expected": {
+    "puzzleId": "pinpoint-925-2026-05-24",
+    "canonicalUrl": "https://example.com/linkedin-pinpoint-answers/pinpoint-answer-925/",
+    "revisionId": "rev-full-analysis-925",
+    "contentMode": "full-analysis",
+    "answer": "BASS",
+    "clues": [
+      "Low instrument",
+      "Fishing target",
+      "Deep voice",
+      "Speaker setting",
+      "Music section"
+    ],
+    "policies": {
+      "indexPolicy": "index",
+      "sitemapPolicy": "include",
+      "schemaPolicy": "faq_allowed",
+      "internalLinkPolicy": "normal",
+      "requiredAction": "none"
+    },
+    "schemaTypes": ["Article", "FAQPage"],
+    "sitemapLastmod": "2026-05-24",
+    "schemaDateModified": "2026-05-24",
+    "expectedInternalLinks": ["/linkedin-pinpoint-answers/pinpoint-answer-924/"]
+  },
+  "buildOutput": {
+    "appDir": ".next/server/app",
+    "siteBaseUrl": "https://example.com",
+    "httpStatus": 200
+  }
+}

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "content-kitchen:review-decision": "tsx scripts/run-content-kitchen-review-decision.ts",
     "content-kitchen:post-publish-audit": "tsx scripts/run-content-kitchen-post-publish-audit.ts",
     "content-kitchen:post-publish-observed-facts": "tsx scripts/run-content-kitchen-post-publish-observed-facts.ts",
+    "content-kitchen:post-publish-build-output-adapter": "tsx scripts/run-content-kitchen-post-publish-build-output-adapter.ts",
     "test:pinpoint-seo": "tsx scripts/check-pinpoint-seo-builders.ts",
     "test:content-kitchen": "tsx scripts/check-content-kitchen-contract.ts",
     "test:pinpoint-routing": "tsx scripts/check-routing-regressions.ts",

--- a/scripts/check-content-kitchen-contract.ts
+++ b/scripts/check-content-kitchen-contract.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, readdir, readFile, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -103,6 +103,12 @@ import {
   runCli as runContentKitchenPostPublishObservedFactsCli,
   runContentKitchenPostPublishObservedFactsFromFile,
 } from "./run-content-kitchen-post-publish-observed-facts";
+import {
+  POST_PUBLISH_BUILD_OUTPUT_ADAPTER_INPUT_VERSION,
+  POST_PUBLISH_BUILD_OUTPUT_ADAPTER_RESULT_VERSION,
+  runCli as runContentKitchenPostPublishBuildOutputAdapterCli,
+  runContentKitchenPostPublishBuildOutputAdapterFromFile,
+} from "./run-content-kitchen-post-publish-build-output-adapter";
 import {
   REVIEW_UI_SURFACE_VERSION,
   renderReviewUiInputHtml,
@@ -3657,6 +3663,18 @@ async function assertPostPublishAuditDoc() {
     "`--output` must not equal `sources.htmlPath`",
     "`--output` must not equal `sources.sitemapPath`",
     "output must not include raw HTML",
+    "Build Output Adapter",
+    "content-kitchen-post-publish-build-output-adapter-input-v0",
+    "content-kitchen-post-publish-build-output-adapter-result-v0",
+    "npm run content-kitchen:post-publish-build-output-adapter",
+    "--input lib/puzzles/content-kitchen/examples/post-publish-build-output-adapter.input.example.json",
+    "--output /tmp/content-kitchen-post-publish-observed-facts-input.json",
+    "post-publish-build-output-adapter.input.example.json",
+    "`buildOutput.appDir`",
+    "`buildOutput.siteBaseUrl`",
+    "`buildOutput.sitemapPath`",
+    "`--output` must not equal the resolved HTML source",
+    "`--output` must not equal the resolved sitemap source",
   ];
 
   for (const snippet of requiredSnippets) {
@@ -4513,6 +4531,145 @@ async function assertPostPublishObservedFactsBuilderAndExamples() {
   );
 }
 
+async function assertPostPublishBuildOutputAdapterAndExamples() {
+  const packageJson = JSON.parse(await readFile(PACKAGE_JSON_PATH, "utf8")) as {
+    scripts?: Record<string, string>;
+  };
+  assert.ok(
+    packageJson.scripts?.["content-kitchen:post-publish-build-output-adapter"]?.includes(
+      "run-content-kitchen-post-publish-build-output-adapter.ts",
+    ),
+    "package.json should expose the content-kitchen post-publish build output adapter",
+  );
+
+  const adapterExamplePath = resolve(EXAMPLE_DIR, "post-publish-build-output-adapter.input.example.json");
+  const observedExamplePath = resolve(EXAMPLE_DIR, "post-publish-observed-facts-pass.input.example.json");
+  const htmlExamplePath = resolve(EXAMPLE_DIR, "post-publish-observed-facts-pass.html.example");
+  const sitemapExamplePath = resolve(EXAMPLE_DIR, "post-publish-observed-facts-sitemap.xml.example");
+  const observedExample = JSON.parse(await readFile(observedExamplePath, "utf8")) as {
+    expected: PostPublishAuditExpectedStateV0;
+  };
+  const tmpDir = await mkdtemp(resolve(tmpdir(), "content-kitchen-build-output-adapter-"));
+  try {
+    const appDir = resolve(tmpDir, ".next", "server", "app");
+    const detailDir = resolve(appDir, "linkedin-pinpoint-answers");
+    await mkdir(detailDir, { recursive: true });
+    const htmlPath = resolve(detailDir, "pinpoint-answer-925.html");
+    const sitemapPath = resolve(appDir, "sitemap.xml.body");
+    await writeFile(htmlPath, await readFile(htmlExamplePath, "utf8"), "utf8");
+    await writeFile(sitemapPath, await readFile(sitemapExamplePath, "utf8"), "utf8");
+
+    const adapterInputPath = resolve(tmpDir, "adapter-input.json");
+    await writeFile(
+      adapterInputPath,
+      `${JSON.stringify(
+        {
+          schemaVersion: POST_PUBLISH_BUILD_OUTPUT_ADAPTER_INPUT_VERSION,
+          artifactId: "art_post_publish_build_output_adapter_contract_test",
+          checkedAt: "2026-05-24T10:30:00.000Z",
+          expected: observedExample.expected,
+          buildOutput: {
+            appDir: ".next/server/app",
+            siteBaseUrl: "https://example.com",
+            httpStatus: 200,
+          },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+
+    const outputPath = resolve(tmpDir, "observed-facts-builder-input.json");
+    const result = await runContentKitchenPostPublishBuildOutputAdapterFromFile({
+      inputPath: adapterInputPath,
+      outputPath,
+    });
+    const writtenInput = JSON.parse(await readFile(outputPath, "utf8")) as {
+      schemaVersion: string;
+      sources: {
+        fetchedUrl: string;
+        httpStatus: number;
+        htmlPath: string;
+        sitemapPath: string;
+      };
+    };
+
+    assert.equal(
+      result.schemaVersion,
+      POST_PUBLISH_BUILD_OUTPUT_ADAPTER_RESULT_VERSION,
+      "build output adapter result version should be stable",
+    );
+    assert.equal(result.dryRunOnly, true, "build output adapter should stay dry-run only");
+    assert.equal(
+      result.observedFactsBuilderInput.schemaVersion,
+      POST_PUBLISH_OBSERVED_FACTS_BUILDER_INPUT_VERSION,
+      "build output adapter should output observed facts builder input",
+    );
+    assert.equal(
+      writtenInput.schemaVersion,
+      POST_PUBLISH_OBSERVED_FACTS_BUILDER_INPUT_VERSION,
+      "build output adapter output file should be observed facts builder input",
+    );
+    assert.equal(result.sourceFiles.appDir, appDir, "build output adapter should resolve appDir");
+    assert.equal(result.sourceFiles.htmlPath, htmlPath, "build output adapter should find static detail HTML");
+    assert.equal(result.sourceFiles.sitemapPath, sitemapPath, "build output adapter should find sitemap.xml.body");
+    assert.equal(
+      writtenInput.sources.fetchedUrl,
+      "https://example.com/linkedin-pinpoint-answers/pinpoint-answer-925/",
+      "build output adapter should use expected canonical URL as fetchedUrl",
+    );
+    assert.equal(writtenInput.sources.httpStatus, 200, "build output adapter should preserve local status");
+    assert.equal(writtenInput.sources.htmlPath, htmlPath, "build output adapter should write resolved HTML path");
+    assert.equal(
+      writtenInput.sources.sitemapPath,
+      sitemapPath,
+      "build output adapter should write resolved sitemap path",
+    );
+    assert.ok(
+      !JSON.stringify(writtenInput).includes("<main"),
+      "build output adapter output should not include raw rendered HTML",
+    );
+
+    const observedFactsResult = await runContentKitchenPostPublishObservedFactsFromFile({
+      inputPath: outputPath,
+      outputPath: resolve(tmpDir, "audit-runner-input.json"),
+    });
+    const auditResult = await runContentKitchenPostPublishAuditFromFile({
+      inputPath: observedFactsResult.outputPath ?? "",
+    });
+    assert.equal(
+      auditResult.auditArtifact.auditOutcome,
+      "published_and_audit_passed",
+      "build output adapter output should feed observed facts builder and audit runner",
+    );
+
+    await assert.rejects(
+      () => runContentKitchenPostPublishBuildOutputAdapterCli(["--input", adapterInputPath, "--output", adapterInputPath]),
+      /--output must be different from --input/,
+      "build output adapter CLI should reject output paths that overwrite input",
+    );
+    await assert.rejects(
+      () => runContentKitchenPostPublishBuildOutputAdapterCli(["--input", adapterInputPath, "--output", htmlPath]),
+      /--output must be different from resolved HTML source/,
+      "build output adapter CLI should reject output paths that overwrite HTML source",
+    );
+    await assert.rejects(
+      () => runContentKitchenPostPublishBuildOutputAdapterCli(["--input", adapterInputPath, "--output", sitemapPath]),
+      /--output must be different from resolved sitemap source/,
+      "build output adapter CLI should reject output paths that overwrite sitemap source",
+    );
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+
+  const inputRaw = await readFile(adapterExamplePath, "utf8");
+  assert.ok(
+    inputRaw.includes(POST_PUBLISH_BUILD_OUTPUT_ADAPTER_INPUT_VERSION),
+    "build output adapter example should use stable input version",
+  );
+}
+
 async function main() {
   const fileNames = (await readdir(FIXTURE_DIR)).filter((fileName) => fileName.endsWith(".json")).sort();
   assert.ok(fileNames.length >= 6, "content kitchen should have at least 6 fixtures");
@@ -4566,6 +4723,7 @@ async function main() {
   assertPostPublishAuditContract();
   await assertPostPublishAuditRunnerAndExamples();
   await assertPostPublishObservedFactsBuilderAndExamples();
+  await assertPostPublishBuildOutputAdapterAndExamples();
   console.log(`content-kitchen contract fixtures passed (${fileNames.length} fixtures)`);
 }
 

--- a/scripts/run-content-kitchen-post-publish-build-output-adapter.ts
+++ b/scripts/run-content-kitchen-post-publish-build-output-adapter.ts
@@ -1,0 +1,339 @@
+import { constants } from "node:fs";
+import { access, mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, isAbsolute, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import {
+  POST_PUBLISH_OBSERVED_FACTS_BUILDER_INPUT_VERSION,
+  type PostPublishObservedFactsBuilderInput,
+} from "./run-content-kitchen-post-publish-observed-facts";
+import type { PostPublishAuditExpectedStateV0 } from "../lib/puzzles/content-kitchen/types";
+
+export const POST_PUBLISH_BUILD_OUTPUT_ADAPTER_INPUT_VERSION =
+  "content-kitchen-post-publish-build-output-adapter-input-v0";
+export const POST_PUBLISH_BUILD_OUTPUT_ADAPTER_RESULT_VERSION =
+  "content-kitchen-post-publish-build-output-adapter-result-v0";
+
+export type PostPublishBuildOutputAdapterInput = {
+  schemaVersion?: typeof POST_PUBLISH_BUILD_OUTPUT_ADAPTER_INPUT_VERSION;
+  artifactId: string;
+  checkedAt: string;
+  expected: PostPublishAuditExpectedStateV0;
+  buildOutput: {
+    appDir: string;
+    siteBaseUrl?: string;
+    httpStatus?: number;
+    sitemapPath?: string;
+  };
+};
+
+export type ContentKitchenPostPublishBuildOutputAdapterResult = {
+  schemaVersion: typeof POST_PUBLISH_BUILD_OUTPUT_ADAPTER_RESULT_VERSION;
+  dryRunOnly: true;
+  sourcePath: string;
+  outputPath?: string;
+  sourceFiles: {
+    appDir: string;
+    htmlPath: string;
+    sitemapPath?: string;
+  };
+  observedFactsBuilderInput: PostPublishObservedFactsBuilderInput;
+};
+
+type ParsedArgs = {
+  inputPath: string;
+  outputPath?: string;
+  pretty: boolean;
+};
+
+function readArgValue(argv: string[], index: number, name: string): string {
+  const value = argv[index + 1];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${name} requires a value`);
+  }
+
+  return value;
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
+  let inputPath = "";
+  let outputPath: string | undefined;
+  let pretty = true;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--input") {
+      inputPath = resolve(readArgValue(argv, index, "--input"));
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--output") {
+      outputPath = resolve(readArgValue(argv, index, "--output"));
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--compact") {
+      pretty = false;
+      continue;
+    }
+
+    if (arg === "--pretty") {
+      pretty = true;
+      continue;
+    }
+
+    if (arg === "--help" || arg === "-h") {
+      throw new Error(
+        "Usage: npm run content-kitchen:post-publish-build-output-adapter -- --input <path> [--output <path>] [--pretty|--compact]",
+      );
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  if (!inputPath) {
+    throw new Error("Missing required --input <path>");
+  }
+  if (outputPath === inputPath) {
+    throw new Error("--output must be different from --input");
+  }
+
+  return {
+    inputPath,
+    outputPath,
+    pretty,
+  };
+}
+
+function requireObject(value: unknown, fieldPath: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${fieldPath} must be an object`);
+  }
+
+  return value as Record<string, unknown>;
+}
+
+function requireText(record: Record<string, unknown>, key: string, fieldPath: string): string {
+  const value = record[key];
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`${fieldPath}.${key} must be a non-empty string`);
+  }
+
+  return value;
+}
+
+function optionalText(record: Record<string, unknown>, key: string, fieldPath: string): string | undefined {
+  const value = record[key];
+  if (value === undefined) return undefined;
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`${fieldPath}.${key} must be a non-empty string`);
+  }
+
+  return value;
+}
+
+function optionalNumber(record: Record<string, unknown>, key: string, fieldPath: string): number | undefined {
+  const value = record[key];
+  if (value === undefined) return undefined;
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new Error(`${fieldPath}.${key} must be a finite number`);
+  }
+
+  return value;
+}
+
+function rejectUnsafePayload(raw: string): void {
+  const unsafeSnippets = [
+    "rawRenderedHtml",
+    "renderedHtml",
+    "modelPrompt",
+    "<main",
+    "<html",
+    "<script",
+    "\"secret",
+    "\"secrets",
+    "\"apiKey",
+    "\"token",
+  ];
+  const lowerRaw = raw.toLowerCase();
+  const found = unsafeSnippets.find((snippet) => lowerRaw.includes(snippet.toLowerCase()));
+  if (found) {
+    throw new Error(`build output adapter input must not include raw HTML, model prompts, or secrets (${found})`);
+  }
+}
+
+function parseAdapterInput(raw: string): PostPublishBuildOutputAdapterInput {
+  rejectUnsafePayload(raw);
+  const record = requireObject(JSON.parse(raw) as unknown, "input");
+  const schemaVersion = record.schemaVersion;
+  if (schemaVersion !== undefined && schemaVersion !== POST_PUBLISH_BUILD_OUTPUT_ADAPTER_INPUT_VERSION) {
+    throw new Error(`schemaVersion must be ${POST_PUBLISH_BUILD_OUTPUT_ADAPTER_INPUT_VERSION}`);
+  }
+  const checkedAt = requireText(record, "checkedAt", "input");
+  if (!Number.isFinite(Date.parse(checkedAt))) {
+    throw new Error("input.checkedAt must be a valid timestamp");
+  }
+
+  const expected = requireObject(record.expected, "expected") as unknown as PostPublishAuditExpectedStateV0;
+  const canonicalUrl = requireText(record.expected as Record<string, unknown>, "canonicalUrl", "expected");
+  let parsedCanonicalUrl: URL;
+  try {
+    parsedCanonicalUrl = new URL(canonicalUrl);
+  } catch {
+    throw new Error("expected.canonicalUrl must be an absolute URL");
+  }
+
+  const buildOutput = requireObject(record.buildOutput, "buildOutput");
+  const siteBaseUrl = optionalText(buildOutput, "siteBaseUrl", "buildOutput");
+  if (siteBaseUrl) {
+    let parsedSiteBaseUrl: URL;
+    try {
+      parsedSiteBaseUrl = new URL(siteBaseUrl);
+    } catch {
+      throw new Error("buildOutput.siteBaseUrl must be an absolute URL");
+    }
+    if (parsedSiteBaseUrl.origin !== parsedCanonicalUrl.origin) {
+      throw new Error("buildOutput.siteBaseUrl must match expected.canonicalUrl origin");
+    }
+  }
+
+  return {
+    ...(schemaVersion ? { schemaVersion: schemaVersion as typeof POST_PUBLISH_BUILD_OUTPUT_ADAPTER_INPUT_VERSION } : {}),
+    artifactId: requireText(record, "artifactId", "input"),
+    checkedAt,
+    expected,
+    buildOutput: {
+      appDir: requireText(buildOutput, "appDir", "buildOutput"),
+      ...(siteBaseUrl ? { siteBaseUrl } : {}),
+      ...(optionalNumber(buildOutput, "httpStatus", "buildOutput") !== undefined
+        ? { httpStatus: optionalNumber(buildOutput, "httpStatus", "buildOutput") }
+        : {}),
+      ...(optionalText(buildOutput, "sitemapPath", "buildOutput")
+        ? { sitemapPath: optionalText(buildOutput, "sitemapPath", "buildOutput") }
+        : {}),
+    },
+  };
+}
+
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await access(path, constants.R_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function resolveExistingPath(inputPath: string, value: string, fieldPath: string): Promise<string> {
+  const candidates = isAbsolute(value)
+    ? [value]
+    : [resolve(dirname(inputPath), value), resolve(process.cwd(), value)];
+  const uniqueCandidates = [...new Set(candidates)];
+  for (const candidate of uniqueCandidates) {
+    if (await fileExists(candidate)) return candidate;
+  }
+
+  throw new Error(`${fieldPath} does not exist or is not readable: ${uniqueCandidates.join(" or ")}`);
+}
+
+function buildHtmlPathCandidates(appDir: string, canonicalUrl: string): string[] {
+  const pathname = new URL(canonicalUrl).pathname;
+  const withoutLeadingSlash = decodeURIComponent(pathname).replace(/^\/+/, "");
+  const withoutTrailingSlash = withoutLeadingSlash.replace(/\/+$/, "");
+
+  return [
+    resolve(appDir, `${withoutTrailingSlash}.html`),
+    resolve(appDir, withoutTrailingSlash, "index.html"),
+    resolve(appDir, withoutLeadingSlash, "index.html"),
+  ];
+}
+
+async function findHtmlPath(appDir: string, canonicalUrl: string): Promise<string> {
+  const candidates = buildHtmlPathCandidates(appDir, canonicalUrl);
+  for (const candidate of candidates) {
+    if (await fileExists(candidate)) return candidate;
+  }
+
+  throw new Error(`build output HTML was not found for expected.canonicalUrl: ${candidates.join(" or ")}`);
+}
+
+async function findSitemapPath(inputPath: string, appDir: string, sitemapPath?: string): Promise<string | undefined> {
+  if (sitemapPath) {
+    return resolveExistingPath(inputPath, sitemapPath, "buildOutput.sitemapPath");
+  }
+
+  const candidates = [resolve(appDir, "sitemap.xml.body"), resolve(appDir, "sitemap.xml")];
+  for (const candidate of candidates) {
+    if (await fileExists(candidate)) return candidate;
+  }
+
+  return undefined;
+}
+
+export async function runContentKitchenPostPublishBuildOutputAdapterFromFile(input: {
+  inputPath: string;
+  outputPath?: string;
+}): Promise<ContentKitchenPostPublishBuildOutputAdapterResult> {
+  const inputPath = resolve(input.inputPath);
+  const outputPath = input.outputPath ? resolve(input.outputPath) : undefined;
+  if (outputPath === inputPath) {
+    throw new Error("--output must be different from --input");
+  }
+
+  const parsed = parseAdapterInput(await readFile(inputPath, "utf8"));
+  const appDir = await resolveExistingPath(inputPath, parsed.buildOutput.appDir, "buildOutput.appDir");
+  const htmlPath = await findHtmlPath(appDir, parsed.expected.canonicalUrl);
+  const sitemapPath = await findSitemapPath(inputPath, appDir, parsed.buildOutput.sitemapPath);
+  if (outputPath === htmlPath) {
+    throw new Error("--output must be different from resolved HTML source");
+  }
+  if (outputPath && sitemapPath === outputPath) {
+    throw new Error("--output must be different from resolved sitemap source");
+  }
+
+  const observedFactsBuilderInput: PostPublishObservedFactsBuilderInput = {
+    schemaVersion: POST_PUBLISH_OBSERVED_FACTS_BUILDER_INPUT_VERSION,
+    artifactId: parsed.artifactId,
+    checkedAt: parsed.checkedAt,
+    expected: parsed.expected,
+    sources: {
+      fetchedUrl: parsed.expected.canonicalUrl,
+      ...(parsed.buildOutput.httpStatus !== undefined ? { httpStatus: parsed.buildOutput.httpStatus } : {}),
+      htmlPath,
+      ...(sitemapPath ? { sitemapPath } : {}),
+    },
+  };
+  const result: ContentKitchenPostPublishBuildOutputAdapterResult = {
+    schemaVersion: POST_PUBLISH_BUILD_OUTPUT_ADAPTER_RESULT_VERSION,
+    dryRunOnly: true,
+    sourcePath: inputPath,
+    ...(outputPath ? { outputPath } : {}),
+    sourceFiles: {
+      appDir,
+      htmlPath,
+      ...(sitemapPath ? { sitemapPath } : {}),
+    },
+    observedFactsBuilderInput,
+  };
+
+  if (outputPath) {
+    await mkdir(dirname(outputPath), { recursive: true });
+    await writeFile(outputPath, `${JSON.stringify(observedFactsBuilderInput, null, 2)}\n`, "utf8");
+  }
+
+  return result;
+}
+
+export async function runCli(argv: string[] = process.argv.slice(2)): Promise<void> {
+  const args = parseArgs(argv);
+  const result = await runContentKitchenPostPublishBuildOutputAdapterFromFile(args);
+  console.log(JSON.stringify(result, null, args.pretty ? 2 : 0));
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  runCli().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Summary

- add PR11.4 local build output adapter for `.next/server/app`
- output observed facts builder input with resolved detail HTML and sitemap paths
- document the local-only rules and cover the adapter in the content-kitchen contract test

## Checks

- `npm run test:content-kitchen`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- local smoke chain: build output adapter -> observed facts builder -> post-publish audit for Pinpoint #754
