### PR TITLE
[codex] Add PR11 local audit chain

### DIFF
--- a/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
+++ b/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
@@ -2390,6 +2390,18 @@ PR11 fourth implementation slice:
 - prove the output does not include raw rendered HTML
 - keep this local-only; do not fetch public URLs, run a browser, read production storage, write review queue storage, send Feishu messages, publish content, or run Worker cron yet
 
+PR11 fifth implementation slice:
+
+- add a one-command local audit chain
+- read the same input as the build output adapter
+- locate local build output HTML and sitemap
+- extract observed facts from the local files
+- output the final `content-kitchen-post-publish-audit-v0` artifact
+- keep the chain dry-run only and local-only
+- reject unsafe paths where `--output` equals `--input`, the resolved HTML source, or the resolved sitemap source
+- prove the output does not include raw rendered HTML
+- do not fetch public URLs, run a browser, read production storage, write review queue storage, send Feishu messages, publish content, or run Worker cron yet
+
 
 ## Review UI Requirements
 

--- a/docs/pinpoint-content-kitchen-pr11-post-publish-audit-contract-2026-05-24.md
+++ b/docs/pinpoint-content-kitchen-pr11-post-publish-audit-contract-2026-05-24.md
@@ -290,3 +290,42 @@ Adapter rules:
 - the adapter does not send Feishu messages
 - the adapter does not write review queue storage
 - the adapter does not publish content
+
+## Local Audit Chain
+
+PR11.5 adds a one-command local audit chain.
+
+Chain result uses `content-kitchen-post-publish-local-audit-chain-result-v0`.
+
+The chain reads the same input as the build output adapter.
+
+Run it after a local build with:
+
+```bash
+npm run content-kitchen:post-publish-local-audit -- \
+  --input lib/puzzles/content-kitchen/examples/post-publish-build-output-adapter.input.example.json \
+  --output /tmp/content-kitchen-post-publish-audit.json \
+  --pretty
+```
+
+The output file is the final post-publish audit artifact.
+
+The chain does these local steps:
+
+1. locate build output HTML and sitemap from `.next/server/app`
+2. extract observed facts from local HTML and local sitemap
+3. build the `content-kitchen-post-publish-audit-v0` artifact
+
+Chain rules:
+
+- `--input` is required
+- `--output` is optional
+- `--output` must not equal `--input`
+- `--output` must not equal the resolved HTML source
+- `--output` must not equal the resolved sitemap source
+- output must not include raw HTML
+- the chain does not fetch public URLs
+- the chain does not run a browser
+- the chain does not send Feishu messages
+- the chain does not write review queue storage
+- the chain does not publish content

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "content-kitchen:post-publish-audit": "tsx scripts/run-content-kitchen-post-publish-audit.ts",
     "content-kitchen:post-publish-observed-facts": "tsx scripts/run-content-kitchen-post-publish-observed-facts.ts",
     "content-kitchen:post-publish-build-output-adapter": "tsx scripts/run-content-kitchen-post-publish-build-output-adapter.ts",
+    "content-kitchen:post-publish-local-audit": "tsx scripts/run-content-kitchen-post-publish-local-audit-chain.ts",
     "test:pinpoint-seo": "tsx scripts/check-pinpoint-seo-builders.ts",
     "test:content-kitchen": "tsx scripts/check-content-kitchen-contract.ts",
     "test:pinpoint-routing": "tsx scripts/check-routing-regressions.ts",

--- a/scripts/check-content-kitchen-contract.ts
+++ b/scripts/check-content-kitchen-contract.ts
@@ -110,6 +110,11 @@ import {
   runContentKitchenPostPublishBuildOutputAdapterFromFile,
 } from "./run-content-kitchen-post-publish-build-output-adapter";
 import {
+  POST_PUBLISH_LOCAL_AUDIT_CHAIN_RESULT_VERSION,
+  runCli as runContentKitchenPostPublishLocalAuditChainCli,
+  runContentKitchenPostPublishLocalAuditChainFromFile,
+} from "./run-content-kitchen-post-publish-local-audit-chain";
+import {
   REVIEW_UI_SURFACE_VERSION,
   renderReviewUiInputHtml,
 } from "./content-kitchen-review-ui-surface";
