### PR TITLE
fix: redirect legacy singular pinpoint answer routes

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -96,6 +96,12 @@ const nextConfig: NextConfig = {
         destination: "/puzzles",
         permanent: true,
       },
+      // Legacy singular answer archive: /en/linkedin-pinpoint-answer → /puzzles
+      {
+        source: `/${locale}/linkedin-pinpoint-answer`,
+        destination: "/puzzles",
+        permanent: true,
+      },
       // Puzzles archive: /en/puzzles → /puzzles
       {
         source: `/${locale}/puzzles`,
@@ -125,6 +131,13 @@ const nextConfig: NextConfig = {
       // detail URL so old indexed URLs do not compete as canonicals.
       {
         source: `/${locale}/puzzles/pinpoint-answer-:number(\\d+)`,
+        destination: "/linkedin-pinpoint-answers/pinpoint-answer-:number/",
+        permanent: true,
+      },
+      // Legacy singular answer detail:
+      // /en/linkedin-pinpoint-answer/pinpoint-678 → /linkedin-pinpoint-answers/pinpoint-answer-678/
+      {
+        source: `/${locale}/linkedin-pinpoint-answer/pinpoint-:number(\\d+)`,
         destination: "/linkedin-pinpoint-answers/pinpoint-answer-:number/",
         permanent: true,
       },
@@ -224,6 +237,18 @@ const nextConfig: NextConfig = {
       {
         source: "/linkedin-pinpoint",
         destination: "/puzzles",
+        permanent: true as const,
+      },
+      // Legacy singular answer archive → canonical archive
+      {
+        source: "/linkedin-pinpoint-answer",
+        destination: "/puzzles",
+        permanent: true as const,
+      },
+      // Legacy singular answer detail → canonical detail
+      {
+        source: "/linkedin-pinpoint-answer/pinpoint-:number(\\d+)",
+        destination: "/linkedin-pinpoint-answers/pinpoint-answer-:number/",
         permanent: true as const,
       },
       // Old root detail alias validates the number before redirecting onward.

--- a/scripts/check-routing-regressions.ts
+++ b/scripts/check-routing-regressions.ts
@@ -100,12 +100,19 @@ async function checkRedirectConfig() {
   assertRedirectRule(rules, "/fr/puzzles/:number(\\d+)", "/puzzles/:number");
   assertRedirectRule(rules, "/de/pinpoint/:date(\\d{4}-\\d{2}-\\d{2})", "/pinpoint/:date");
   assertRedirectRule(rules, "/en/linkedin-pinpoint", "/puzzles");
+  assertRedirectRule(rules, "/de/linkedin-pinpoint-answer", "/puzzles");
   assertRedirectRule(rules, "/puzzles/connectors", "/puzzles");
   assertRedirectRule(rules, "/sitemaps/pt-BR.xml", "/sitemap.xml");
   assertRedirectRule(rules, "/feedback", "/contact-us");
   assertRedirectRule(rules, "/linkedin-pinpoint", "/puzzles");
+  assertRedirectRule(rules, "/linkedin-pinpoint-answer", "/puzzles");
   assertRedirectRule(rules, "/pinpoint-answer-:number(\\d+)", "/puzzles/:number");
   assertRedirectRule(rules, "/linkedin-pinpoint/:number(\\d+)", "/puzzles/:number");
+  assertRedirectRule(
+    rules,
+    "/linkedin-pinpoint-answer/pinpoint-:number(\\d+)",
+    "/linkedin-pinpoint-answers/pinpoint-answer-:number/",
+  );
   assertRedirectRule(
     rules,
     "/puzzles/pinpoint-answer-:number(\\d+)",
@@ -114,6 +121,11 @@ async function checkRedirectConfig() {
   assertRedirectRule(
     rules,
     "/fr/puzzles/pinpoint-answer-:number(\\d+)",
+    "/linkedin-pinpoint-answers/pinpoint-answer-:number/",
+  );
+  assertRedirectRule(
+    rules,
+    "/fr/linkedin-pinpoint-answer/pinpoint-:number(\\d+)",
     "/linkedin-pinpoint-answers/pinpoint-answer-:number/",
   );
   assertRedirectRule(rules, "/fr/pinpoint/:number(\\d+)-analysis", "/pinpoint/:number-analysis");


### PR DESCRIPTION
## Summary
- redirect legacy singular answer archive paths to /puzzles
- redirect legacy singular answer detail paths like /linkedin-pinpoint-answer/pinpoint-754/ to the canonical /linkedin-pinpoint-answers/pinpoint-answer-754/ path
- add routing regression assertions for the singular legacy route family

## Checks
- npm run test:pinpoint-routing
- npm run test:pinpoint-guardrails
- npm run typecheck
- npm run lint
- npm run build
- local production smoke: old singular answer detail routes return 308 to canonical detail routes