### PR TITLE
Refresh static page metadata

### DIFF
--- a/data/static-page-metadata.json
+++ b/data/static-page-metadata.json
@@ -1,8 +1,8 @@
 {
-  "generatedAt": "2026-05-04T07:02:08.000Z",
+  "generatedAt": "2026-05-01T14:33:13.000Z",
   "routes": {
     "/": {
-      "lastModified": "2026-05-04T07:02:08.000Z",
+      "lastModified": "2026-05-01T14:33:13.000Z",
       "sourceFiles": [
         "app/(site)/(home)/page.tsx",
         "components/home/HomeBenefitsFaq.tsx",
@@ -17,7 +17,7 @@
       ]
     },
     "/puzzles": {
-      "lastModified": "2026-05-04T07:02:08.000Z",
+      "lastModified": "2026-04-26T08:40:31.000Z",
       "sourceFiles": [
         "app/(site)/puzzles/page.tsx",
         "components/archive/ArchiveExplorer.tsx",
@@ -25,32 +25,32 @@
       ]
     },
     "/about-us": {
-      "lastModified": "2026-05-04T07:02:08.000Z",
+      "lastModified": "2026-03-31T12:59:13.000Z",
       "sourceFiles": [
         "app/(site)/about-us/page.tsx"
       ]
     },
     "/contact-us": {
-      "lastModified": "2026-05-04T07:02:08.000Z",
+      "lastModified": "2026-04-26T08:40:31.000Z",
       "sourceFiles": [
         "app/(site)/contact-us/page.tsx",
         "components/contact/ContactFeedbackForm.tsx"
       ]
     },
     "/privacy": {
-      "lastModified": "2026-05-04T07:02:08.000Z",
+      "lastModified": "2026-04-26T08:40:31.000Z",
       "sourceFiles": [
         "app/(site)/privacy/page.tsx"
       ]
     },
     "/terms": {
-      "lastModified": "2026-05-04T07:02:08.000Z",
+      "lastModified": "2026-04-26T08:40:31.000Z",
       "sourceFiles": [
         "app/(site)/terms/page.tsx"
       ]
     },
     "/disclaimer": {
-      "lastModified": "2026-05-04T07:02:08.000Z",
+      "lastModified": "2026-03-31T12:59:06.000Z",
       "sourceFiles": [
         "app/(site)/disclaimer/page.tsx"
       ]


### PR DESCRIPTION
## Summary
- refresh generated static page metadata so the production release script starts from a clean tree
- keep this PR scoped to `data/static-page-metadata.json`

## Why
`npm run release:production` regenerates this file before checking git cleanliness. The current main branch rewrote it during the release run, so the script stopped before deploying.

## Checks
- npm run validate:data
- npm run test:pinpoint-guardrails
- npm run typecheck
- npm run lint
- npm run build
