### PR TITLE
Update GitHub Actions runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       reason: ${{ steps.intermediate.outputs.reason }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -53,12 +53,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm
@@ -95,7 +95,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Summary
- update actions/checkout from v4 to v6
- update actions/setup-node from v4 to v6
- keep project Node install at Node 20

## Why
GitHub main CI warned that Node.js 20 action runtimes are being deprecated. The v6 actions use node24 according to their official action.yml files.

## Checks
- ruby YAML parse for .github/workflows/ci.yml
- npm run validate:data