### PR TITLE
[codex] Add PR11 public fetch audit

### DIFF
--- a/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
+++ b/docs/pinpoint-content-kitchen-competitor-derived-plan-2026-05-22.md
@@ -2402,6 +2402,20 @@ PR11 fifth implementation slice:
 - prove the output does not include raw rendered HTML
 - do not fetch public URLs, run a browser, read production storage, write review queue storage, send Feishu messages, publish content, or run Worker cron yet
 
+PR11 sixth implementation slice:
+
+- add a read-only public fetch audit command
+- read `content-kitchen-post-publish-public-fetch-audit-input-v0` JSON from `--input`
+- fetch `expected.canonicalUrl`
+- fetch same-origin `publicFetch.sitemapUrl` when provided, or `/sitemap.xml` by default
+- extract observed facts from fetched HTML and sitemap text in memory
+- output the final `content-kitchen-post-publish-audit-v0` artifact
+- mark the reader result with `publicFetchPerformedByReader: true`
+- keep the core audit artifact contract fact-only, with `safety.publicFetchPerformedByContract: false`
+- reject unsafe inputs containing raw rendered HTML, model prompts, or secrets
+- reject cross-origin sitemap URLs
+- keep this read-only; do not run a browser, read production storage, write review queue storage, send Feishu messages, publish content, or run Worker cron yet
+
 
 ## Review UI Requirements
 

--- a/docs/pinpoint-content-kitchen-pr11-post-publish-audit-contract-2026-05-24.md
+++ b/docs/pinpoint-content-kitchen-pr11-post-publish-audit-contract-2026-05-24.md
@@ -329,3 +329,59 @@ Chain rules:
 - the chain does not send Feishu messages
 - the chain does not write review queue storage
 - the chain does not publish content
+
+## Public Fetch Audit
+
+PR11.6 adds a read-only public fetch audit command.
+
+Input uses `content-kitchen-post-publish-public-fetch-audit-input-v0`.
+
+Reader result uses `content-kitchen-post-publish-public-fetch-audit-result-v0`.
+
+Run it with:
+
+```bash
+npm run content-kitchen:post-publish-public-fetch-audit -- \
+  --input lib/puzzles/content-kitchen/examples/post-publish-public-fetch-audit.input.example.json \
+  --output /tmp/content-kitchen-post-publish-audit.json \
+  --pretty
+```
+
+Example file:
+
+- `post-publish-public-fetch-audit.input.example.json`
+
+The public fetch reader is read-only.
+
+It reads:
+
+- `expected.canonicalUrl`
+- `publicFetch.sitemapUrl` when provided
+- `publicFetch.timeoutMs` when provided
+- `publicFetch.userAgent` when provided
+
+If `publicFetch.sitemapUrl` is missing, it tries `/sitemap.xml` on the same site origin as `expected.canonicalUrl`.
+
+It does these steps:
+
+1. fetch the public canonical URL
+2. fetch the same-origin sitemap URL when the page fetch succeeds
+3. extract observed facts from the fetched HTML and sitemap text in memory
+4. build the final `content-kitchen-post-publish-audit-v0` artifact
+
+Reader rules:
+
+- `--input` is required
+- `--output` is optional
+- `--output` must not equal `--input`
+- `expected.canonicalUrl` must use `http` or `https`
+- `publicFetch.sitemapUrl` must use the same origin as `expected.canonicalUrl`
+- `publicFetch.timeoutMs` must be between 500 and 30000 when provided
+- output must not include raw HTML
+- the reader does not run a browser
+- the reader does not send Feishu messages
+- the reader does not write review queue storage
+- the reader does not publish content
+- the reader does not run Worker cron
+
+The result wrapper marks `publicFetchPerformedByReader: true`. The audit artifact still marks `safety.publicFetchPerformedByContract: false` because the core audit contract only consumes facts; the reader is the part that performs the fetch.

