### PR TITLE
Refactor Worker route dispatch

### DIFF
--- a/scripts/check-pinpoint-guardrails.ts
+++ b/scripts/check-pinpoint-guardrails.ts
@@ -20,6 +20,7 @@ import { validatePublishEligibility } from "../lib/puzzles/publish-eligibility.s
 import { validatePinpointEvidenceV1 } from "../lib/puzzles/pinpoint-evidence-v1.shared.mjs";
 import { validateReleaseOverrideDryRun } from "../lib/puzzles/release-override.shared.mjs";
 import { decidePinpointReleaseQueueAction } from "../lib/puzzles/release-queue-policy.shared.mjs";
+import { resolveWorkerFetchRoute } from "../worker/src/routes/dispatch";
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(SCRIPT_DIR, "..");
@@ -2663,12 +2664,60 @@ function checkReleaseQueuePolicy() {
   console.log("ok: release queue policy blocks duplicate production pushes and unsafe deployment states");
 }
 
+function checkWorkerRouteDispatchResolver() {
+  function routeFor(path: string, options: { method?: string; host?: string } = {}) {
+    const method = options.method ?? "GET";
+    const host = options.host ?? "example.workers.dev";
+    const request = new Request(`https://${host}${path}`, { method });
+    return resolveWorkerFetchRoute(request, new URL(request.url));
+  }
+
+  assert.equal(routeFor("/"), "root");
+  assert.equal(routeFor("/graphql"), "graphql");
+  assert.equal(routeFor("/api/pinpoint/today"), "pinpointToday");
+  assert.equal(routeFor("/admin/seed"), "adminSeed");
+  assert.equal(routeFor("/admin/seed", { host: "pinpointanswertoday.app" }), "notFound");
+  assert.equal(routeFor("/admin/preflight-linkedin"), "adminPreflightLinkedin");
+  assert.equal(routeFor("/admin/test-fallback"), "adminTestFallback");
+  assert.equal(routeFor("/admin/candidate-branch-dry-run", { method: "POST" }), "adminCandidateBranchDryRun");
+  assert.equal(routeFor("/admin/candidate-branch-dry-run"), "notFound");
+  assert.equal(routeFor("/admin/release-queue-dry-run", { method: "POST" }), "adminReleaseQueueDryRun");
+  assert.equal(routeFor("/admin/release-queue-dry-run"), "notFound");
+  assert.equal(routeFor("/admin/run"), "adminRun");
+  assert.equal(routeFor("/admin/put-doc", { method: "POST" }), "adminPutDoc");
+  assert.equal(routeFor("/admin/put-doc"), "notFound");
+  assert.equal(routeFor("/admin/upload-ops", { method: "POST" }), "adminUploadOps");
+  assert.equal(routeFor("/admin/upload-ops"), "notFound");
+  assert.equal(routeFor("/health"), "health");
+  assert.equal(routeFor("/monitor/cron-status"), "monitorCronStatus");
+  assert.equal(routeFor("/missing"), "notFound");
+
+  console.log("ok: worker route resolver preserves fetch route matching");
+}
+
 async function checkCandidateBranchDryRunRouteSafety() {
   const workerSource = await readFile(resolve(ROOT, "worker/src/index.ts"), "utf8");
+  const dispatchSource = await readFile(resolve(ROOT, "worker/src/routes/dispatch.ts"), "utf8");
 
   assert.ok(
-    workerSource.includes('url.pathname === "/admin/candidate-branch-dry-run" && req.method === "POST"'),
+    dispatchSource.includes('url.pathname === "/admin/candidate-branch-dry-run" && req.method === "POST"'),
     "candidate branch dry-run route must be POST-only",
+  );
+  assert.equal(
+    resolveWorkerFetchRoute(
+      new Request("https://example.workers.dev/admin/candidate-branch-dry-run", { method: "GET" }),
+      new URL("https://example.workers.dev/admin/candidate-branch-dry-run"),
+    ),
+    "notFound",
+    "candidate branch dry-run must not match GET requests",
+  );
+  assert.equal(
+    resolveWorkerFetchRoute(
+      new Request("https://example.workers.dev/admin/candidate-branch-dry-run", { method: "POST" }),
+      new URL("https://example.workers.dev/admin/candidate-branch-dry-run"),
+    ),
+    "adminCandidateBranchDryRun",
+    "candidate branch dry-run must match POST requests",
   );
   assert.ok(
     workerSource.includes("candidate dry-run is blocked on the primary branch"),
@@ -2689,10 +2738,31 @@ async function checkCandidateBranchDryRunRouteSafety() {
 
 async function checkReleaseQueueDryRunRouteSafety() {
   const workerSource = await readFile(resolve(ROOT, "worker/src/index.ts"), "utf8");
-  const routeStart = workerSource.indexOf('url.pathname === "/admin/release-queue-dry-run" && req.method === "POST"');
-  const routeEnd = workerSource.indexOf('url.pathname === "/admin/run"', routeStart);
+  const dispatchSource = await readFile(resolve(ROOT, "worker/src/routes/dispatch.ts"), "utf8");
+  const routeStart = workerSource.indexOf('case "adminReleaseQueueDryRun"');
+  const routeEnd = workerSource.indexOf('case "adminRun"', routeStart);
   assert.ok(routeStart >= 0, "release queue dry-run route must exist and be POST-only");
   assert.ok(routeEnd > routeStart, "release queue dry-run route must stay before the real admin run route");
+  assert.ok(
+    dispatchSource.includes('url.pathname === "/admin/release-queue-dry-run" && req.method === "POST"'),
+    "release queue dry-run route must be POST-only in the route resolver",
+  );
+  assert.equal(
+    resolveWorkerFetchRoute(
+      new Request("https://example.workers.dev/admin/release-queue-dry-run", { method: "GET" }),
+      new URL("https://example.workers.dev/admin/release-queue-dry-run"),
+    ),
+    "notFound",
+    "release queue dry-run must not match GET requests",
+  );
+  assert.equal(
+    resolveWorkerFetchRoute(
+      new Request("https://example.workers.dev/admin/release-queue-dry-run", { method: "POST" }),
+      new URL("https://example.workers.dev/admin/release-queue-dry-run"),
+    ),
+    "adminReleaseQueueDryRun",
+    "release queue dry-run must match POST requests",
+  );
 
   const routeSource = workerSource.slice(routeStart, routeEnd);
   assert.ok(routeSource.includes("getAdminSecret(env)"), "release queue dry-run route must be admin-gated");
@@ -2929,6 +2999,7 @@ async function main() {
   checkIntermediateStateCommitDetection();
   await checkWorkerEnrichCommitsOnlyFinalPublicPayload();
   checkReleaseQueuePolicy();
+  checkWorkerRouteDispatchResolver();
   await checkCandidateBranchDryRunRouteSafety();
   await checkReleaseQueueDryRunRouteSafety();
   await checkReleaseQueueDryRunOpsScript();

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -28,6 +28,7 @@ import {
   regeneratePuzzleDraft,
   type EnrichInput,
 } from "./enrich-llm";
+import { resolveWorkerFetchRoute } from "./routes/dispatch";
 
 export interface Env {
   PP_DATA: KVNamespace;
@@ -5829,11 +5830,11 @@ export default {
   async fetch(req: Request, env: Env): Promise<Response> {
     const url = new URL(req.url);
 
-    if (url.pathname === "/") {
-      return new Response("ok");
-    }
+    switch (resolveWorkerFetchRoute(req, url)) {
+      case "root":
+        return new Response("ok");
 
-  if (url.pathname === "/graphql") {
+      case "graphql": {
 
     const pre = preflightIfNeeded(req);
     if (pre) return pre;
@@ -5916,7 +5917,7 @@ export default {
     return resp;
   }
 
-    if (url.pathname === "/api/pinpoint/today") {
+      case "pinpointToday": {
       const date = url.searchParams.get("d") ?? getBeijingTodayDate();
       const today = getBeijingTodayDate();
       const body = await env.PP_DATA.get(keyOf(date));
@@ -5926,7 +5927,7 @@ export default {
       return new Response(body, { headers: { "content-type": "application/json" } });
     }
 
-    if (url.pathname === "/admin/seed" && url.hostname.endsWith(".workers.dev")) {
+      case "adminSeed": {
       const adminSecret = getAdminSecret(env);
       if (!adminSecret) return new Response("admin secret not configured", { status: 503 });
       const secret = url.searchParams.get("secret");
@@ -5949,7 +5950,7 @@ export default {
       return new Response("seeded");
     }
 
-    if (url.pathname === "/admin/preflight-linkedin") {
+      case "adminPreflightLinkedin": {
       const adminSecret = getAdminSecret(env);
       if (!adminSecret) return new Response("admin secret not configured", { status: 503 });
       const secret = url.searchParams.get("secret");
@@ -5995,7 +5996,7 @@ export default {
       }
     }
 
-    if (url.pathname === "/admin/test-fallback") {
+      case "adminTestFallback": {
       const adminSecret = getAdminSecret(env);
       if (!adminSecret) return new Response("admin secret not configured", { status: 503 });
       const secret = url.searchParams.get("secret");
@@ -6076,7 +6077,7 @@ export default {
       }
     }
 
-    if (url.pathname === "/admin/candidate-branch-dry-run" && req.method === "POST") {
+      case "adminCandidateBranchDryRun": {
       const adminSecret = getAdminSecret(env);
       if (!adminSecret) return new Response("admin secret not configured", { status: 503 });
       const secret = url.searchParams.get("secret");
@@ -6141,7 +6142,7 @@ export default {
       });
     }
 
-    if (url.pathname === "/admin/release-queue-dry-run" && req.method === "POST") {
+      case "adminReleaseQueueDryRun": {
       const adminSecret = getAdminSecret(env);
       if (!adminSecret) return new Response("admin secret not configured", { status: 503 });
       const secret = url.searchParams.get("secret");
@@ -6234,7 +6235,7 @@ export default {
       });
     }
 
-    if (url.pathname === "/admin/run") {
+      case "adminRun": {
       const adminSecret = getAdminSecret(env);
       if (!adminSecret) return new Response("admin secret not configured", { status: 503 });
       const secret = url.searchParams.get("secret");
@@ -6517,7 +6518,7 @@ export default {
       }
     }
 
-    if (url.pathname === "/admin/put-doc" && req.method === "POST") {
+      case "adminPutDoc": {
       const enabled = env.ADMIN_PUT_DOC_ENABLED === 'true';
       const isProd = (env.ENVIRONMENT || '').toLowerCase() === 'production';
       if (isProd || !enabled) {
@@ -6646,7 +6647,7 @@ export default {
       }
     }
 
-    if (url.pathname === "/admin/upload-ops" && req.method === "POST") {
+      case "adminUploadOps": {
       const adminSecret = getAdminSecret(env);
       if (!adminSecret) return new Response("admin secret not configured", { status: 503 });
       const secret = url.searchParams.get("secret");
@@ -6669,12 +6670,12 @@ export default {
       }
     }
 
-    if (url.pathname === "/health") {
+      case "health": {
       const raw = await env.PP_DATA.get("pinpoint:last");
       return new Response(raw ?? "{}", { headers: { "content-type": "application/json" } });
     }
 
-    if (url.pathname === "/monitor/cron-status") {
+      case "monitorCronStatus": {
       const date = String(url.searchParams.get("date") || "").trim();
       const limitRaw = Number.parseInt(String(url.searchParams.get("limit") || "10"), 10);
       const limit = Number.isFinite(limitRaw) ? Math.max(1, Math.min(limitRaw, cronHeartbeatRunsLimit)) : 10;
@@ -6703,7 +6704,10 @@ export default {
       });
     }
 
-    return new Response("Not Found", { status: 404 });
+      case "notFound":
+      default:
+        return new Response("Not Found", { status: 404 });
+    }
   },
 
   async scheduled(controller: ScheduledController, env: Env, ctx: ExecutionContext) {

--- a/worker/src/routes/dispatch.ts
+++ b/worker/src/routes/dispatch.ts
@@ -1,0 +1,36 @@
+export type WorkerFetchRoute =
+  | "root"
+  | "graphql"
+  | "pinpointToday"
+  | "adminSeed"
+  | "adminPreflightLinkedin"
+  | "adminTestFallback"
+  | "adminCandidateBranchDryRun"
+  | "adminReleaseQueueDryRun"
+  | "adminRun"
+  | "adminPutDoc"
+  | "adminUploadOps"
+  | "health"
+  | "monitorCronStatus"
+  | "notFound";
+
+export function resolveWorkerFetchRoute(req: Request, url: URL): WorkerFetchRoute {
+  if (url.pathname === "/") return "root";
+  if (url.pathname === "/graphql") return "graphql";
+  if (url.pathname === "/api/pinpoint/today") return "pinpointToday";
+  if (url.pathname === "/admin/seed" && url.hostname.endsWith(".workers.dev")) return "adminSeed";
+  if (url.pathname === "/admin/preflight-linkedin") return "adminPreflightLinkedin";
+  if (url.pathname === "/admin/test-fallback") return "adminTestFallback";
+  if (url.pathname === "/admin/candidate-branch-dry-run" && req.method === "POST") {
+    return "adminCandidateBranchDryRun";
+  }
+  if (url.pathname === "/admin/release-queue-dry-run" && req.method === "POST") {
+    return "adminReleaseQueueDryRun";
+  }
+  if (url.pathname === "/admin/run") return "adminRun";
+  if (url.pathname === "/admin/put-doc" && req.method === "POST") return "adminPutDoc";
+  if (url.pathname === "/admin/upload-ops" && req.method === "POST") return "adminUploadOps";
+  if (url.pathname === "/health") return "health";
+  if (url.pathname === "/monitor/cron-status") return "monitorCronStatus";
+  return "notFound";
+}


### PR DESCRIPTION
## Summary
- extract Worker fetch route matching into worker/src/routes/dispatch.ts
- keep existing route bodies in worker/src/index.ts
- add guardrail coverage for route matching and POST-only admin routes

## Checks
- npm --prefix worker run typecheck
- npm run test:pinpoint-guardrails
- npm run typecheck
- npm run validate:data
- npm run lint
- npm run build