@@ -3675,6 +3680,11 @@ async function assertPostPublishAuditDoc() {
     "`buildOutput.sitemapPath`",
     "`--output` must not equal the resolved HTML source",
     "`--output` must not equal the resolved sitemap source",
+    "Local Audit Chain",
+    "content-kitchen-post-publish-local-audit-chain-result-v0",
+    "npm run content-kitchen:post-publish-local-audit",
+    "The chain reads the same input as the build output adapter.",
+    "The output file is the final post-publish audit artifact.",
   ];
 
   for (const snippet of requiredSnippets) {
@@ -4670,6 +4680,128 @@ async function assertPostPublishBuildOutputAdapterAndExamples() {
   );
 }
 
+async function assertPostPublishLocalAuditChainAndExamples() {
+  const packageJson = JSON.parse(await readFile(PACKAGE_JSON_PATH, "utf8")) as {
+    scripts?: Record<string, string>;
+  };
+  assert.ok(
+    packageJson.scripts?.["content-kitchen:post-publish-local-audit"]?.includes(
+      "run-content-kitchen-post-publish-local-audit-chain.ts",
+    ),
+    "package.json should expose the content-kitchen post-publish local audit chain",
+  );
+
+  const observedExamplePath = resolve(EXAMPLE_DIR, "post-publish-observed-facts-pass.input.example.json");
+  const htmlExamplePath = resolve(EXAMPLE_DIR, "post-publish-observed-facts-pass.html.example");
+  const sitemapExamplePath = resolve(EXAMPLE_DIR, "post-publish-observed-facts-sitemap.xml.example");
+  const observedExample = JSON.parse(await readFile(observedExamplePath, "utf8")) as {
+    expected: PostPublishAuditExpectedStateV0;
+  };
+  const tmpDir = await mkdtemp(resolve(tmpdir(), "content-kitchen-local-audit-chain-"));
+  try {
+    const appDir = resolve(tmpDir, ".next", "server", "app");
+    const detailDir = resolve(appDir, "linkedin-pinpoint-answers");
+    await mkdir(detailDir, { recursive: true });
+    const htmlPath = resolve(detailDir, "pinpoint-answer-925.html");
+    const sitemapPath = resolve(appDir, "sitemap.xml.body");
+    await writeFile(htmlPath, await readFile(htmlExamplePath, "utf8"), "utf8");
+    await writeFile(sitemapPath, await readFile(sitemapExamplePath, "utf8"), "utf8");
+
+    const chainInputPath = resolve(tmpDir, "local-audit-chain-input.json");
+    await writeFile(
+      chainInputPath,
+      `${JSON.stringify(
+        {
+          schemaVersion: POST_PUBLISH_BUILD_OUTPUT_ADAPTER_INPUT_VERSION,
+          artifactId: "art_post_publish_local_audit_chain_contract_test",
+          checkedAt: "2026-05-24T10:40:00.000Z",
+          expected: observedExample.expected,
+          buildOutput: {
+            appDir: ".next/server/app",
+            siteBaseUrl: "https://example.com",
+            httpStatus: 200,
+          },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+
+    const outputPath = resolve(tmpDir, "post-publish-audit.json");
+    const result = await runContentKitchenPostPublishLocalAuditChainFromFile({
+      inputPath: chainInputPath,
+      outputPath,
+    });
+    const writtenArtifact = JSON.parse(await readFile(outputPath, "utf8")) as {
+      artifactVersion: string;
+      artifactType: string;
+      auditOutcome: string;
+      issueCodes: string[];
+      safety: {
+        rawRenderedHtmlIncluded: boolean;
+        publicFetchPerformedByContract: boolean;
+        publishAllowed: boolean;
+      };
+    };
+
+    assert.equal(
+      result.schemaVersion,
+      POST_PUBLISH_LOCAL_AUDIT_CHAIN_RESULT_VERSION,
+      "local audit chain result version should be stable",
+    );
+    assert.equal(result.dryRunOnly, true, "local audit chain should stay dry-run only");
+    assert.equal(result.sourceFiles.appDir, appDir, "local audit chain should resolve appDir");
+    assert.equal(result.sourceFiles.htmlPath, htmlPath, "local audit chain should find static detail HTML");
+    assert.equal(result.sourceFiles.sitemapPath, sitemapPath, "local audit chain should find sitemap.xml.body");
+    assert.equal(
+      result.auditArtifact.auditOutcome,
+      "published_and_audit_passed",
+      "local audit chain should produce a passing audit artifact",
+    );
+    assert.deepEqual(result.auditArtifact.issueCodes, [], "local audit chain should produce no issue codes");
+    assert.equal(writtenArtifact.artifactType, "post_publish_audit", "local audit chain output should be an artifact");
+    assert.equal(
+      writtenArtifact.auditOutcome,
+      "published_and_audit_passed",
+      "local audit chain output file should be the final audit artifact",
+    );
+    assert.equal(
+      writtenArtifact.safety.rawRenderedHtmlIncluded,
+      false,
+      "local audit chain output should not include raw rendered HTML",
+    );
+    assert.equal(
+      writtenArtifact.safety.publicFetchPerformedByContract,
+      false,
+      "local audit chain should not fetch public URLs itself",
+    );
+    assert.equal(writtenArtifact.safety.publishAllowed, false, "local audit chain should not publish");
+    assert.ok(
+      !JSON.stringify(writtenArtifact).includes("<main"),
+      "local audit chain output should not include raw rendered HTML",
+    );
+
+    await assert.rejects(
+      () => runContentKitchenPostPublishLocalAuditChainCli(["--input", chainInputPath, "--output", chainInputPath]),
+      /--output must be different from --input/,
+      "local audit chain CLI should reject output paths that overwrite input",
+    );
+    await assert.rejects(
+      () => runContentKitchenPostPublishLocalAuditChainCli(["--input", chainInputPath, "--output", htmlPath]),
+      /--output must be different from resolved HTML source/,
+      "local audit chain CLI should reject output paths that overwrite HTML source",
+    );
+    await assert.rejects(
+      () => runContentKitchenPostPublishLocalAuditChainCli(["--input", chainInputPath, "--output", sitemapPath]),
+      /--output must be different from resolved sitemap source/,
+      "local audit chain CLI should reject output paths that overwrite sitemap source",
+    );
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+}
+
 async function main() {
   const fileNames = (await readdir(FIXTURE_DIR)).filter((fileName) => fileName.endsWith(".json")).sort();
   assert.ok(fileNames.length >= 6, "content kitchen should have at least 6 fixtures");
@@ -4724,6 +4856,7 @@ async function main() {
   await assertPostPublishAuditRunnerAndExamples();
   await assertPostPublishObservedFactsBuilderAndExamples();
   await assertPostPublishBuildOutputAdapterAndExamples();
+  await assertPostPublishLocalAuditChainAndExamples();
   console.log(`content-kitchen contract fixtures passed (${fileNames.length} fixtures)`);
 }
 

--- a/scripts/run-content-kitchen-post-publish-local-audit-chain.ts
+++ b/scripts/run-content-kitchen-post-publish-local-audit-chain.ts
@@ -1,0 +1,160 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import type { PostPublishAuditArtifactV0 } from "../lib/puzzles/content-kitchen/types";
+import {
+  POST_PUBLISH_AUDIT_RUNNER_INPUT_VERSION,
+  runContentKitchenPostPublishAuditJson,
+  type PostPublishAuditRunnerInput,
+} from "./run-content-kitchen-post-publish-audit";
+import {
+  runContentKitchenPostPublishBuildOutputAdapterFromFile,
+} from "./run-content-kitchen-post-publish-build-output-adapter";
+import {
+  buildPostPublishObservedFacts,
+} from "./run-content-kitchen-post-publish-observed-facts";
+
+export const POST_PUBLISH_LOCAL_AUDIT_CHAIN_RESULT_VERSION =
+  "content-kitchen-post-publish-local-audit-chain-result-v0";
+
+export type ContentKitchenPostPublishLocalAuditChainResult = {
+  schemaVersion: typeof POST_PUBLISH_LOCAL_AUDIT_CHAIN_RESULT_VERSION;
+  dryRunOnly: true;
+  sourcePath: string;
+  outputPath?: string;
+  sourceFiles: {
+    appDir: string;
+    htmlPath: string;
+    sitemapPath?: string;
+  };
+  auditArtifact: PostPublishAuditArtifactV0;
+};
+
+type ParsedArgs = {
+  inputPath: string;
+  outputPath?: string;
+  pretty: boolean;
+};
+
+function readArgValue(argv: string[], index: number, name: string): string {
+  const value = argv[index + 1];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${name} requires a value`);
+  }
+
+  return value;
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
+  let inputPath = "";
+  let outputPath: string | undefined;
+  let pretty = true;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--input") {
+      inputPath = resolve(readArgValue(argv, index, "--input"));
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--output") {
+      outputPath = resolve(readArgValue(argv, index, "--output"));
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--compact") {
+      pretty = false;
+      continue;
+    }
+
+    if (arg === "--pretty") {
+      pretty = true;
+      continue;
+    }
+
+    if (arg === "--help" || arg === "-h") {
+      throw new Error(
+        "Usage: npm run content-kitchen:post-publish-local-audit -- --input <path> [--output <path>] [--pretty|--compact]",
+      );
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  if (!inputPath) {
+    throw new Error("Missing required --input <path>");
+  }
+  if (outputPath === inputPath) {
+    throw new Error("--output must be different from --input");
+  }
+
+  return {
+    inputPath,
+    outputPath,
+    pretty,
+  };
+}
+
+export async function runContentKitchenPostPublishLocalAuditChainFromFile(input: {
+  inputPath: string;
+  outputPath?: string;
+}): Promise<ContentKitchenPostPublishLocalAuditChainResult> {
+  const inputPath = resolve(input.inputPath);
+  const outputPath = input.outputPath ? resolve(input.outputPath) : undefined;
+  if (outputPath === inputPath) {
+    throw new Error("--output must be different from --input");
+  }
+
+  const adapterResult = await runContentKitchenPostPublishBuildOutputAdapterFromFile({ inputPath });
+  if (outputPath === adapterResult.sourceFiles.htmlPath) {
+    throw new Error("--output must be different from resolved HTML source");
+  }
+  if (outputPath && adapterResult.sourceFiles.sitemapPath === outputPath) {
+    throw new Error("--output must be different from resolved sitemap source");
+  }
+
+  const observed = await buildPostPublishObservedFacts({
+    expected: adapterResult.observedFactsBuilderInput.expected,
+    sources: adapterResult.observedFactsBuilderInput.sources,
+    htmlPath: adapterResult.sourceFiles.htmlPath,
+    ...(adapterResult.sourceFiles.sitemapPath ? { sitemapPath: adapterResult.sourceFiles.sitemapPath } : {}),
+  });
+  const auditRunnerInput: PostPublishAuditRunnerInput = {
+    schemaVersion: POST_PUBLISH_AUDIT_RUNNER_INPUT_VERSION,
+    artifactId: adapterResult.observedFactsBuilderInput.artifactId,
+    checkedAt: adapterResult.observedFactsBuilderInput.checkedAt,
+    expected: adapterResult.observedFactsBuilderInput.expected,
+    observed,
+  };
+  const auditArtifact = runContentKitchenPostPublishAuditJson(auditRunnerInput);
+  const result: ContentKitchenPostPublishLocalAuditChainResult = {
+    schemaVersion: POST_PUBLISH_LOCAL_AUDIT_CHAIN_RESULT_VERSION,
+    dryRunOnly: true,
+    sourcePath: inputPath,
+    ...(outputPath ? { outputPath } : {}),
+    sourceFiles: adapterResult.sourceFiles,
+    auditArtifact,
+  };
+
+  if (outputPath) {
+    await mkdir(dirname(outputPath), { recursive: true });
+    await writeFile(outputPath, `${JSON.stringify(auditArtifact, null, 2)}\n`, "utf8");
+  }
+
+  return result;
+}
+
+export async function runCli(argv: string[] = process.argv.slice(2)): Promise<void> {
+  const args = parseArgs(argv);
+  const result = await runContentKitchenPostPublishLocalAuditChainFromFile(args);
+  console.log(JSON.stringify(result, null, args.pretty ? 2 : 0));
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  runCli().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Summary

- add a one-command local post-publish audit chain
- chain the build output adapter, observed facts builder, and audit runner in memory
- write the final `content-kitchen-post-publish-audit-v0` artifact to `--output`
- document PR11.5 and cover it in the content-kitchen contract test

## Checks

- `npm run test:content-kitchen`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- local smoke: `content-kitchen:post-publish-local-audit` against built Pinpoint #754 output