--- a/lib/puzzles/content-kitchen/examples/post-publish-public-fetch-audit.input.example.json
+++ b/lib/puzzles/content-kitchen/examples/post-publish-public-fetch-audit.input.example.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "content-kitchen-post-publish-public-fetch-audit-input-v0",
+  "artifactId": "art_post_publish_public_fetch_audit_example",
+  "checkedAt": "2026-05-24T11:00:00.000Z",
+  "expected": {
+    "puzzleId": "pinpoint-925-2026-05-24",
+    "canonicalUrl": "https://example.com/linkedin-pinpoint-answers/pinpoint-answer-925/",
+    "revisionId": "rev-full-analysis-925",
+    "contentMode": "full-analysis",
+    "answer": "BASS",
+    "clues": [
+      "Low instrument",
+      "Fishing target",
+      "Deep voice",
+      "Speaker setting",
+      "Music section"
+    ],
+    "policies": {
+      "indexPolicy": "index",
+      "sitemapPolicy": "include",
+      "schemaPolicy": "faq_allowed",
+      "internalLinkPolicy": "normal",
+      "requiredAction": "none"
+    },
+    "schemaTypes": ["Article", "FAQPage"],
+    "sitemapLastmod": "2026-05-24",
+    "schemaDateModified": "2026-05-24",
+    "expectedInternalLinks": ["/linkedin-pinpoint-answers/pinpoint-answer-924/"]
+  },
+  "publicFetch": {
+    "sitemapUrl": "https://example.com/sitemap.xml",
+    "timeoutMs": 10000,
+    "userAgent": "PinpointContentKitchenAudit/0.1"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "content-kitchen:post-publish-observed-facts": "tsx scripts/run-content-kitchen-post-publish-observed-facts.ts",
     "content-kitchen:post-publish-build-output-adapter": "tsx scripts/run-content-kitchen-post-publish-build-output-adapter.ts",
     "content-kitchen:post-publish-local-audit": "tsx scripts/run-content-kitchen-post-publish-local-audit-chain.ts",
+    "content-kitchen:post-publish-public-fetch-audit": "tsx scripts/run-content-kitchen-post-publish-public-fetch-audit.ts",
     "test:pinpoint-seo": "tsx scripts/check-pinpoint-seo-builders.ts",
     "test:content-kitchen": "tsx scripts/check-content-kitchen-contract.ts",
     "test:pinpoint-routing": "tsx scripts/check-routing-regressions.ts",

--- a/scripts/check-content-kitchen-contract.ts
+++ b/scripts/check-content-kitchen-contract.ts
@@ -1,5 +1,7 @@
 import assert from "node:assert/strict";
 import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -114,6 +116,12 @@ import {
   runCli as runContentKitchenPostPublishLocalAuditChainCli,
   runContentKitchenPostPublishLocalAuditChainFromFile,
 } from "./run-content-kitchen-post-publish-local-audit-chain";
+import {
+  POST_PUBLISH_PUBLIC_FETCH_AUDIT_INPUT_VERSION,
+  POST_PUBLISH_PUBLIC_FETCH_AUDIT_RESULT_VERSION,
+  runCli as runContentKitchenPostPublishPublicFetchAuditCli,
+  runContentKitchenPostPublishPublicFetchAuditFromFile,
+} from "./run-content-kitchen-post-publish-public-fetch-audit";
 import {
   REVIEW_UI_SURFACE_VERSION,
   renderReviewUiInputHtml,
@@ -3685,6 +3693,16 @@ async function assertPostPublishAuditDoc() {
     "npm run content-kitchen:post-publish-local-audit",
     "The chain reads the same input as the build output adapter.",
     "The output file is the final post-publish audit artifact.",
+    "Public Fetch Audit",
+    "content-kitchen-post-publish-public-fetch-audit-input-v0",
+    "content-kitchen-post-publish-public-fetch-audit-result-v0",
+    "npm run content-kitchen:post-publish-public-fetch-audit",
+    "--input lib/puzzles/content-kitchen/examples/post-publish-public-fetch-audit.input.example.json",
+    "post-publish-public-fetch-audit.input.example.json",
+    "`publicFetch.sitemapUrl`",
+    "`publicFetch.timeoutMs`",
+    "`publicFetch.userAgent`",
+    "The public fetch reader is read-only.",
   ];
 
   for (const snippet of requiredSnippets) {
@@ -4802,6 +4820,196 @@ async function assertPostPublishLocalAuditChainAndExamples() {
   }
 }
 
+function listenOnLocalhost(server: Server): Promise<number> {
+  return new Promise((resolveListen, rejectListen) => {
+    server.once("error", rejectListen);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address() as AddressInfo;
+      server.off("error", rejectListen);
+      resolveListen(address.port);
+    });
+  });
+}
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise((resolveClose, rejectClose) => {
+    if (!server.listening) {
+      resolveClose();
+      return;
+    }
+    server.close((error) => {
+      if (error) rejectClose(error);
+      else resolveClose();
+    });
+  });
+}
+
+async function assertPostPublishPublicFetchAuditAndExamples() {
+  const packageJson = JSON.parse(await readFile(PACKAGE_JSON_PATH, "utf8")) as {
+    scripts?: Record<string, string>;
+  };
+  assert.ok(
+    packageJson.scripts?.["content-kitchen:post-publish-public-fetch-audit"]?.includes(
+      "run-content-kitchen-post-publish-public-fetch-audit.ts",
+    ),
+    "package.json should expose the content-kitchen post-publish public fetch audit",
+  );
+
+  const publicFetchExamplePath = resolve(EXAMPLE_DIR, "post-publish-public-fetch-audit.input.example.json");
+  const observedExamplePath = resolve(EXAMPLE_DIR, "post-publish-observed-facts-pass.input.example.json");
+  const htmlExamplePath = resolve(EXAMPLE_DIR, "post-publish-observed-facts-pass.html.example");
+  const sitemapExamplePath = resolve(EXAMPLE_DIR, "post-publish-observed-facts-sitemap.xml.example");
+  const observedExample = JSON.parse(await readFile(observedExamplePath, "utf8")) as {
+    expected: PostPublishAuditExpectedStateV0;
+  };
+  const htmlExample = await readFile(htmlExamplePath, "utf8");
+  const sitemapExample = await readFile(sitemapExamplePath, "utf8");
+  let baseUrl = "";
+  const server = createServer((request, response) => {
+    if (request.url === "/linkedin-pinpoint-answers/pinpoint-answer-925/") {
+      response.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+      response.end(htmlExample.replaceAll("https://example.com", baseUrl));
+      return;
+    }
+    if (request.url === "/sitemap.xml") {
+      response.writeHead(200, { "content-type": "application/xml; charset=utf-8" });
+      response.end(sitemapExample.replaceAll("https://example.com", baseUrl));
+      return;
+    }
+    response.writeHead(404, { "content-type": "text/plain; charset=utf-8" });
+    response.end("not found");
+  });
+  const tmpDir = await mkdtemp(resolve(tmpdir(), "content-kitchen-public-fetch-audit-"));
+  try {
+    const port = await listenOnLocalhost(server);
+    baseUrl = `http://127.0.0.1:${port}`;
+    const publicFetchInputPath = resolve(tmpDir, "public-fetch-audit-input.json");
+    await writeFile(
+      publicFetchInputPath,
+      `${JSON.stringify(
+        {
+          schemaVersion: POST_PUBLISH_PUBLIC_FETCH_AUDIT_INPUT_VERSION,
+          artifactId: "art_post_publish_public_fetch_audit_contract_test",
+          checkedAt: "2026-05-24T11:00:00.000Z",
+          expected: {
+            ...observedExample.expected,
+            canonicalUrl: `${baseUrl}/linkedin-pinpoint-answers/pinpoint-answer-925/`,
+          },
+          publicFetch: {
+            sitemapUrl: `${baseUrl}/sitemap.xml`,
+            timeoutMs: 5000,
+            userAgent: "PinpointContentKitchenAudit/0.1",
+          },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+
+    const outputPath = resolve(tmpDir, "post-publish-audit.json");
+    const result = await runContentKitchenPostPublishPublicFetchAuditFromFile({
+      inputPath: publicFetchInputPath,
+      outputPath,
+    });
+    const writtenArtifact = JSON.parse(await readFile(outputPath, "utf8")) as {
+      artifactVersion: string;
+      artifactType: string;
+      auditOutcome: string;
+      issueCodes: string[];
+      safety: {
+        rawRenderedHtmlIncluded: boolean;
+        publicFetchPerformedByContract: boolean;
+        publishAllowed: boolean;
+      };
+    };
+
+    assert.equal(
+      result.schemaVersion,
+      POST_PUBLISH_PUBLIC_FETCH_AUDIT_RESULT_VERSION,
+      "public fetch audit result version should be stable",
+    );
+    assert.equal(result.readOnly, true, "public fetch audit should stay read-only");
+    assert.equal(result.dryRunOnly, true, "public fetch audit should stay dry-run only");
+    assert.equal(
+      result.publicFetchPerformedByReader,
+      true,
+      "public fetch audit should clearly mark that the reader fetched public URLs",
+    );
+    assert.equal(result.fetched.httpStatus, 200, "public fetch audit should record page HTTP status");
+    assert.equal(result.fetched.sitemapHttpStatus, 200, "public fetch audit should record sitemap HTTP status");
+    assert.equal(
+      result.auditArtifact.auditOutcome,
+      "published_and_audit_passed",
+      "public fetch audit should produce a passing audit artifact",
+    );
+    assert.deepEqual(result.auditArtifact.issueCodes, [], "public fetch audit should produce no issue codes");
+    assert.equal(writtenArtifact.artifactType, "post_publish_audit", "public fetch output should be an artifact");
+    assert.equal(
+      writtenArtifact.auditOutcome,
+      "published_and_audit_passed",
+      "public fetch output file should be the final audit artifact",
+    );
+    assert.equal(
+      writtenArtifact.safety.rawRenderedHtmlIncluded,
+      false,
+      "public fetch audit output should not include raw rendered HTML",
+    );
+    assert.equal(
+      writtenArtifact.safety.publicFetchPerformedByContract,
+      false,
+      "public fetch audit should keep the core artifact contract fetch-free",
+    );
+    assert.equal(writtenArtifact.safety.publishAllowed, false, "public fetch audit should not publish");
+    assert.ok(
+      !JSON.stringify(writtenArtifact).includes("<main"),
+      "public fetch audit output should not include raw rendered HTML",
+    );
+
+    await assert.rejects(
+      () => runContentKitchenPostPublishPublicFetchAuditCli(["--input", publicFetchInputPath, "--output", publicFetchInputPath]),
+      /--output must be different from --input/,
+      "public fetch audit CLI should reject output paths that overwrite input",
+    );
+
+    const badSitemapInputPath = resolve(tmpDir, "bad-sitemap-origin.json");
+    await writeFile(
+      badSitemapInputPath,
+      `${JSON.stringify(
+        {
+          schemaVersion: POST_PUBLISH_PUBLIC_FETCH_AUDIT_INPUT_VERSION,
+          artifactId: "art_post_publish_public_fetch_bad_sitemap_origin",
+          checkedAt: "2026-05-24T11:05:00.000Z",
+          expected: {
+            ...observedExample.expected,
+            canonicalUrl: `${baseUrl}/linkedin-pinpoint-answers/pinpoint-answer-925/`,
+          },
+          publicFetch: {
+            sitemapUrl: "https://example.org/sitemap.xml",
+          },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+    await assert.rejects(
+      () => runContentKitchenPostPublishPublicFetchAuditFromFile({ inputPath: badSitemapInputPath }),
+      /publicFetch.sitemapUrl must use the same origin/,
+      "public fetch audit should reject sitemap URLs from another origin",
+    );
+  } finally {
+    await closeServer(server);
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+
+  const inputRaw = await readFile(publicFetchExamplePath, "utf8");
+  assert.ok(
+    inputRaw.includes(POST_PUBLISH_PUBLIC_FETCH_AUDIT_INPUT_VERSION),
+    "public fetch audit example should use stable input version",
+  );
+}
+
 async function main() {
   const fileNames = (await readdir(FIXTURE_DIR)).filter((fileName) => fileName.endsWith(".json")).sort();
   assert.ok(fileNames.length >= 6, "content kitchen should have at least 6 fixtures");
@@ -4857,6 +5065,7 @@ async function main() {
   await assertPostPublishObservedFactsBuilderAndExamples();
   await assertPostPublishBuildOutputAdapterAndExamples();
   await assertPostPublishLocalAuditChainAndExamples();
+  await assertPostPublishPublicFetchAuditAndExamples();
   console.log(`content-kitchen contract fixtures passed (${fileNames.length} fixtures)`);
 }
 

--- a/scripts/run-content-kitchen-post-publish-observed-facts.ts
+++ b/scripts/run-content-kitchen-post-publish-observed-facts.ts
@@ -441,6 +441,23 @@ export async function buildPostPublishObservedFacts(input: {
   sitemapPath?: string;
 }): Promise<PostPublishAuditObservedStateV0> {
   const html = await readFile(input.htmlPath, "utf8");
+  const sitemapXml = input.sitemapPath ? await readFile(input.sitemapPath, "utf8") : undefined;
+
+  return buildPostPublishObservedFactsFromHtml({
+    expected: input.expected,
+    sources: input.sources,
+    html,
+    ...(sitemapXml ? { sitemapXml } : {}),
+  });
+}
+
+export function buildPostPublishObservedFactsFromHtml(input: {
+  expected: PostPublishAuditExpectedStateV0;
+  sources: Pick<PostPublishObservedFactsBuilderInput["sources"], "fetchedUrl" | "httpStatus">;
+  html: string;
+  sitemapXml?: string;
+}): PostPublishAuditObservedStateV0 {
+  const html = input.html;
   const visibleText = visibleTextFromHtml(html);
   const normalizedVisibleText = normalizeForMatch(visibleText);
   const schemaObjects = parseJsonLdObjects(html);
@@ -449,8 +466,8 @@ export async function buildPostPublishObservedFacts(input: {
       .map((href) => normalizeInternalLink(href, input.expected.canonicalUrl))
       .filter((href): href is string => Boolean(href)),
   )];
-  const sitemapFacts = input.sitemapPath
-    ? parseSitemap(await readFile(input.sitemapPath, "utf8"), input.expected.canonicalUrl)
+  const sitemapFacts = input.sitemapXml
+    ? parseSitemap(input.sitemapXml, input.expected.canonicalUrl)
     : {};
   const statusOk =
     input.sources.httpStatus === undefined ||

--- a/scripts/run-content-kitchen-post-publish-public-fetch-audit.ts
+++ b/scripts/run-content-kitchen-post-publish-public-fetch-audit.ts
@@ -1,0 +1,450 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import type {
+  ContentMode,
+  IndexPolicy,
+  InternalLinkPolicy,
+  PostPublishAuditArtifactV0,
+  PostPublishAuditExpectedStateV0,
+  RequiredAction,
+  SchemaPolicy,
+  SitemapPolicy,
+  ValidationPolicies,
+} from "../lib/puzzles/content-kitchen/types";
+import {
+  POST_PUBLISH_AUDIT_RUNNER_INPUT_VERSION,
+  runContentKitchenPostPublishAuditJson,
+  type PostPublishAuditRunnerInput,
+} from "./run-content-kitchen-post-publish-audit";
+import {
+  buildPostPublishObservedFactsFromHtml,
+} from "./run-content-kitchen-post-publish-observed-facts";
+
+export const POST_PUBLISH_PUBLIC_FETCH_AUDIT_INPUT_VERSION =
+  "content-kitchen-post-publish-public-fetch-audit-input-v0";
+export const POST_PUBLISH_PUBLIC_FETCH_AUDIT_RESULT_VERSION =
+  "content-kitchen-post-publish-public-fetch-audit-result-v0";
+
+export type PostPublishPublicFetchAuditInput = {
+  schemaVersion?: typeof POST_PUBLISH_PUBLIC_FETCH_AUDIT_INPUT_VERSION;
+  artifactId: string;
+  checkedAt: string;
+  expected: PostPublishAuditExpectedStateV0;
+  publicFetch?: {
+    sitemapUrl?: string;
+    timeoutMs?: number;
+    userAgent?: string;
+  };
+};
+
+export type ContentKitchenPostPublishPublicFetchAuditResult = {
+  schemaVersion: typeof POST_PUBLISH_PUBLIC_FETCH_AUDIT_RESULT_VERSION;
+  readOnly: true;
+  dryRunOnly: true;
+  publicFetchPerformedByReader: true;
+  sourcePath: string;
+  outputPath?: string;
+  fetched: {
+    url: string;
+    httpStatus?: number;
+    sitemapUrl?: string;
+    sitemapHttpStatus?: number;
+  };
+  auditArtifact: PostPublishAuditArtifactV0;
+};
+
+type ParsedArgs = {
+  inputPath: string;
+  outputPath?: string;
+  pretty: boolean;
+};
+
+type FetchResult = {
+  url: string;
+  httpStatus?: number;
+  ok: boolean;
+  body: string;
+};
+
+function readArgValue(argv: string[], index: number, name: string): string {
+  const value = argv[index + 1];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${name} requires a value`);
+  }
+
+  return value;
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
+  let inputPath = "";
+  let outputPath: string | undefined;
+  let pretty = true;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--input") {
+      inputPath = resolve(readArgValue(argv, index, "--input"));
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--output") {
+      outputPath = resolve(readArgValue(argv, index, "--output"));
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--compact") {
+      pretty = false;
+      continue;
+    }
+
+    if (arg === "--pretty") {
+      pretty = true;
+      continue;
+    }
+
+    if (arg === "--help" || arg === "-h") {
+      throw new Error(
+        "Usage: npm run content-kitchen:post-publish-public-fetch-audit -- --input <path> [--output <path>] [--pretty|--compact]",
+      );
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  if (!inputPath) {
+    throw new Error("Missing required --input <path>");
+  }
+  if (outputPath === inputPath) {
+    throw new Error("--output must be different from --input");
+  }
+
+  return {
+    inputPath,
+    outputPath,
+    pretty,
+  };
+}
+
+function requireObject(value: unknown, fieldPath: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${fieldPath} must be an object`);
+  }
+
+  return value as Record<string, unknown>;
+}
+
+function requireText(record: Record<string, unknown>, key: string, fieldPath: string): string {
+  const value = record[key];
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`${fieldPath}.${key} must be a non-empty string`);
+  }
+
+  return value;
+}
+
+function optionalText(record: Record<string, unknown>, key: string, fieldPath: string): string | undefined {
+  const value = record[key];
+  if (value === undefined) return undefined;
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`${fieldPath}.${key} must be a non-empty string`);
+  }
+
+  return value;
+}
+
+function optionalNumber(record: Record<string, unknown>, key: string, fieldPath: string): number | undefined {
+  const value = record[key];
+  if (value === undefined) return undefined;
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new Error(`${fieldPath}.${key} must be a finite number`);
+  }
+
+  return value;
+}
+
+function optionalTextArray(record: Record<string, unknown>, key: string, fieldPath: string): string[] | undefined {
+  const value = record[key];
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value) || value.some((item) => typeof item !== "string" || !item.trim())) {
+    throw new Error(`${fieldPath}.${key} must be an array of non-empty strings`);
+  }
+
+  return [...value];
+}
+
+function requireTextArray(record: Record<string, unknown>, key: string, fieldPath: string): string[] {
+  const value = optionalTextArray(record, key, fieldPath);
+  if (!value) {
+    throw new Error(`${fieldPath}.${key} must be an array of non-empty strings`);
+  }
+
+  return value;
+}
+
+function requireEnum<T extends string>(
+  record: Record<string, unknown>,
+  key: string,
+  fieldPath: string,
+  values: readonly T[],
+): T {
+  const value = record[key];
+  if (typeof value !== "string" || !values.includes(value as T)) {
+    throw new Error(`${fieldPath}.${key} must be one of: ${values.join(", ")}`);
+  }
+
+  return value as T;
+}
+
+function parsePolicies(value: unknown): ValidationPolicies {
+  const policies = requireObject(value, "expected.policies");
+  return {
+    indexPolicy: requireEnum<IndexPolicy>(policies, "indexPolicy", "expected.policies", [
+      "index",
+      "noindex",
+      "review_required",
+      "block_publish",
+    ]),
+    sitemapPolicy: requireEnum<SitemapPolicy>(policies, "sitemapPolicy", "expected.policies", [
+      "include",
+      "exclude",
+      "remove_on_next_build",
+      "include_after_audit",
+    ]),
+    schemaPolicy: requireEnum<SchemaPolicy>(policies, "schemaPolicy", "expected.policies", [
+      "none",
+      "article_only",
+      "faq_allowed",
+      "block_schema",
+    ]),
+    internalLinkPolicy: requireEnum<InternalLinkPolicy>(policies, "internalLinkPolicy", "expected.policies", [
+      "normal",
+      "deemphasized",
+      "hidden_from_recent",
+    ]),
+    requiredAction: requireEnum<RequiredAction>(policies, "requiredAction", "expected.policies", [
+      "none",
+      "enrich",
+      "review",
+      "block_publish",
+      "upgrade",
+      "rollback",
+      "degrade",
+      "create_fix_task",
+      "dead_letter",
+      "keep_current",
+    ]),
+  };
+}
+
+function requireHttpUrl(value: string, fieldPath: string): URL {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error(`${fieldPath} must be an absolute URL`);
+  }
+  if (url.protocol !== "https:" && url.protocol !== "http:") {
+    throw new Error(`${fieldPath} must use http or https`);
+  }
+
+  return url;
+}
+
+function parseExpected(value: unknown): PostPublishAuditExpectedStateV0 {
+  const expected = requireObject(value, "expected");
+  const canonicalUrl = requireText(expected, "canonicalUrl", "expected");
+  requireHttpUrl(canonicalUrl, "expected.canonicalUrl");
+
+  return {
+    puzzleId: requireText(expected, "puzzleId", "expected"),
+    canonicalUrl,
+    revisionId: requireText(expected, "revisionId", "expected"),
+    contentMode: requireEnum<ContentMode>(expected, "contentMode", "expected", ["answer-first", "full-analysis"]),
+    answer: requireText(expected, "answer", "expected"),
+    clues: requireTextArray(expected, "clues", "expected"),
+    policies: parsePolicies(expected.policies),
+    ...(optionalTextArray(expected, "schemaTypes", "expected") ? { schemaTypes: optionalTextArray(expected, "schemaTypes", "expected") } : {}),
+    ...(optionalText(expected, "sitemapLastmod", "expected") ? { sitemapLastmod: optionalText(expected, "sitemapLastmod", "expected") } : {}),
+    ...(optionalText(expected, "schemaDateModified", "expected") ? { schemaDateModified: optionalText(expected, "schemaDateModified", "expected") } : {}),
+    ...(optionalTextArray(expected, "expectedInternalLinks", "expected") ? { expectedInternalLinks: optionalTextArray(expected, "expectedInternalLinks", "expected") } : {}),
+  };
+}
+
+function rejectUnsafePayload(raw: string): void {
+  const unsafeSnippets = [
+    "rawRenderedHtml",
+    "renderedHtml",
+    "modelPrompt",
+    "<main",
+    "<html",
+    "<script",
+    "\"secret",
+    "\"secrets",
+    "\"apiKey",
+    "\"token",
+  ];
+  const lowerRaw = raw.toLowerCase();
+  const found = unsafeSnippets.find((snippet) => lowerRaw.includes(snippet.toLowerCase()));
+  if (found) {
+    throw new Error(`public fetch audit input must not include raw HTML, model prompts, or secrets (${found})`);
+  }
+}
+
+function parsePublicFetchAuditInput(raw: string): PostPublishPublicFetchAuditInput {
+  rejectUnsafePayload(raw);
+  const record = requireObject(JSON.parse(raw) as unknown, "input");
+  const schemaVersion = record.schemaVersion;
+  if (schemaVersion !== undefined && schemaVersion !== POST_PUBLISH_PUBLIC_FETCH_AUDIT_INPUT_VERSION) {
+    throw new Error(`schemaVersion must be ${POST_PUBLISH_PUBLIC_FETCH_AUDIT_INPUT_VERSION}`);
+  }
+  const checkedAt = requireText(record, "checkedAt", "input");
+  if (!Number.isFinite(Date.parse(checkedAt))) {
+    throw new Error("input.checkedAt must be a valid timestamp");
+  }
+
+  const expected = parseExpected(record.expected);
+  const canonicalUrl = requireHttpUrl(expected.canonicalUrl, "expected.canonicalUrl");
+  const publicFetch = record.publicFetch === undefined
+    ? {}
+    : requireObject(record.publicFetch, "publicFetch");
+  const sitemapUrl = optionalText(publicFetch, "sitemapUrl", "publicFetch");
+  if (sitemapUrl) {
+    const parsedSitemapUrl = requireHttpUrl(sitemapUrl, "publicFetch.sitemapUrl");
+    if (parsedSitemapUrl.origin !== canonicalUrl.origin) {
+      throw new Error("publicFetch.sitemapUrl must use the same origin as expected.canonicalUrl");
+    }
+  }
+  const timeoutMs = optionalNumber(publicFetch, "timeoutMs", "publicFetch");
+  if (timeoutMs !== undefined && (timeoutMs < 500 || timeoutMs > 30000)) {
+    throw new Error("publicFetch.timeoutMs must be between 500 and 30000");
+  }
+
+  return {
+    ...(schemaVersion ? { schemaVersion: schemaVersion as typeof POST_PUBLISH_PUBLIC_FETCH_AUDIT_INPUT_VERSION } : {}),
+    artifactId: requireText(record, "artifactId", "input"),
+    checkedAt,
+    expected,
+    publicFetch: {
+      ...(sitemapUrl ? { sitemapUrl } : {}),
+      ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+      ...(optionalText(publicFetch, "userAgent", "publicFetch")
+        ? { userAgent: optionalText(publicFetch, "userAgent", "publicFetch") }
+        : {}),
+    },
+  };
+}
+
+function defaultSitemapUrl(canonicalUrl: string): string {
+  const url = new URL(canonicalUrl);
+  return `${url.origin}/sitemap.xml`;
+}
+
+async function fetchText(url: string, input: {
+  timeoutMs: number;
+  userAgent: string;
+}): Promise<FetchResult> {
+  try {
+    const response = await fetch(url, {
+      headers: {
+        accept: "text/html,application/xhtml+xml,application/xml,text/xml;q=0.9,*/*;q=0.8",
+        "user-agent": input.userAgent,
+      },
+      signal: AbortSignal.timeout(input.timeoutMs),
+    });
+
+    return {
+      url,
+      httpStatus: response.status,
+      ok: response.ok,
+      body: await response.text(),
+    };
+  } catch {
+    return {
+      url,
+      ok: false,
+      body: "",
+    };
+  }
+}
+
+export async function runContentKitchenPostPublishPublicFetchAuditFromFile(input: {
+  inputPath: string;
+  outputPath?: string;
+}): Promise<ContentKitchenPostPublishPublicFetchAuditResult> {
+  const inputPath = resolve(input.inputPath);
+  const outputPath = input.outputPath ? resolve(input.outputPath) : undefined;
+  if (outputPath === inputPath) {
+    throw new Error("--output must be different from --input");
+  }
+
+  const parsed = parsePublicFetchAuditInput(await readFile(inputPath, "utf8"));
+  const timeoutMs = parsed.publicFetch?.timeoutMs ?? 10000;
+  const userAgent = parsed.publicFetch?.userAgent ?? "PinpointContentKitchenAudit/0.1";
+  const pageFetch = await fetchText(parsed.expected.canonicalUrl, { timeoutMs, userAgent });
+  const sitemapUrl = parsed.publicFetch?.sitemapUrl ?? defaultSitemapUrl(parsed.expected.canonicalUrl);
+  const sitemapFetch = pageFetch.ok
+    ? await fetchText(sitemapUrl, { timeoutMs, userAgent })
+    : undefined;
+  const observed = pageFetch.ok
+    ? buildPostPublishObservedFactsFromHtml({
+      expected: parsed.expected,
+      sources: {
+        fetchedUrl: pageFetch.url,
+        ...(pageFetch.httpStatus !== undefined ? { httpStatus: pageFetch.httpStatus } : {}),
+      },
+      html: pageFetch.body,
+      ...(sitemapFetch?.ok ? { sitemapXml: sitemapFetch.body } : {}),
+    })
+    : {
+      fetchedUrl: pageFetch.url,
+      ...(pageFetch.httpStatus !== undefined ? { httpStatus: pageFetch.httpStatus } : {}),
+      fetchOk: false,
+      renderOk: false,
+    };
+  const auditRunnerInput: PostPublishAuditRunnerInput = {
+    schemaVersion: POST_PUBLISH_AUDIT_RUNNER_INPUT_VERSION,
+    artifactId: parsed.artifactId,
+    checkedAt: parsed.checkedAt,
+    expected: parsed.expected,
+    observed,
+  };
+  const auditArtifact = runContentKitchenPostPublishAuditJson(auditRunnerInput);
+  const result: ContentKitchenPostPublishPublicFetchAuditResult = {
+    schemaVersion: POST_PUBLISH_PUBLIC_FETCH_AUDIT_RESULT_VERSION,
+    readOnly: true,
+    dryRunOnly: true,
+    publicFetchPerformedByReader: true,
+    sourcePath: inputPath,
+    ...(outputPath ? { outputPath } : {}),
+    fetched: {
+      url: pageFetch.url,
+      ...(pageFetch.httpStatus !== undefined ? { httpStatus: pageFetch.httpStatus } : {}),
+      ...(sitemapFetch ? { sitemapUrl: sitemapFetch.url } : {}),
+      ...(sitemapFetch?.httpStatus !== undefined ? { sitemapHttpStatus: sitemapFetch.httpStatus } : {}),
+    },
+    auditArtifact,
+  };
+
+  if (outputPath) {
+    await mkdir(dirname(outputPath), { recursive: true });
+    await writeFile(outputPath, `${JSON.stringify(auditArtifact, null, 2)}\n`, "utf8");
+  }
+
+  return result;
+}
+
+export async function runCli(argv: string[] = process.argv.slice(2)): Promise<void> {
+  const args = parseArgs(argv);
+  const result = await runContentKitchenPostPublishPublicFetchAuditFromFile(args);
+  console.log(JSON.stringify(result, null, args.pretty ? 2 : 0));
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  runCli().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Summary

- add a read-only public fetch audit command for PR11.6
- fetch the public canonical URL and same-origin sitemap, then build the post-publish audit artifact without writing raw HTML
- reuse the observed-facts parser in memory so the audit output stays small and safe
- document the command and cover it with a local HTTP-server contract test

## Checks

- `npm run test:content-kitchen`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- read-only live smoke against current production route `/linkedin-pinpoint-answer/pinpoint-754/`

## Note

The live smoke showed the current custom domain serves the legacy route `/linkedin-pinpoint-answer/pinpoint-754/`; the newer `/linkedin-pinpoint-answers/pinpoint-answer-754/` route returns 404 on the custom domain. This PR only adds the reader and does not change production routing.
