### PR TITLE
[codex] Add Pinpoint generic reasoning warnings

### DIFF
--- a/data/puzzles/pinpoint-answer-730.json
+++ b/data/puzzles/pinpoint-answer-730.json
@@ -33,14 +33,14 @@
   },
   "articleBlocks": [
     "The first clues make it clear this is a shared-word phrase puzzle, but not which ending word belongs after every clue without forcing the read.",
-    "A nearby read was \"a loose topic list\". Bread, Rice do not immediately advertise one shared phrase slot before The proof is in the shows where the repeated word belongs. The proof is in the behaves like a proof clue for one fixed phrase pattern, not just a broad topic match.",
-    "Another easy trap was \"standalone clue meanings\". Each clue has an obvious surface meaning if you read it on its own before the shared connector appears. Once The proof is in the locks the phrase position, the full board resolves under one repeated word instead of five separate definitions.",
+    "A nearby read was \"dessert ingredients\". Bread, Rice, and Chocolate can all look like foods or flavors before The proof is in the shows where the repeated word belongs. The proof is in the behaves like a proof clue for one fixed phrase pattern, not just a dessert list.",
+    "Another easy trap was \"separate food words\". Bread, Rice, Chocolate, and Plum each have obvious food meanings before the shared connector appears. Once The proof is in the locks the phrase position, the full board resolves under one repeated word instead of five separate definitions.",
     "Once that phrase appears, examples like \"Bread pudding\" and \"Rice pudding\" stop feeling guessed and start reading like ordinary language under familiar phrases completed by one shared ending word.",
     "Chocolate pudding, Plum (or Christmas) pudding, The proof is in the pudding show that the same shared word fits in the same slot across the whole board, so the answer behaves like one complete phrase family instead of a few lucky matches.",
-    "The answer was Words that come before “pudding”. More precisely, the board resolves as one shared ending word placed after each clue, not a loose topic grouping, which is why Words that come before “pudding” fits better than \"a loose topic list\" or \"standalone clue meanings\" once the full set is checked."
+    "The answer was Words that come before “pudding”. More precisely, the board resolves as one shared ending word placed after each clue, not dessert ingredients, which is why Words that come before “pudding” fits better once the full set is checked."
   ],
   "solutionNarrative": [
-    "I first tried a loose topic list, because the opening clues were broad enough to support a few loose phrase reads. But none of those guesses made \"The proof is in the\" feel exact enough.",
+    "I first tried dessert ingredients, because Bread, Rice, Chocolate, and Plum can all sit near food or flavor ideas. But none of those guesses made \"The proof is in the\" feel exact enough.",
     "Once \"The proof is in the\" clicked, the phrase pattern was finally clear. The same word fit after the earlier clues without forcing any of them, which was when the answer stopped feeling speculative and started feeling confirmed.",
     "After that, I could go back through the board and watch the early clues turn into ordinary language instead of near misses.",
     "The answer was Words that come before “pudding”."
@@ -107,16 +107,16 @@
   "solvePath": {
     "firstRead": "The first clues make it clear this is a shared-word phrase puzzle, but not which ending word belongs after every clue without forcing the read.",
     "falseStarts": [
-      "a loose topic list",
-      "standalone clue meanings"
+      "dessert ingredients",
+      "separate food words"
     ],
     "whyFalseStartPlausible": [
-      "Bread, Rice do not immediately advertise one shared phrase slot before The proof is in the shows where the repeated word belongs.",
-      "Each clue has an obvious surface meaning if you read it on its own before the shared connector appears."
+      "Bread, Rice, and Chocolate can all look like foods or flavors before The proof is in the shows where the repeated word belongs.",
+      "Bread, Rice, Chocolate, and Plum each have obvious food meanings before the shared connector appears."
     ],
     "breakingClue": "The proof is in the",
-    "pivot": "I first tried a loose topic list, because the opening clues were broad enough to support a few loose phrase reads. But none of those guesses made \"The proof is in the\" feel exact enough.\n\nOnce \"The proof is in the\" clicked, the phrase pattern was finally clear. The same word fit after the earlier clues without forcing any of them, which was when the answer stopped feeling speculative and started feeling confirmed.\n\nAfter that, I could go back through the board and watch the early clues turn into ordinary language instead of near misses.\n\nThe answer was Words that come before “pudding”.",
-    "fullBoardConfirmation": "Another easy trap was \"standalone clue meanings\". Each clue has an obvious surface meaning if you read it on its own before the shared connector appears. Once The proof is in the locks the phrase position, the full board resolves under one repeated word instead of five separate definitions."
+    "pivot": "I first tried dessert ingredients, because Bread, Rice, Chocolate, and Plum can all sit near food or flavor ideas. But none of those guesses made \"The proof is in the\" feel exact enough.\n\nOnce \"The proof is in the\" clicked, the phrase pattern was finally clear. The same word fit after the earlier clues without forcing any of them, which was when the answer stopped feeling speculative and started feeling confirmed.\n\nAfter that, I could go back through the board and watch the early clues turn into ordinary language instead of near misses.\n\nThe answer was Words that come before “pudding”.",
+    "fullBoardConfirmation": "Another easy trap was \"separate food words\". Bread, Rice, Chocolate, and Plum each have obvious food meanings before the shared connector appears. Once The proof is in the locks the phrase position, the full board resolves under one repeated word instead of five separate definitions."
   },
   "turningPoint": {
     "clue": "The proof is in the",
@@ -126,35 +126,35 @@
   "clueRows": [
     {
       "clue": "Bread",
-      "surfaceMisread": "a loose topic list",
+      "surfaceMisread": "bakery item",
       "resolvedPhraseOrMember": "Bread pudding",
       "nonObviousWhy": "\"Bread pudding\" is a familiar phrase, so it helps reveal the shared word quickly.",
       "searchableContext": "Bread pudding"
     },
     {
       "clue": "Rice",
-      "surfaceMisread": "a loose topic list",
+      "surfaceMisread": "grain dish",
       "resolvedPhraseOrMember": "Rice pudding",
       "nonObviousWhy": "\"Rice pudding\" is common enough to confirm the same missing word without stretching the phrasing.",
       "searchableContext": "Rice pudding"
     },
     {
       "clue": "Chocolate",
-      "surfaceMisread": "a loose topic list",
+      "surfaceMisread": "flavor",
       "resolvedPhraseOrMember": "Chocolate pudding",
       "nonObviousWhy": "Once the shared word is in place, \"Chocolate pudding\" reads like ordinary language instead of a forced compound.",
       "searchableContext": "Chocolate pudding"
     },
     {
       "clue": "Plum (or Christmas)",
-      "surfaceMisread": "a loose topic list",
+      "surfaceMisread": "holiday dessert",
       "resolvedPhraseOrMember": "Plum (or Christmas) pudding",
       "nonObviousWhy": "\"Plum (or Christmas) pudding\" is a familiar phrase, so it helps reveal the shared word quickly.",
       "searchableContext": "Plum (or Christmas) pudding"
     },
     {
       "clue": "The proof is in the",
-      "surfaceMisread": "a loose topic list",
+      "surfaceMisread": "proverb fragment",
       "resolvedPhraseOrMember": "The proof is in the pudding",
       "nonObviousWhy": "\"The proof is in the pudding\" is common enough to confirm the same missing word without stretching the phrasing.",
       "searchableContext": "The proof is in the pudding"
@@ -199,13 +199,13 @@
   },
   "wrongGuessCandidates": [
     {
-      "label": "a loose topic list",
-      "whyPlausible": "Bread, Rice do not immediately advertise one shared phrase slot before The proof is in the shows where the repeated word belongs.",
-      "whyRejected": "The proof is in the behaves like a proof clue for one fixed phrase pattern, not just a broad topic match."
+      "label": "dessert ingredients",
+      "whyPlausible": "Bread, Rice, and Chocolate can all look like foods or flavors before The proof is in the shows where the repeated word belongs.",
+      "whyRejected": "The proof is in the behaves like a proof clue for one fixed phrase pattern, not just a dessert list."
     },
     {
-      "label": "standalone clue meanings",
-      "whyPlausible": "Each clue has an obvious surface meaning if you read it on its own before the shared connector appears.",
+      "label": "separate food words",
+      "whyPlausible": "Bread, Rice, Chocolate, and Plum each have obvious food meanings before the shared connector appears.",
       "whyRejected": "Once The proof is in the locks the phrase position, the full board resolves under one repeated word instead of five separate definitions."
     }
   ],

--- a/data/puzzles/pinpoint-answer-746.json
+++ b/data/puzzles/pinpoint-answer-746.json
@@ -33,14 +33,14 @@
   },
   "articleBlocks": [
     "The first clues make it clear this is a shared-word phrase puzzle, but not which ending word belongs after every clue without forcing the read.",
-    "A nearby read was \"a loose topic list\". Clear, Short do not immediately advertise one shared phrase slot before Director's shows where the repeated word belongs. Director's behaves like a proof clue for one fixed phrase pattern, not just a broad topic match.",
-    "Another easy trap was \"standalone clue meanings\". Each clue has an obvious surface meaning if you read it on its own before the shared connector appears. Once Director's locks the phrase position, the full board resolves under one repeated word instead of five separate definitions.",
+    "A nearby read was \"movie or haircut terms\". Clear and Short can both describe edits, but they do not prove one shared phrase slot before Director's shows where the repeated word belongs. Director's behaves like a proof clue for one fixed phrase pattern, not just a film-editing read.",
+    "Another easy trap was \"separate everyday phrases\". Clear, Short, and Tax each have obvious surface meanings before the shared connector appears. Once Director's locks the phrase position, the full board resolves under one repeated word instead of five separate definitions.",
     "Once that phrase appears, examples like \"Clear cut\" and \"Short cut\" stop feeling guessed and start reading like ordinary language under familiar phrases completed by one shared ending word.",
     "Tax cut, Director's cut, Hair cut show that the same shared word fits in the same slot across the whole board, so the answer behaves like one complete phrase family instead of a few lucky matches.",
-    "The answer was the phrase pattern Words that come before “cut”. More precisely, the board resolves as one shared ending word placed after each clue, not a loose topic grouping, which is why Words that come before “cut” fits better than \"a loose topic list\" or \"standalone clue meanings\" once the full set is checked."
+    "The answer was the phrase pattern Words that come before “cut”. More precisely, the board resolves as one shared ending word placed after each clue, not movie or haircut terms, which is why Words that come before “cut” fits better once the full set is checked."
   ],
   "solutionNarrative": [
-    "I first tried a loose topic list, because the opening clues were broad enough to support a few loose phrase reads. But none of those guesses made \"Director's\" feel exact enough.",
+    "I first tried movie or haircut terms, because Clear and Short can both describe edits. But that guess did not make \"Director's\" feel exact enough.",
     "Once \"Director's\" clicked, the phrase pattern was finally clear. The same word fit after the earlier clues without forcing any of them, which was when the answer stopped feeling speculative and started feeling confirmed.",
     "After that, I could go back through the board and watch the early clues turn into ordinary language instead of near misses.",
     "The answer was the phrase pattern Words that come before “cut”."
@@ -107,16 +107,16 @@
   "solvePath": {
     "firstRead": "The first clues make it clear this is a shared-word phrase puzzle, but not which ending word belongs after every clue without forcing the read.",
     "falseStarts": [
-      "a loose topic list",
-      "standalone clue meanings"
+      "movie or haircut terms",
+      "separate everyday phrases"
     ],
     "whyFalseStartPlausible": [
-      "Clear, Short do not immediately advertise one shared phrase slot before Director's shows where the repeated word belongs.",
-      "Each clue has an obvious surface meaning if you read it on its own before the shared connector appears."
+      "Clear and Short can both describe edits, but they do not prove one shared phrase slot before Director's shows where the repeated word belongs.",
+      "Clear, Short, and Tax each have obvious surface meanings before the shared connector appears."
     ],
     "breakingClue": "Director's",
-    "pivot": "I first tried a loose topic list, because the opening clues were broad enough to support a few loose phrase reads. But none of those guesses made \"Director's\" feel exact enough.\n\nOnce \"Director's\" clicked, the phrase pattern was finally clear. The same word fit after the earlier clues without forcing any of them, which was when the answer stopped feeling speculative and started feeling confirmed.\n\nAfter that, I could go back through the board and watch the early clues turn into ordinary language instead of near misses.\n\nThe answer was the phrase pattern Words that come before “cut”.",
-    "fullBoardConfirmation": "Another easy trap was \"standalone clue meanings\". Each clue has an obvious surface meaning if you read it on its own before the shared connector appears. Once Director's locks the phrase position, the full board resolves under one repeated word instead of five separate definitions."
+    "pivot": "I first tried movie or haircut terms, because Clear and Short can both describe edits. But that guess did not make \"Director's\" feel exact enough.\n\nOnce \"Director's\" clicked, the phrase pattern was finally clear. The same word fit after the earlier clues without forcing any of them, which was when the answer stopped feeling speculative and started feeling confirmed.\n\nAfter that, I could go back through the board and watch the early clues turn into ordinary language instead of near misses.\n\nThe answer was the phrase pattern Words that come before “cut”.",
+    "fullBoardConfirmation": "Another easy trap was \"separate everyday phrases\". Clear, Short, and Tax each have obvious surface meanings before the shared connector appears. Once Director's locks the phrase position, the full board resolves under one repeated word instead of five separate definitions."
   },
   "turningPoint": {
     "clue": "Director's",
@@ -126,35 +126,35 @@
   "clueRows": [
     {
       "clue": "Clear",
-      "surfaceMisread": "a loose topic list",
+      "surfaceMisread": "clarity adjective",
       "resolvedPhraseOrMember": "Clear cut",
       "nonObviousWhy": "\"Clear cut\" is a familiar phrase, so it helps reveal the shared word quickly.",
       "searchableContext": "Clear cut"
     },
     {
       "clue": "Short",
-      "surfaceMisread": "a loose topic list",
+      "surfaceMisread": "length adjective",
       "resolvedPhraseOrMember": "Short cut",
       "nonObviousWhy": "\"Short cut\" is common enough to confirm the same missing word without stretching the phrasing.",
       "searchableContext": "Short cut"
     },
     {
       "clue": "Tax",
-      "surfaceMisread": "a loose topic list",
+      "surfaceMisread": "money policy",
       "resolvedPhraseOrMember": "Tax cut",
       "nonObviousWhy": "Once the shared word is in place, \"Tax cut\" reads like ordinary language instead of a forced compound.",
       "searchableContext": "Tax cut"
     },
     {
       "clue": "Director's",
-      "surfaceMisread": "a loose topic list",
+      "surfaceMisread": "film version",
       "resolvedPhraseOrMember": "Director's cut",
       "nonObviousWhy": "\"Director's cut\" is a familiar phrase, so it helps reveal the shared word quickly.",
       "searchableContext": "Director's cut"
     },
     {
       "clue": "Hair",
-      "surfaceMisread": "a loose topic list",
+      "surfaceMisread": "salon clue",
       "resolvedPhraseOrMember": "Hair cut",
       "nonObviousWhy": "\"Hair cut\" is common enough to confirm the same missing word without stretching the phrasing.",
       "searchableContext": "Hair cut"
@@ -199,13 +199,13 @@
   },
   "wrongGuessCandidates": [
     {
-      "label": "a loose topic list",
-      "whyPlausible": "Clear, Short do not immediately advertise one shared phrase slot before Director's shows where the repeated word belongs.",
-      "whyRejected": "Director's behaves like a proof clue for one fixed phrase pattern, not just a broad topic match."
+      "label": "movie or haircut terms",
+      "whyPlausible": "Clear and Short can both describe edits, but they do not prove one shared phrase slot before Director's shows where the repeated word belongs.",
+      "whyRejected": "Director's behaves like a proof clue for one fixed phrase pattern, not just a film-editing read."
     },
     {
-      "label": "standalone clue meanings",
-      "whyPlausible": "Each clue has an obvious surface meaning if you read it on its own before the shared connector appears.",
+      "label": "separate everyday phrases",
+      "whyPlausible": "Clear, Short, and Tax each have obvious surface meanings before the shared connector appears.",
       "whyRejected": "Once Director's locks the phrase position, the full board resolves under one repeated word instead of five separate definitions."
     }
   ],

--- a/data/puzzles/pinpoint-answer-752.json
+++ b/data/puzzles/pinpoint-answer-752.json
@@ -60,13 +60,13 @@
     }
   ],
   "solvePath": {
-    "firstRead": "Motor Damage Quality Remote Air traffic can look like five unrelated topics at first, so the first read can drift toward a loose list instead of one phrase pattern.",
+    "firstRead": "Motor Damage Quality Remote Air traffic can look like five unrelated systems at first, so the first read can drift toward machines, repairs, and aviation instead of one phrase pattern.",
     "falseStarts": [
-      "a loose topic list",
-      "standalone clue meanings"
+      "unrelated systems",
+      "remote-control device clue"
     ],
     "whyFalseStartPlausible": [
-      "Motor Damage Quality Remote Air traffic looks like a loose topic list before Air traffic forces one shared slot.",
+      "Motor, Damage, Quality, Remote, and Air traffic can look like machines, repairs, standards, devices, and aviation before Air traffic forces one shared slot.",
       "Remote can point toward devices, so it is easy to stop too early instead of checking the full board."
     ],
     "breakingClue": "Air traffic",

--- a/data/puzzles/pinpoint-answer-758.json
+++ b/data/puzzles/pinpoint-answer-758.json
@@ -110,11 +110,11 @@
     "firstRead": "Way and Mat first pointed toward a loose home or object read, so the board still needed one exact shared word.",
     "falseStarts": [
       "a loose home theme",
-      "standalone clue meanings"
+      "separate home words"
     ],
     "whyFalseStartPlausible": [
       "the first three clues, Way Mat Bell, looked home-adjacent; that Way Mat Bell run still did not prove door until Jamb and Knob narrowed the missing word.",
-      "Each clue has an obvious surface meaning if you read it on its own before the shared connector appears."
+      "Way, Mat, and Bell can each work as ordinary home words before the shared connector appears."
     ],
     "breakingClue": "Knob",
     "pivot": "I first tried a loose home theme, because the opening clues were broad enough to support a few phrase reads. But that guess did not make Jamb or Knob feel exact enough.\n\nOnce Knob clicked as doorknob, the phrase pattern was clear. The same word fit before the earlier clues without forcing any of them.\n\nAfter that, I could go back through the board and watch Way, Mat, Bell, Jamb, and Knob turn into ordinary words.\n\nThe answer was \"Words that come after “door”\".",
@@ -128,35 +128,35 @@
   "clueRows": [
     {
       "clue": "Way",
-      "surfaceMisread": "a loose topic list",
+      "surfaceMisread": "route or direction",
       "resolvedPhraseOrMember": "doorway",
       "nonObviousWhy": "Doorway is a familiar word, so Way helps reveal the shared opening word quickly.",
       "searchableContext": "doorway"
     },
     {
       "clue": "Mat",
-      "surfaceMisread": "a loose topic list",
+      "surfaceMisread": "floor item",
       "resolvedPhraseOrMember": "doormat",
       "nonObviousWhy": "Doormat is common enough to confirm the same missing word without stretching the phrasing.",
       "searchableContext": "doormat"
     },
     {
       "clue": "Bell",
-      "surfaceMisread": "a loose topic list",
+      "surfaceMisread": "sound or chime",
       "resolvedPhraseOrMember": "doorbell",
       "nonObviousWhy": "Once the shared word is in place, doorbell reads like ordinary language instead of a forced compound.",
       "searchableContext": "doorbell"
     },
     {
       "clue": "Jamb",
-      "surfaceMisread": "a loose topic list",
+      "surfaceMisread": "frame part",
       "resolvedPhraseOrMember": "doorjamb",
       "nonObviousWhy": "Doorjamb is a familiar word, so Jamb helps reveal the shared word quickly.",
       "searchableContext": "doorjamb"
     },
     {
       "clue": "Knob",
-      "surfaceMisread": "a loose topic list",
+      "surfaceMisread": "handle part",
       "resolvedPhraseOrMember": "doorknob",
       "nonObviousWhy": "Doorknob is common enough to confirm the same missing word without stretching the phrasing.",
       "searchableContext": "doorknob"
@@ -203,11 +203,11 @@
     {
       "label": "a loose home theme",
       "whyPlausible": "The first three clues, Way Mat Bell, look home-adjacent; that Way Mat Bell run still does not prove door until Jamb and Knob narrow the missing word.",
-      "whyRejected": "Knob behaves like a proof clue for one fixed door pattern, not just a broad topic match."
+      "whyRejected": "Knob behaves like a proof clue for one fixed door pattern, not just a home-object read."
     },
     {
-      "label": "standalone clue meanings",
-      "whyPlausible": "Each clue has an obvious surface meaning if you read it on its own before the shared connector appears.",
+      "label": "separate home words",
+      "whyPlausible": "Way, Mat, and Bell can each work as ordinary home words before the shared connector appears.",
       "whyRejected": "Once Knob locks the phrase position, the full board resolves under door instead of five separate definitions."
     }
   ],

--- a/data/puzzles/pinpoint-answer-760.json
+++ b/data/puzzles/pinpoint-answer-760.json
@@ -34,7 +34,7 @@
   },
   "articleBlocks": [
     "Today's puzzle looked simple because Paper and Cut both open a lot of familiar phrases.",
-    "My first read drifted toward a loose topic list, but that was too broad for LinkedIn Pinpoint 760.",
+    "My first read drifted toward office materials, but that was too narrow for LinkedIn Pinpoint 760.",
     "Paper, Cut, Feed, and Flash only become useful when they are tested in the same phrase slot.",
     "Hump (🐋) is the clue that makes the slot visible, because Hump back is much harder to ignore.",
     "Once Hump back lands, the earlier clues stop acting like separate words and start acting like one phrase chain.",
@@ -110,12 +110,12 @@
   "solvePath": {
     "firstRead": "Paper and Cut make it clear this is probably a shared-word phrase puzzle, but they do not prove which word should follow every clue.",
     "falseStarts": [
-      "a loose topic list",
-      "standalone clue meanings"
+      "office materials",
+      "separate word meanings"
     ],
     "whyFalseStartPlausible": [
-      "Paper and Cut both fit too many everyday phrase frames before Hump (🐋) shows where the repeated word belongs.",
-      "Each clue has an obvious surface meaning if you read it on its own before the shared connector appears."
+      "Paper and Cut can point toward stationery, printing, or office supplies before Hump (🐋) shows where the repeated word belongs.",
+      "Feed and Flash both have obvious surface meanings if you read them on their own before the shared connector appears."
     ],
     "breakingClue": "Hump (🐋)",
     "pivot": "Paper and Cut first made the board feel like a loose phrase puzzle, so I waited instead of locking in a theme too early.\n\nHump (🐋) changed the solve. Hump back made the missing slot clear, then Paper back, Cut back, Feed back, and Flash back all checked cleanly.\n\nThe answer was \"Words that come before “back”\" because the same ending word fits every clue in the same place.",
@@ -129,35 +129,35 @@
   "clueRows": [
     {
       "clue": "Paper",
-      "surfaceMisread": "a loose topic list",
+      "surfaceMisread": "office supplies",
       "resolvedPhraseOrMember": "Paper back",
       "nonObviousWhy": "\"Paper back\" is a familiar phrase, so it helps reveal the shared word quickly.",
       "searchableContext": "Paper back"
     },
     {
       "clue": "Cut",
-      "surfaceMisread": "a loose topic list",
+      "surfaceMisread": "scissors or injury",
       "resolvedPhraseOrMember": "Cut back",
       "nonObviousWhy": "\"Cut back\" is common enough to confirm the same missing word without stretching the phrasing.",
       "searchableContext": "Cut back"
     },
     {
       "clue": "Feed",
-      "surfaceMisread": "a loose topic list",
+      "surfaceMisread": "food or social feed",
       "resolvedPhraseOrMember": "Feed back",
       "nonObviousWhy": "Once the shared word is in place, \"Feed back\" reads like ordinary language instead of a forced compound.",
       "searchableContext": "Feed back"
     },
     {
       "clue": "Flash",
-      "surfaceMisread": "a loose topic list",
+      "surfaceMisread": "light or camera",
       "resolvedPhraseOrMember": "Flash back",
       "nonObviousWhy": "\"Flash back\" is a familiar phrase, so it helps reveal the shared word quickly.",
       "searchableContext": "Flash back"
     },
     {
       "clue": "Hump (🐋)",
-      "surfaceMisread": "a loose topic list",
+      "surfaceMisread": "whale shape",
       "resolvedPhraseOrMember": "Hump back",
       "nonObviousWhy": "The familiar expression \"Hump back\" makes the missing word \"back\" obvious in plain language.",
       "searchableContext": "Hump back"
@@ -202,13 +202,13 @@
   },
   "wrongGuessCandidates": [
     {
-      "label": "a loose topic list",
-      "whyPlausible": "Paper, Cut do not immediately advertise one shared phrase slot before Hump (🐋) shows where the repeated word belongs.",
-      "whyRejected": "Hump (🐋) behaves like a proof clue for one fixed phrase pattern, not just a broad topic match."
+      "label": "office materials",
+      "whyPlausible": "Paper and Cut can point toward stationery, printing, or office supplies before Hump (🐋) shows where the repeated word belongs.",
+      "whyRejected": "Hump (🐋) behaves like a proof clue for one fixed phrase pattern, not just an office-materials read."
     },
     {
-      "label": "standalone clue meanings",
-      "whyPlausible": "Each clue has an obvious surface meaning if you read it on its own before the shared connector appears.",
+      "label": "separate word meanings",
+      "whyPlausible": "Feed and Flash both have obvious surface meanings if you read them on their own before the shared connector appears.",
       "whyRejected": "Once Hump (🐋) locks the phrase position, the full board resolves under one repeated word instead of five separate definitions."
     }
   ],

--- a/data/puzzles/pinpoint-answer-765.json
+++ b/data/puzzles/pinpoint-answer-765.json
@@ -33,11 +33,11 @@
   },
   "articleBlocks": [
     "The first clues make it clear this is a shared-word phrase puzzle, but not which ending word belongs after every clue without forcing the read. Read in order, White, Pirate, National, Checkered, Capture the points to one phrase slot rather than five separate definitions.",
-    "A nearby read was \"a loose topic list\". White, Pirate do not immediately advertise one shared phrase slot before Capture the shows where the repeated word belongs. Capture the behaves like a proof clue for one fixed phrase pattern, not just a broad topic match.",
-    "Another easy trap was \"standalone clue meanings\". Each clue has an obvious surface meaning if you read it on its own before the shared connector appears. Once Capture the locks the phrase position, the full board resolves under one repeated word instead of five separate definitions.",
+    "A nearby read was \"color or surrender words\". White can point to color or surrender, and Pirate can point to ships before Capture the shows where the repeated word belongs. Capture the behaves like a proof clue for one fixed phrase pattern, not just a color-or-ship read.",
+    "Another easy trap was \"isolated clue definitions\". National and Checkered both have obvious surface meanings before the shared connector appears. Once Capture the locks the phrase position, the full board resolves under one repeated word instead of five separate definitions.",
     "Once that phrase appears, examples like \"White flag\" and \"Pirate flag\" stop feeling guessed and start reading like ordinary language under familiar phrases completed by one shared ending word.",
     "National flag, Checkered flag, Capture the flag show that the same shared word fits in the same slot across the whole board, so the answer behaves like one complete phrase family instead of a few lucky matches.",
-    "The answer was \"Words that come before “flag”\". More precisely, the board resolves as one shared ending word placed after each clue, not a loose topic grouping, which is why \"Words that come before “flag”\" fits better than \"a loose topic list\" or \"standalone clue meanings\" once the full set is checked."
+    "The answer was \"Words that come before “flag”\". More precisely, the board resolves as one shared ending word placed after each clue, not a color theme or isolated definitions, which is why \"Words that come before “flag”\" fits better once the full set is checked."
   ],
   "solutionNarrative": [
     "White first sent me toward color ideas, and I also considered whether the clue might point to chess. Both reads felt possible, but they did not give Pirate a natural partner.",
@@ -107,16 +107,16 @@
   "solvePath": {
     "firstRead": "The first clues make it clear this is a shared-word phrase puzzle, but not which ending word belongs after every clue without forcing the read.",
     "falseStarts": [
-      "a loose topic list",
-      "standalone clue meanings"
+      "color or surrender words",
+      "isolated clue definitions"
     ],
     "whyFalseStartPlausible": [
-      "White, Pirate, National, Checkered, Capture the can look like a loose topic list before Capture the shows where the repeated word belongs.",
-      "Each clue has an obvious surface meaning if you read it on its own before the shared connector appears."
+      "White can point toward color or surrender, and Pirate can point toward ships before Capture the shows where the repeated word belongs.",
+      "National and Checkered have obvious surface meanings if you read them on their own before the shared connector appears."
     ],
     "breakingClue": "Capture the",
     "pivot": "White first sent me toward color ideas, and I also considered whether the clue might point to chess. Both reads felt possible, but they did not give Pirate a natural partner.\n\nPirate changed the solve. I wrote down \"pirate flag\" and immediately checked whether White could work the same way. \"White flag\" sounded normal, so the hidden ending started to look much more likely.\n\nThen I tested the rest of the board without jumping ahead. National flag, Checkered flag, and Capture the flag all landed cleanly, which made the answer feel earned instead of guessed.\n\nThe answer was \"Words that come before “flag”\".",
-    "fullBoardConfirmation": "Another easy trap was \"standalone clue meanings\". Each clue has an obvious surface meaning if you read it on its own before the shared connector appears. Once Capture the locks the phrase position, the full board resolves under one repeated word instead of five separate definitions."
+    "fullBoardConfirmation": "Another easy trap was \"isolated clue definitions\". National and Checkered have obvious surface meanings if you read them on their own before the shared connector appears. Once Capture the locks the phrase position, the full board resolves under one repeated word instead of five separate definitions."
   },
   "turningPoint": {
     "clue": "Capture the",
@@ -126,7 +126,7 @@
   "clueRows": [
     {
       "clue": "White",
-      "surfaceMisread": "a loose topic list",
+      "surfaceMisread": "color or surrender cue",
       "resolvedPhraseOrMember": "White flag",
       "nonObviousWhy": "\"White flag\" is a familiar phrase, so it helps reveal the shared word quickly.",
       "searchableContext": "White flag",
@@ -134,7 +134,7 @@
     },
     {
       "clue": "Pirate",
-      "surfaceMisread": "a loose topic list",
+      "surfaceMisread": "ships or raiders",
       "resolvedPhraseOrMember": "Pirate flag",
       "nonObviousWhy": "\"Pirate flag\" is common enough to confirm the same missing word without stretching the phrasing.",
       "searchableContext": "Pirate flag",
@@ -142,7 +142,7 @@
     },
     {
       "clue": "National",
-      "surfaceMisread": "a loose topic list",
+      "surfaceMisread": "country label",
       "resolvedPhraseOrMember": "National flag",
       "nonObviousWhy": "Once the shared word is in place, \"National flag\" reads like ordinary language instead of a forced compound.",
       "searchableContext": "National flag",
@@ -150,7 +150,7 @@
     },
     {
       "clue": "Checkered",
-      "surfaceMisread": "a loose topic list",
+      "surfaceMisread": "racing pattern",
       "resolvedPhraseOrMember": "Checkered flag",
       "nonObviousWhy": "\"Checkered flag\" is a familiar phrase, so it helps reveal the shared word quickly.",
       "searchableContext": "Checkered flag",
@@ -158,7 +158,7 @@
     },
     {
       "clue": "Capture the",
-      "surfaceMisread": "a loose topic list",
+      "surfaceMisread": "game instruction",
       "resolvedPhraseOrMember": "Capture the flag",
       "nonObviousWhy": "\"Capture the flag\" is common enough to confirm the same missing word without stretching the phrasing.",
       "searchableContext": "Capture the flag",
@@ -204,13 +204,13 @@
   },
   "wrongGuessCandidates": [
     {
-      "label": "a loose topic list",
-      "whyPlausible": "White, Pirate do not immediately advertise one shared phrase slot before Capture the shows where the repeated word belongs.",
-      "whyRejected": "Capture the behaves like a proof clue for one fixed phrase pattern, not just a broad topic match."
+      "label": "color or surrender words",
+      "whyPlausible": "White can point toward color or surrender, and Pirate can point toward ships before Capture the shows where the repeated word belongs.",
+      "whyRejected": "Capture the behaves like a proof clue for one fixed phrase pattern, not just a color-or-ship read."
     },
     {
-      "label": "standalone clue meanings",
-      "whyPlausible": "Each clue has an obvious surface meaning if you read it on its own before the shared connector appears.",
+      "label": "isolated clue definitions",
+      "whyPlausible": "National and Checkered have obvious surface meanings if you read them on their own before the shared connector appears.",
       "whyRejected": "Once Capture the locks the phrase position, the full board resolves under one repeated word instead of five separate definitions."
     }
   ],

--- a/docs/pinpoint-legacy-site-reverse-engineering-2026-06-04.md
+++ b/docs/pinpoint-legacy-site-reverse-engineering-2026-06-04.md
@@ -1,0 +1,689 @@
+# Pinpoint Legacy Site Reverse Engineering
+
+Date: 2026-06-04
+
+Source inspected:
+
+`/Users/elng/Downloads/us.sitesucker.mac.sitesucker-pro/pinpointanswer.today`
+
+注意：
+
+这份 SiteSucker 快照不在当前仓库里。
+
+所以报告数字是“本机这份快照可复现”，不是“任何机器天然可复现”。
+
+当前快照指纹：
+
+```text
+htmlFileCount: 303
+totalBytes: 32303363
+sha256: 49b70aa6338c225beead2ad60a402710fab34365a1353dfa1329a40315a10cef
+```
+
+## 结论先说
+
+这个目录不是完整源码，而是 SiteSucker 抓下来的旧站静态页面。
+
+所以它不能告诉我们后台怎么抓 LinkedIn、怎么定时发布、怎么调用模型。
+
+但它能告诉我们一件很重要的事：
+
+旧站最终公开出来的页面，内容结构非常稳定。
+
+它不是靠长篇大论赢，而是靠每天稳定生成同一套内容骨架：
+
+1. 先给 5 个 clue。
+2. 答案默认隐藏，用户点 reveal 才看。
+3. 正文写成解题过程，不是只写答案。
+4. 每个 clue 都落到一个具体短语、例子、或成员。
+5. FAQ 和 recent links 每页都有。
+6. 页面是预渲染 HTML，Google 一打开就能读到正文。
+
+我们应该学它的输出方法，不是照搬它的页面名字、路由、schema 或旧模块标题。
+
+## 批量统计
+
+统计范围：
+
+- 详情页数量：303 页
+- 题号范围：`pinpoint-458` 到 `pinpoint-760`
+- 页面路径：`/linkedin-pinpoint-answer/pinpoint-{number}/`
+
+统计方法：
+
+```bash
+node scripts/analyze-legacy-pinpoint-site.mjs
+node scripts/analyze-legacy-pinpoint-site.mjs --json
+```
+
+如果 SiteSucker 目录换了，可以这样指定：
+
+```bash
+node scripts/analyze-legacy-pinpoint-site.mjs --source /path/to/pinpointanswer.today/linkedin-pinpoint-answer
+```
+
+这个脚本只做启发式统计。
+
+它统计的是静态 HTML 里已经能匹配到的内容。
+
+它会先去掉 `script`、`style`、`noscript`，再数页面文字、标题、表格、FAQ、schema 和一些解题语言。
+
+所以这些数字不是靠人工估计，也不是靠 Next.js 内部数据硬猜。
+
+但它也不是完整浏览器渲染审计：
+
+- schema 只是字符串匹配，不是完整解析 JSON-LD。
+- FAQ 数量是从 `FAQ` 到 `Recent` 之间数问号。
+- 5 行表格是取页面里最大的 table 行数，不是逐格语义解析。
+- 词数包含导航、按钮、recent links、隐藏/折叠内容等 HTML 文本。
+
+所以这些数字适合看旧站的大体稳定模式，不适合当成逐页精确审计。
+
+核心启发式统计：
+
+| 项目 | 数量 |
+| --- | ---: |
+| 详情页总数 | 303 |
+| 匹配到 clue card / reveal 交互 | 303 |
+| 匹配到 recent links | 303 |
+| 匹配到 `NewsArticle` | 303 |
+| 匹配到 `BreadcrumbList` | 303 |
+| 匹配到 `Game` | 303 |
+| 匹配到 `WebSite` / `Organization` | 303 |
+| 匹配到 `FAQPage` | 286 |
+| 匹配到 `Answer & Full Analysis` 标题 | 286 |
+| 匹配到 `Words & How They Fit` 或同类表格 | 291 |
+| 表格正好 5 行 clue 内容 | 295 |
+| 匹配到 FAQ 标题 | 290 |
+| FAQ 大多 3 个问题 | 275 |
+| 使用第一人称解题口吻 | 294 |
+| 明确写 wrong / trap / decoy / first thought 等错误方向 | 214 |
+| 明确写 turning / clicked / breakthrough / pivot 等转折语言 | 238 |
+| 明确写 confirmation / confirmed / sealed 等验证语言 | 197 |
+
+HTML 文本词数：
+
+| 指标 | 词数 |
+| --- | ---: |
+| 中位数 | 801 |
+| 最少 | 333 |
+| 最多 | 1308 |
+| 25 分位 | 767 |
+| 75 分位 | 844 |
+
+这说明旧站的正式详情页，整页文本体量大多数不是 2000 词长文。
+
+它的主力形态更像是中等长度的稳定解释页。
+
+因为这个词数口径包含导航、按钮和 recent links，所以不要把它理解成“正文纯文本一定是 750 到 850 词”。
+
+## 异常页
+
+这些异常页说明旧站也不是 100% 完美，但主流页面结构非常稳定。
+
+缺 `Answer & Full Analysis` 标题：
+
+```text
+pinpoint-458, pinpoint-459, pinpoint-460, pinpoint-461, pinpoint-462, pinpoint-463, pinpoint-464, pinpoint-465, pinpoint-466, pinpoint-467, pinpoint-468, pinpoint-470, pinpoint-471, pinpoint-472, pinpoint-473, pinpoint-474, pinpoint-729
+```
+
+缺 `Words & How They Fit` 或同类表格标题：
+
+```text
+pinpoint-458, pinpoint-459, pinpoint-460, pinpoint-461, pinpoint-462, pinpoint-463, pinpoint-464, pinpoint-465, pinpoint-466, pinpoint-467, pinpoint-468, pinpoint-739
+```
+
+表格不是 5 行 clue 内容：
+
+```text
+pinpoint-458:0, pinpoint-459:0, pinpoint-460:0, pinpoint-461:0, pinpoint-462:0, pinpoint-463:0, pinpoint-464:0, pinpoint-465:0
+```
+
+缺 FAQ 标题：
+
+```text
+pinpoint-458, pinpoint-459, pinpoint-460, pinpoint-461, pinpoint-462, pinpoint-463, pinpoint-464, pinpoint-465, pinpoint-466, pinpoint-467, pinpoint-468, pinpoint-480, pinpoint-517
+```
+
+FAQ 不是 3 个问题：
+
+```text
+pinpoint-458:0, pinpoint-459:0, pinpoint-460:0, pinpoint-461:0, pinpoint-462:0, pinpoint-463:0, pinpoint-464:0, pinpoint-465:0, pinpoint-466:0, pinpoint-467:0, pinpoint-468:0, pinpoint-478:4, pinpoint-480:0, pinpoint-517:0, pinpoint-533:4, pinpoint-582:5, pinpoint-584:4, pinpoint-585:4, pinpoint-587:5, pinpoint-589:4, pinpoint-590:5, pinpoint-593:2, pinpoint-594:2, pinpoint-626:4, pinpoint-634:4, pinpoint-728:4, pinpoint-746:4, pinpoint-748:4
+```
+
+## 它的页面怎么执行
+
+旧站执行链路是：
+
+```text
+后台提前生成内容
+-> Next.js build 成静态 HTML
+-> 每个题一个 index.html
+-> 用户访问 HTML
+-> JS 只负责按钮、展开、复制、tooltip、广告等交互
+```
+
+不是：
+
+```text
+用户打开页面
+-> 浏览器调用 API
+-> 前端再生成内容
+```
+
+证据：
+
+- 没有 `package.json`、`app/`、`src/` 等源码入口。
+- 每个详情页都是静态 `index.html`。
+- 页面数据已经写在 HTML 和 `self.__next_f.push(...)` 里。
+- `_next/static/chunks/app/[locale]/linkedin-pinpoint-answer/[slug]/page-*.js` 只负责 reveal、copy、read more、clue tooltip 等交互。
+
+这点对我们很重要：
+
+正式页应该尽量做到“发布时就已经完整”，不要指望用户访问时再补内容。
+
+## 旧站详情页固定骨架
+
+典型详情页是这样：
+
+1. Title
+   - `LinkedIn Pinpoint 760 : Paper, Cut, Feed, Flash, Hump`
+
+2. H1
+   - `LinkedIn Pinpoint #760 Answer & Analysis`
+
+3. 首屏问题
+   - `What connects "Paper", "Cut", "Feed", "Flash", "Hump"...`
+   - 鼓励先看 hints，再 reveal。
+
+4. 三个信任卡片
+   - `Daily Updates`
+   - `Detailed Explanations`
+   - `Continuous Challenge`
+
+5. Clue / reveal 区
+   - 5 个 clue card
+   - hover / tap 后显示 clue 解释
+   - answer 默认隐藏
+   - click reveal 后显示答案
+
+6. Full Analysis
+   - 第一人称解题过程
+   - false start
+   - turning clue
+   - confirmation clues
+
+7. Category
+   - 明确最终答案类别或模式
+
+8. 5 行 clue 表格
+   - `Word`
+   - `Phrase / Example`
+   - `Meaning & Usage`
+
+9. FAQ
+   - 通常 3 条
+
+10. Recent answers
+   - 给用户和搜索引擎继续爬的路径
+
+## 最值得学的内容方法
+
+### 方法 1: false start 必须具体
+
+旧站不是写：
+
+```text
+a loose topic list
+standalone clue meanings
+```
+
+它会写更像人的错误方向。
+
+例如 #760：
+
+```text
+Paper 让我先想到 wood / pulp / office supplies / printable materials。
+```
+
+例如 #750：
+
+```text
+False, Paper, Nature 先让人往普通词义或自然主题猜。
+```
+
+我们当前项目的问题是：
+
+结构已经有了 `wrongGuessCandidates`，但内容有时太空。
+
+当前 #765 就是例子。
+
+它的 clue 是：
+
+```text
+White / Pirate / National / Checkered / Capture the
+```
+
+答案是：
+
+```text
+Words that come before “flag”
+```
+
+但 `wrongGuessCandidates` 里还出现了：
+
+```text
+a loose topic list
+standalone clue meanings
+```
+
+这两个不是人的真实猜法，更像占位标签。
+
+更关键的是，它不只是 JSON 里难看。
+
+真实页面链路是：
+
+```text
+data/puzzles/pinpoint-answer-765.json
+-> buildReasoningArticleDraft()
+-> PuzzleFullAnalysis.tsx
+-> Answer Reasoning 正文
+```
+
+`buildReasoningArticleDraft()` 会把 `solvePath.falseStarts[0]` 写成：
+
+```text
+My first read drifted toward "a loose topic list"...
+```
+
+所以这是会污染页面正文的问题，不只是后台字段问题。
+
+字段级对照：
+
+| 字段 | 当前问题 | 是否影响页面 | 应该改成 |
+| --- | --- | --- | --- |
+| `solvePath.falseStarts` | `a loose topic list` / `standalone clue meanings` | 会进 `Answer Reasoning` | `color words` / `chess or surrender read` |
+| `wrongGuessCandidates[].label` | 抽象标签 | 会影响修复和复盘文案 | 具体错误方向 |
+| `clueRows[].surfaceMisread` | 5 行都写 `a loose topic list` | 会影响后续质量判断 | 每个 clue 的真实误读 |
+| `turningPoint.whatChangedAfterIt` | `earlier clues stop feeling broad` | 能过校验但偏空 | `Pirate flag` 带动回查 `White flag` |
+| `clueRows[].resolvedPhraseOrMember` | `White flag` 等已经具体 | 这部分是好的 | 保留并用于 board-check |
+
+应该改成：
+
+- 错误猜测必须是具体名词或具体方向。
+- 禁止 `loose topic list`、`standalone clue meanings` 这种空标签。
+- 错误猜测至少要引用 1 到 2 个真实 clue。
+
+#765 更好的写法应该像这样：
+
+```text
+White 先容易让人想到颜色、投降、或者 chess。
+Pirate 出现后，可以试 pirate flag。
+再回头试 White flag，发现它也能接上。
+这时才知道不是颜色主题，也不是海盗主题，而是每个 clue 后面都能接 flag。
+```
+
+根因可以说清楚：
+
+```text
+上游会生成空标签
+-> fallback / auto-repair 可能保留空标签
+-> validate:data 主要查字段非空
+-> reasoning article 检查主要查结构
+-> 最后页面结构过了，但内容仍然像模板
+```
+
+所以不是“模板没讨论过”。
+
+是模板有了，但质量门只查了结构，没有查“这个猜法像不像真人会猜”。
+
+好坏段落对照：
+
+| 类型 | 段落 | 问题 / 优点 |
+| --- | --- | --- |
+| 当前坏例子 | `My first read drifted toward "a loose topic list"...` | 看不出真人会怎么猜，只是模板标签。 |
+| 旧站可学写法 | `Paper 让我先想到 wood / pulp / office supplies / printable materials。` | 错误方向具体，而且绑定真实 clue。 |
+| #765 应改写法 | `White 先让人想到颜色或投降，Pirate 出现后才值得试 pirate flag，再回头验证 White flag。` | 有误读、有转折、有验证。 |
+
+### 方法 2: turning clue 要像“转折点”
+
+旧站经常用这类标题：
+
+- `Cut Changes Everything`
+- `The Second Clue Changes Everything`
+- `The Aha Moment`
+- `The Word That Changed Everything`
+- `The clue that changed everything`
+
+这说明它不是只说“某 clue 很重要”，而是把它写成一个解题转折。
+
+我们当前项目已经有 `turningPoint` 字段，但有时只写：
+
+```text
+Capture the is the clue that makes the shared answer concrete enough...
+```
+
+这能过校验，但不像人话。
+
+应该改成：
+
+```text
+看到 Pirate 时，我先想到 pirate flag。
+再回头试 White flag，发现 White 也能接上。
+这时才知道不是颜色、不是海盗，而是同一个结尾词。
+```
+
+### 方法 3: 5 个 clue 都要有具体落点
+
+旧站表格最有价值。
+
+它不只是说 “这个 clue fits the answer”。
+
+它会给具体落点：
+
+| Clue | Phrase / Example | Meaning |
+| --- | --- | --- |
+| Paper | Paperback | A book with a flexible paper cover |
+| Cut | Cutback | A reduction in spending, size, or scope |
+| Feed | Feedback | Information or reactions about performance |
+| Flash | Flashback | A sudden memory or scene from the past |
+| Hump | Humpback | A whale species known for its curved back |
+
+我们现在已经有 `clueRows` / `display.clueTableRows`，但是页面不再显示旧表格模块。
+
+这没有问题。
+
+重点不是恢复旧标题，而是保证底层数据必须达到这个质量：
+
+- 每个 clue 一个具体 phrase/member。
+- 每个 phrase/member 不能只是 clue 原词。
+- 每个解释必须说明为什么它成立。
+- phrase-pattern 题要特别处理空格，比如 `Paper back` 应该更自然地显示成 `Paperback`，除非原短语本身要分开。
+
+当前页面可以这样承接 5 个 clue 解释：
+
+- `Answer Reasoning` 里的 board-check block 负责展示 5 个具体 phrase/member。
+- `What This Pinpoint Teaches` 只放 2 到 3 个当天题的解题经验，不要变成旧表格。
+- `clueRows` / `display.clueTableRows` 继续当底层质量数据。
+
+另外要单独注意 clue tooltip。
+
+当前 detail 页面会把 `wordHints` 传给 clue hint。
+
+#765 的 `wordHints` 里已经有 `White flag`、`Pirate flag` 这类答案相关短语。
+
+所以“reveal 前不提前泄露答案”不是现在已经满足的事实，只能作为后续检查项。
+
+不要恢复旧标题。
+
+原因很简单：当前发布检查已经把旧标题当成问题。
+
+### 方法 4: FAQ 要和当天题相关
+
+旧站 FAQ 通常是 3 条：
+
+1. 答案是什么。
+2. 这个题为什么容易误导。
+3. 遇到类似题怎么解。
+
+好的 FAQ 不是泛泛而谈。
+
+例如 #760：
+
+- Why are compound word puzzles so common in Pinpoint?
+- What's the best strategy for spotting before/after word patterns?
+- Was "paper cut" a trap in this puzzle?
+
+我们当前项目要避免：
+
+```text
+How do the clues confirm the answer?
+```
+
+这种太泛的问题可以有，但不能全是这种。
+
+应该要求至少一条 FAQ 绑定具体 clue 或具体 false start。
+
+### 方法 5: 正文不需要特别长，但必须完整
+
+旧站多数页面 750 到 850 词。
+
+它的有效结构是：
+
+```text
+开头悬念
+-> 第一错误方向
+-> 转折 clue
+-> 答案模式
+-> 剩余 clue 验证
+-> 5 行表格
+-> 3 条 FAQ
+-> recent links
+```
+
+所以我们不应该只提高字数。
+
+应该提高“每段有没有承担任务”。
+
+## 我们不能直接复制的地方
+
+### 不复制旧路由
+
+旧站路由：
+
+```text
+/linkedin-pinpoint-answer/pinpoint-760/
+```
+
+我们当前路由：
+
+```text
+/linkedin-pinpoint-answers/pinpoint-answer-760/
+```
+
+不能改回旧路由。
+
+### 不恢复旧模块标题
+
+我们当前发布检查已经禁止这些旧标题：
+
+- `Clue Connections`
+- `Words & How They Fit`
+- `Lessons Learned`
+- `Compact FAQ`
+- `Quick Take`
+
+所以不能直接把旧模块搬回来。
+
+正确做法是：
+
+保留当前页面形态，但把旧站的 5 行 clue 解释能力吸收进 `Answer Reasoning` 和 `What This Pinpoint Teaches`。
+
+### 不照搬 `FAQPage`
+
+旧站很多页面有 `FAQPage`。
+
+我们当前项目已经采用更谨慎的结构化数据策略：
+
+- Article
+- Game
+- ItemList
+- BreadcrumbList
+
+所以不要为了复制旧站而重新堆 `FAQPage`。
+
+### 不照搬假日记口吻
+
+旧站经常写 “I guessed / I submitted / Correct”。
+
+这有可读性，但也有风险：
+
+- 如果不是用户真实操作，就容易像假经历。
+- 如果模型编得太细，可能看起来不可信。
+
+我们应该用“解题复盘口吻”，不要伪装成真实当天操作记录。
+
+不要写：
+
+```text
+I submitted the answer.
+Correct.
+On my second guess, I solved it.
+```
+
+可以写：
+
+```text
+A solver might first test color words from White.
+Pirate then makes pirate flag worth checking.
+Once White flag and Pirate flag both work, the safer read is a shared ending word.
+```
+
+这还是像人在解题，但不假装我们真的点过 LinkedIn 的提交按钮。
+
+## 对当前项目的具体改法
+
+### 第一层: 加内容黑名单
+
+这些词应该被判为质量问题：
+
+- `a loose topic list`
+- `standalone clue meanings`
+- `broad topic match`
+- `the answer becomes clear`
+- `all clues point to the same`
+- `shared category`
+- `common theme`
+- `they all fit`
+
+这些不是绝对不能出现一次，而是不能作为 false start、turning point、clue explanation 的主体。
+
+### 第二层: 加 false start 具体度检查
+
+`wrongGuessCandidates[].label` 应该满足：
+
+- 2 到 6 个词。
+- 不能是抽象标签。
+- 至少一个 candidate 的 `whyPlausible` 要引用真实 clue。
+- `whyRejected` 要引用 turning clue 或某个打破它的 clue。
+
+### 第三层: 加 clueRows 质量检查
+
+每个 `clueRows` 要检查：
+
+- 必须正好 5 行。
+- clue 顺序必须和原题一致。
+- `resolvedPhraseOrMember` 不能为空。
+- `resolvedPhraseOrMember` 不能等于 clue 原词。
+- `nonObviousWhy` 不能只写 `fits the same answer`。
+- phrase-pattern 题里，resolved phrase 要像自然短语。
+
+### 第四层: 加 reasoning 质量检查
+
+现在 `scripts/check-pinpoint-reasoning-article.ts` 主要检查：
+
+- 有没有 answer block。
+- answer block 是否在最后。
+- 段落是否太长。
+- 有没有过早泄露答案。
+
+它还不够。
+
+应该新增检查：
+
+- first-read block 不能只使用抽象 false start。
+- turning-clue block 必须引用具体 clue。
+- board-check block 至少列出 5 个具体 phrase/member。
+- 非答案部分过度重复 `connector/category/pattern/board/frame` 现在已有 `abstract-term-repeat` warning，但它抓不住 #765 这种空标签。
+- #765 这种结构合格但内容泛的页面，应该至少给 warning，最好挡在 full-analysis 发布前。
+
+### 第五层: 发布策略保持静态优先
+
+旧站最稳的一点是：
+
+正式页上线时，HTML 已经完整。
+
+所以我们当前项目也应该坚持：
+
+- 当天正式页必须预渲染出完整 detail HTML。
+- 发布检查必须检查真实 build 后的 HTML。
+- 不要把核心正文放到访问时再补。
+
+### 第六层: guardrail 先 warning, 再 blocking
+
+我们的第一目标是保护北京时间 15:00 更新窗口。
+
+所以内容质量闸门不能一上来就挡住正式站。
+
+当前真实 cron 窗口是：
+
+```text
+北京时间 15:01, 15:03, 15:05, 15:07, 15:10, 15:15, 15:20, 15:25
+```
+
+所以更准确的最低目标是：
+
+```text
+15:25 前，首页 / detail / API 必须显示当天题。
+```
+
+建议分三步：
+
+1. 先 warning。
+   - `test:pinpoint-reasoning-article` 和候选分支摘要先报出泛化问题。
+   - 不挡当天答案页发布。
+   - 第一阶段只能是 `warn` / `info`。
+   - 不能放进 `pinpoint:prepublish-gate` 的 `hard` / `review` / `downgrade` 分支。
+
+2. 再考虑 full-analysis 分层。
+   - 这一步目前不是现有代码直接支持的流程。
+   - 当前 `release:production`、Worker、预发布门都按 `full-analysis` 公开要求检查。
+   - 如果要允许轻量内容先公开，必须先改完整的 `answer-first` / `light-explainer` 公开规则。
+   - 没改这套规则前，不要在报告或脚本里说“可以先更新当天页但不提升 full-analysis”。
+
+3. 连续稳定几天后再 blocking。
+   - 只有当 warning 连续几天都能稳定抓准，才把它变成硬阻断。
+
+这样做的好处是：
+
+- 当天内容不会因为一个新规则卡死。
+- 质量问题会被看见。
+- 后续如果候选分支机器检查通过，会自动 fast-forward 到 `main`。
+- 正式站真正更新，还要等 `main` 部署和公开检查通过。
+
+真实发布链还要注意这些卡点：
+
+- 工作区必须干净，不能带无关改动。
+- `validate:data` / `validate:data:auto-repair` 是第一道硬门。
+- Vercel 构建失败或超时会卡。
+- Cloudflare / Wrangler 部署失败会卡。
+- Worker 自动发布被暂停会卡。
+- 抓到旧题会跳过。
+- GraphQL / fallback 没准备好会影响内容生成。
+- 候选分支 CI 失败或超时会卡。
+- release queue 遇到部署中、未知状态、短时间重复 push，也可能延迟。
+- post-publish audit 如果遇到 Cloudflare 子请求限制，应走 deferred，不应误判成发布失败。
+
+## 下一步建议
+
+下一步不要再写内容模板文档了。
+
+模板已经够多。
+
+下一步应该直接改 guardrail。
+
+建议先做一个小 PR：
+
+1. 在 `lib/puzzles/semantic-lint.ts` 增加泛化短语检查。
+2. 通过 `lib/puzzles/content-contract.ts` 进入数据校验链。
+3. 在 `lib/puzzles/reasoning-article.ts` 补渲染后文章检查，保证页面正文不会出现 `My first read drifted toward "a loose topic list"`。
+4. 在 `scripts/check-pinpoint-reasoning-article.ts` 把这类问题先显示成 warning。
+5. 用 `pinpoint-answer-765` 做回归样本，证明现在能抓出 `a loose topic list` 这类空话。
+6. 第一阶段不把这个问题接进发布阻断门。
+7. 不改首页 SEO 标题和描述。
+
+这样改的好处：
+
+- 不影响今天准时发布主链路。
+- 先把“结构过了但内容泛”的问题抓出来。
+- 后面再决定是 blocking 还是 warning。

--- a/lib/puzzles/content-contract.ts
+++ b/lib/puzzles/content-contract.ts
@@ -38,7 +38,13 @@ export type ContentContractInput = {
   overview?: string | null;
   solutionEmergence?: string | null;
   articleBlocks?: string[] | null;
-  wrongGuesses?: Array<{ guess?: string | null; explanation?: string | null }> | null;
+  wrongGuesses?: Array<{
+    guess?: string | null;
+    explanation?: string | null;
+    label?: string | null;
+    whyPlausible?: string | null;
+    whyRejected?: string | null;
+  }> | null;
   clueDetails?: Array<{ clue?: string | null; phrase?: string | null; explanation?: string | null }> | null;
   lessons?: Array<{ title?: string | null; body?: string | null }> | null;
   faqs?: Array<{ question?: string | null; answer?: string | null }> | null;

--- a/lib/puzzles/reasoning-article.ts
+++ b/lib/puzzles/reasoning-article.ts
@@ -26,6 +26,17 @@ export type ReasoningArticleQualityIssue = {
   severity: "hard" | "warn";
 };
 
+const GENERIC_REASONING_FILLER_PATTERNS = [
+  /\ba loose topic list\b/i,
+  /\bstandalone clue meanings\b/i,
+  /\bbroad topic match\b/i,
+  /\bthe answer becomes clear\b/i,
+  /\ball clues point to the same\b/i,
+  /\bshared category\b/i,
+  /\bcommon theme\b/i,
+  /\bthey all fit\b/i,
+];
+
 function normalizeParagraphKey(paragraph: string): string {
   return paragraph.toLowerCase().replace(/\s+/g, " ").trim();
 }
@@ -557,6 +568,14 @@ function pushIssue(
   issues.push({ code, message, severity });
 }
 
+function findGenericReasoningFiller(value: string): string | null {
+  for (const pattern of GENERIC_REASONING_FILLER_PATTERNS) {
+    const match = value.match(pattern);
+    if (match?.[0]) return match[0];
+  }
+  return null;
+}
+
 export function validateReasoningArticleDraft(
   draft: ReasoningArticleDraft,
   puzzle: Pick<PuzzleDetail, "answer" | "slug">,
@@ -584,6 +603,16 @@ export function validateReasoningArticleDraft(
     }
 
     for (const paragraph of block.body) {
+      const filler = findGenericReasoningFiller(paragraph);
+      if (filler) {
+        pushIssue(
+          issues,
+          "warn",
+          "generic-reasoning-filler",
+          `${block.key} uses generic filler instead of a clue-specific solving path: ${filler}`,
+        );
+      }
+
       const words = wordCount(paragraph);
       if (words > 70) {
         pushIssue(issues, "hard", "paragraph-too-long", `${block.key} paragraph has ${words} words.`);
@@ -593,6 +622,16 @@ export function validateReasoningArticleDraft(
     }
 
     for (const item of block.bullets ?? []) {
+      const filler = findGenericReasoningFiller(item);
+      if (filler) {
+        pushIssue(
+          issues,
+          "warn",
+          "generic-reasoning-filler",
+          `${block.key} bullet uses generic filler instead of a human false start: ${filler}`,
+        );
+      }
+
       const words = wordCount(item);
       if (words > 16) {
         pushIssue(issues, "warn", "bullet-long", `${block.key} bullet is long: ${item}`);

--- a/lib/puzzles/semantic-lint.ts
+++ b/lib/puzzles/semantic-lint.ts
@@ -15,11 +15,19 @@ export type SemanticContentInput = {
   overview?: string | null;
   solutionEmergence?: string | null;
   articleBlocks?: string[] | null;
-  wrongGuesses?: Array<{ guess?: string | null; explanation?: string | null }> | null;
+  wrongGuesses?: Array<{
+    guess?: string | null;
+    explanation?: string | null;
+    label?: string | null;
+    whyPlausible?: string | null;
+    whyRejected?: string | null;
+  }> | null;
   faqs?: Array<{ question?: string | null; answer?: string | null }> | null;
   clueDetails?: Array<{ clue?: string | null; phrase?: string | null; explanation?: string | null }> | null;
   lessons?: Array<{ title?: string | null; body?: string | null }> | null;
 };
+
+type SemanticWrongGuess = NonNullable<SemanticContentInput["wrongGuesses"]>[number];
 
 const LOCALE_MARKER_PATTERN = /\[(?:fr|de|pt-BR)\]/i;
 const BROKEN_ENTITY_PATTERN = /&#92;|&#x5c;|&#x5C;/i;
@@ -46,6 +54,29 @@ const GENERIC_FALSE_START_PATTERNS = [
   /\bwarning words?\b/i,
   /\bmixed signals?\b/i,
   /\bgeneral clues?\b/i,
+];
+const GENERIC_SOFT_FALSE_START_PATTERNS = [
+  /^(?:a\s+)?loose topic list$/i,
+  /^(?:a\s+)?loose topic grouping$/i,
+  /^(?:a\s+)?loose category match$/i,
+  /^(?:a\s+)?loose theme match$/i,
+  /^standalone clue meanings$/i,
+  /^standalone meanings$/i,
+  /^broad topic match$/i,
+  /^shared category$/i,
+  /^common theme$/i,
+  /^they all fit$/i,
+  /^all clues point to the same$/i,
+];
+const GENERIC_REASONING_FILLER_PATTERNS = [
+  /\ba loose topic list\b/i,
+  /\bstandalone clue meanings\b/i,
+  /\bbroad topic match\b/i,
+  /\bthe answer becomes clear\b/i,
+  /\ball clues point to the same\b/i,
+  /\bshared category\b/i,
+  /\bcommon theme\b/i,
+  /\bthey all fit\b/i,
 ];
 const GENERIC_CATEGORY_PIVOT_PATTERNS = [
   /\bwhat kind of source or title it was\b/i,
@@ -300,6 +331,22 @@ function looksLikeMachineGuess(value: string | null | undefined): boolean {
   return GENERIC_FALSE_START_PATTERNS.some((pattern) => pattern.test(text));
 }
 
+function looksLikeGenericSoftFalseStart(value: string | null | undefined): boolean {
+  const text = normalizeText(value);
+  if (!text) return false;
+  return GENERIC_SOFT_FALSE_START_PATTERNS.some((pattern) => pattern.test(text));
+}
+
+function containsGenericReasoningFiller(value: string | null | undefined): boolean {
+  const text = normalizeText(value);
+  if (!text) return false;
+  return GENERIC_REASONING_FILLER_PATTERNS.some((pattern) => pattern.test(text));
+}
+
+function getWrongGuessLabel(item: SemanticWrongGuess | null | undefined): string | null | undefined {
+  return item?.guess ?? item?.label;
+}
+
 function sampleText(value: string | null | undefined): string | undefined {
   const normalized = normalizeText(value);
   return normalized ? normalized.slice(0, 160) : undefined;
@@ -361,18 +408,38 @@ export function collectSemanticLintIssues(input: SemanticContentInput): Semantic
   scanTextEntry(issues, "solutionEmergence", input.solutionEmergence, input.locale);
   input.articleBlocks?.forEach((item, index) => {
     scanTextEntry(issues, `articleBlocks[${index}]`, item, input.locale);
+    if (containsGenericReasoningFiller(item)) {
+      pushIssue(
+        issues,
+        "copy.genericReasoningFiller",
+        "Article copy uses generic filler instead of a clue-specific solving path",
+        `articleBlocks[${index}]`,
+        item,
+      );
+    }
   });
 
   input.wrongGuesses?.forEach((item, index) => {
-    scanTextEntry(issues, `wrongGuesses[${index}].guess`, item?.guess, input.locale);
-    scanTextEntry(issues, `wrongGuesses[${index}].explanation`, item?.explanation, input.locale);
-    if (looksLikeMachineGuess(item?.guess)) {
+    const label = getWrongGuessLabel(item);
+    const labelField = item?.guess !== undefined ? `wrongGuesses[${index}].guess` : `wrongGuesses[${index}].label`;
+    const explanation = item?.explanation ?? [item?.whyPlausible, item?.whyRejected].filter(Boolean).join(" ");
+    scanTextEntry(issues, labelField, label, input.locale);
+    scanTextEntry(issues, `wrongGuesses[${index}].explanation`, explanation, input.locale);
+    if (item?.guess !== undefined && looksLikeMachineGuess(label)) {
       pushIssue(
         issues,
         "wrongGuesses.machineyGuess",
         "Wrong-guess label sounds machine-made instead of like a believable human false start",
-        `wrongGuesses[${index}].guess`,
-        item?.guess,
+        labelField,
+        label,
+      );
+    } else if (looksLikeMachineGuess(label) || looksLikeGenericSoftFalseStart(label)) {
+      pushIssue(
+        issues,
+        "wrongGuesses.genericLabel",
+        "Wrong-guess label is too generic to explain how a human would misread the clues",
+        labelField,
+        label,
       );
     }
   });
@@ -492,6 +559,36 @@ export function collectSemanticLintIssues(input: SemanticContentInput): Semantic
     ["faqs[1].answer", input.faqs?.[1]?.answer],
     ["faqs[2].answer", input.faqs?.[2]?.answer],
   ];
+
+  const genericReasoningFillerFields: Array<[string, string | null | undefined]> = [
+    ["overview", input.overview],
+    ["solutionEmergence", input.solutionEmergence],
+    ["summary", input.summary],
+    ...(input.faqs?.flatMap((item, index) => [
+      [`faqs[${index}].question`, item?.question] as [string, string | null | undefined],
+      [`faqs[${index}].answer`, item?.answer] as [string, string | null | undefined],
+    ]) ?? []),
+    ...(input.clueDetails?.flatMap((item, index) => [
+      [`clueDetails[${index}].phrase`, item?.phrase] as [string, string | null | undefined],
+      [`clueDetails[${index}].explanation`, item?.explanation] as [string, string | null | undefined],
+    ]) ?? []),
+    ...(input.lessons?.flatMap((item, index) => [
+      [`lessons[${index}].title`, item?.title] as [string, string | null | undefined],
+      [`lessons[${index}].body`, item?.body] as [string, string | null | undefined],
+    ]) ?? []),
+  ];
+
+  for (const [field, value] of genericReasoningFillerFields) {
+    if (containsGenericReasoningFiller(value)) {
+      pushIssue(
+        issues,
+        "copy.genericReasoningFiller",
+        "Copy uses generic filler instead of a clue-specific solving path",
+        field,
+        value,
+      );
+    }
+  }
 
   for (const [field, value] of temporaryPageFields) {
     const text = normalizeText(value);

--- a/scripts/analyze-legacy-pinpoint-site.mjs
+++ b/scripts/analyze-legacy-pinpoint-site.mjs
@@ -1,0 +1,273 @@
+#!/usr/bin/env node
+
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { createHash } from "node:crypto";
+
+const DEFAULT_SOURCE =
+  "/Users/elng/Downloads/us.sitesucker.mac.sitesucker-pro/pinpointanswer.today/linkedin-pinpoint-answer";
+
+function parseArgs(argv) {
+  const args = {
+    json: false,
+    source: process.env.LEGACY_PINPOINT_SITE || DEFAULT_SOURCE,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--json") {
+      args.json = true;
+    } else if (arg === "--source") {
+      args.source = argv[index + 1] || "";
+      index += 1;
+    } else if (arg.startsWith("--source=")) {
+      args.source = arg.slice("--source=".length);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return args;
+}
+
+function decodeHtml(value) {
+  const named = {
+    amp: "&",
+    apos: "'",
+    gt: ">",
+    lt: "<",
+    nbsp: " ",
+    quot: '"',
+  };
+
+  return String(value || "")
+    .replace(/&#(\d+);/g, (_, code) => String.fromCodePoint(Number.parseInt(code, 10)))
+    .replace(/&#x([0-9a-f]+);/gi, (_, code) => String.fromCodePoint(Number.parseInt(code, 16)))
+    .replace(/&([a-zA-Z][a-zA-Z0-9]+);/g, (match, code) => named[code] ?? match);
+}
+
+function stripVisibleText(html) {
+  return decodeHtml(
+    html
+      .replace(/<script\b[\s\S]*?<\/script>/gi, " ")
+      .replace(/<style\b[\s\S]*?<\/style>/gi, " ")
+      .replace(/<noscript\b[\s\S]*?<\/noscript>/gi, " ")
+      .replace(/<[^>]+>/g, " "),
+  )
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function extractTagText(html, tagName) {
+  const matches = html.matchAll(new RegExp(`<${tagName}\\b[^>]*>([\\s\\S]*?)<\\/${tagName}>`, "gi"));
+  return Array.from(matches, (match) =>
+    decodeHtml((match[1] || "").replace(/<[^>]+>/g, " "))
+      .replace(/\s+/g, " ")
+      .trim(),
+  ).filter(Boolean);
+}
+
+function countWords(text) {
+  return (text.match(/\b[\p{L}\p{N}_]+\b/gu) || []).length;
+}
+
+function percentile(sortedValues, percent) {
+  if (sortedValues.length === 0) return 0;
+  const index = (sortedValues.length - 1) * percent;
+  const lower = Math.floor(index);
+  const upper = Math.ceil(index);
+  if (lower === upper) return sortedValues[lower];
+  return sortedValues[lower] + (sortedValues[upper] - sortedValues[lower]) * (index - lower);
+}
+
+function median(values) {
+  return percentile([...values].sort((left, right) => left - right), 0.5);
+}
+
+function tableBodyRowCount(html) {
+  const tables = Array.from(html.matchAll(/<table\b[\s\S]*?<\/table>/gi), (match) => match[0]);
+  if (tables.length === 0) return 0;
+  return Math.max(
+    ...tables.map((table) => {
+      const trCount = (table.match(/<tr\b/gi) || []).length;
+      return Math.max(0, trCount - 1);
+    }),
+  );
+}
+
+function faqQuestionCount(text) {
+  const faqIndex = text.indexOf("FAQ");
+  if (faqIndex === -1) return 0;
+  const recentIndex = text.indexOf("Recent", faqIndex + 1);
+  const segment = recentIndex === -1 ? text.slice(faqIndex) : text.slice(faqIndex, recentIndex);
+  return (segment.match(/\?/g) || []).length;
+}
+
+function findPages(source) {
+  if (!existsSync(source)) {
+    throw new Error(`Legacy source directory does not exist: ${source}`);
+  }
+
+  return readdirSync(source, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && /^pinpoint-\d+$/.test(entry.name))
+    .map((entry) => {
+      const number = Number.parseInt(entry.name.replace("pinpoint-", ""), 10);
+      return {
+        number,
+        path: join(source, entry.name, "index.html"),
+        slug: entry.name,
+      };
+    })
+    .filter((entry) => existsSync(entry.path))
+    .sort((left, right) => left.number - right.number);
+}
+
+function analyze(source) {
+  const pages = findPages(source);
+  const metrics = {
+    clueCardsDataAttr: 0,
+    reveal: 0,
+    recentLinks: 0,
+    newsArticle: 0,
+    breadcrumbSchema: 0,
+    gameSchema: 0,
+    websiteSchema: 0,
+    organizationSchema: 0,
+    faqSchema: 0,
+    fullAnalysisHeading: 0,
+    wordsTableHeading: 0,
+    exactFiveRowTable: 0,
+    faqHeading: 0,
+    faqThreeQuestions: 0,
+    firstPerson: 0,
+    wrongOrTrapLanguage: 0,
+    turningLanguage: 0,
+    confirmationLanguage: 0,
+  };
+  const outliers = {
+    missingFullAnalysisHeading: [],
+    missingWordsTableHeading: [],
+    tableNotFiveRows: [],
+    missingFaqHeading: [],
+    faqQuestionCountNotThree: [],
+  };
+  const wordCounts = [];
+  const snapshotHash = createHash("sha256");
+  let totalBytes = 0;
+
+  for (const page of pages) {
+    const raw = readFileSync(page.path, "utf8");
+    const rawBytes = Buffer.byteLength(raw);
+    totalBytes += rawBytes;
+    snapshotHash.update(`${page.slug}\0${rawBytes}\0`);
+    snapshotHash.update(raw);
+    const noScript = raw
+      .replace(/<script\b[\s\S]*?<\/script>/gi, " ")
+      .replace(/<style\b[\s\S]*?<\/style>/gi, " ")
+      .replace(/<noscript\b[\s\S]*?<\/noscript>/gi, " ");
+    const text = stripVisibleText(raw);
+    const headings = ["h1", "h2", "h3"].flatMap((tagName) => extractTagText(noScript, tagName));
+    const words = countWords(text);
+    const rowCount = tableBodyRowCount(noScript);
+    const faqCount = faqQuestionCount(text);
+
+    wordCounts.push(words);
+
+    const hasFullAnalysis = headings.some((heading) => heading.includes("Answer & Full Analysis"));
+    const hasWordsTable = headings.some(
+      (heading) => heading.includes("Words & How They Fit") || heading.includes("Words and How They Fit"),
+    );
+    const hasFaq = headings.some((heading) => heading.includes("FAQ"));
+
+    if (raw.includes("data-clue-card")) metrics.clueCardsDataAttr += 1;
+    if (/Reveal.*Answer|Click to reveal|seeTheAnswer|Reveal-answer/i.test(raw)) metrics.reveal += 1;
+    if (/Recent Pinpoint Answers|Recent/i.test(text)) metrics.recentLinks += 1;
+    if (raw.includes("NewsArticle")) metrics.newsArticle += 1;
+    if (raw.includes("BreadcrumbList")) metrics.breadcrumbSchema += 1;
+    if (raw.includes('"Game"') || raw.includes("Game")) metrics.gameSchema += 1;
+    if (raw.includes("WebSite")) metrics.websiteSchema += 1;
+    if (raw.includes("Organization")) metrics.organizationSchema += 1;
+    if (raw.includes("FAQPage")) metrics.faqSchema += 1;
+    if (hasFullAnalysis) metrics.fullAnalysisHeading += 1;
+    if (hasWordsTable) metrics.wordsTableHeading += 1;
+    if (rowCount === 5) metrics.exactFiveRowTable += 1;
+    if (hasFaq) metrics.faqHeading += 1;
+    if (faqCount === 3) metrics.faqThreeQuestions += 1;
+    if (/\bI\b|\bmy\b|\bMy\b/.test(text)) metrics.firstPerson += 1;
+    if (/false start|wrong|trap|decoy|mislead|misleading|first instinct|first thought/i.test(text)) {
+      metrics.wrongOrTrapLanguage += 1;
+    }
+    if (/turning point|changed everything|changes everything|clicked|breakthrough|pivot|shift/i.test(text)) {
+      metrics.turningLanguage += 1;
+    }
+    if (/confirmation|confirmed|sealed it|checks? cleanly|fit.*perfectly/i.test(text)) {
+      metrics.confirmationLanguage += 1;
+    }
+
+    if (!hasFullAnalysis) outliers.missingFullAnalysisHeading.push(page.slug);
+    if (!hasWordsTable) outliers.missingWordsTableHeading.push(page.slug);
+    if (rowCount !== 5) outliers.tableNotFiveRows.push({ slug: page.slug, rowCount });
+    if (!hasFaq) outliers.missingFaqHeading.push(page.slug);
+    if (faqCount !== 3) outliers.faqQuestionCountNotThree.push({ slug: page.slug, questionCount: faqCount });
+  }
+
+  const sortedWords = [...wordCounts].sort((left, right) => left - right);
+
+  return {
+    source,
+    totalPages: pages.length,
+    range: pages.length > 0 ? `${pages[0].slug}..${pages[pages.length - 1].slug}` : "",
+    sourceFingerprint: {
+      htmlFileCount: pages.length,
+      totalBytes,
+      sha256: snapshotHash.digest("hex"),
+    },
+    metrics,
+    outliers,
+    wordCounts: {
+      min: sortedWords[0] ?? 0,
+      p25: Math.round(percentile(sortedWords, 0.25)),
+      median: Math.round(median(sortedWords)),
+      p75: Math.round(percentile(sortedWords, 0.75)),
+      max: sortedWords[sortedWords.length - 1] ?? 0,
+    },
+  };
+}
+
+function printSummary(result) {
+  console.log(`Legacy Pinpoint site: ${result.source}`);
+  console.log(`pages: ${result.totalPages} (${result.range})`);
+  console.log(
+    `source fingerprint: ${result.sourceFingerprint.sha256} (${result.sourceFingerprint.htmlFileCount} html files, ${result.sourceFingerprint.totalBytes} bytes)`,
+  );
+  console.log(`visible words: ${JSON.stringify(result.wordCounts)}`);
+  console.log("metrics:");
+  for (const [key, value] of Object.entries(result.metrics)) {
+    console.log(`- ${key}: ${value}`);
+  }
+  console.log("outliers:");
+  console.log(`- missingFullAnalysisHeading: ${result.outliers.missingFullAnalysisHeading.join(", ") || "none"}`);
+  console.log(`- missingWordsTableHeading: ${result.outliers.missingWordsTableHeading.join(", ") || "none"}`);
+  console.log(
+    `- tableNotFiveRows: ${
+      result.outliers.tableNotFiveRows.map((item) => `${item.slug}:${item.rowCount}`).join(", ") || "none"
+    }`,
+  );
+  console.log(`- missingFaqHeading: ${result.outliers.missingFaqHeading.join(", ") || "none"}`);
+  console.log(
+    `- faqQuestionCountNotThree: ${
+      result.outliers.faqQuestionCountNotThree
+        .map((item) => `${item.slug}:${item.questionCount}`)
+        .join(", ") || "none"
+    }`,
+  );
+}
+
+const args = parseArgs(process.argv.slice(2));
+const result = analyze(args.source);
+
+if (args.json) {
+  console.log(JSON.stringify(result, null, 2));
+} else {
+  printSummary(result);
+}

--- a/scripts/check-pinpoint-guardrails.ts
+++ b/scripts/check-pinpoint-guardrails.ts
@@ -10,7 +10,10 @@ import {
   validateDraftLanguage,
   validateDraftStructure,
 } from "../lib/puzzles/draft-validator";
-import { validateContentContract } from "../lib/puzzles/content-contract";
+import {
+  promotePublishBlockingIssues,
+  validateContentContract,
+} from "../lib/puzzles/content-contract";
 import { validateEvidenceContract } from "../lib/puzzles/evidence-contract";
 import { collectSemanticLintIssues } from "../lib/puzzles/semantic-lint";
 import {
@@ -1831,6 +1834,91 @@ function checkContentContractRequiresThreeCompleteFaqs() {
   console.log("ok: content contract requires three complete FAQ items");
 }
 
+function checkGenericFalseStartWarningsDoNotBlockPublish() {
+  const rawWords = ["White", "Pirate", "National", "Checkered", "Capture the"];
+  const semanticCodes = collectSemanticLintIssues({
+    mainAnswer: "Words that come before flag",
+    articleBlocks: ['My first read drifted toward "a loose topic list" before the later clue corrected it.'],
+    wrongGuesses: [
+      {
+        label: "a loose topic list",
+        whyPlausible: "White and Pirate can look like a broad theme before the phrase slot is tested.",
+        whyRejected: "Capture the makes one exact phrase ending testable.",
+      },
+    ],
+  }).map((issue) => issue.code);
+  assert.ok(
+    semanticCodes.includes("wrongGuesses.genericLabel"),
+    "semantic lint should warn on generic wrong-guess labels",
+  );
+  assert.ok(
+    semanticCodes.includes("copy.genericReasoningFiller"),
+    "semantic lint should warn on generic reasoning filler in article copy",
+  );
+
+  const promotedIssues = promotePublishBlockingIssues(validateContentContract({
+    puzzleNumber: 765,
+    bodyMode: "short",
+    locale: "en",
+    rawWords,
+    mainAnswer: "Words that come before flag",
+    summary: "White, Pirate, National, Checkered, and Capture the need one repeated phrase ending.",
+    seoTitle: "LinkedIn Pinpoint #765 Answer: White, Pirate, National, Checkered, Capture the",
+    seoDescription:
+      "LinkedIn Pinpoint #765 answer for White, Pirate, National, Checkered, and Capture the, with spoiler-safe clues and a complete phrase explanation.",
+    overview:
+      "White first looks like a color clue, and Pirate can point toward ships or flags before the rest of the board is checked. National and Checkered keep the phrase direction alive, while Capture the gives the cleanest way to test one repeated ending across all five clues.",
+    solutionEmergence:
+      "I first read White as color language and Pirate as a sea clue, but that pairing did not explain National and Checkered cleanly. Capture the changed the solve because Capture the flag is a fixed phrase. After that, White flag, Pirate flag, National flag, and Checkered flag all checked cleanly under the same ending. That gave the board one repeated phrase slot instead of five separate clue meanings, and every clue could be verified without stretching the language.",
+    articleBlocks: ['My first read drifted toward "a loose topic list" before Capture the corrected the path.'],
+    wrongGuesses: [
+      {
+        label: "a loose topic list",
+        whyPlausible: "White and Pirate can look like a broad theme before the phrase slot is tested.",
+        whyRejected: "Capture the makes one exact phrase ending testable.",
+      },
+    ],
+    clueDetails: rawWords.map((clue) => ({
+      clue,
+      phrase: `${clue} flag`,
+      explanation: `${clue} fits because it forms a familiar phrase with flag after it.`,
+    })),
+    faqs: [
+      {
+        question: "What is the answer to LinkedIn Pinpoint #765?",
+        answer: "The answer is Words that come before flag.",
+      },
+      {
+        question: "Why does Pirate matter in LinkedIn Pinpoint #765?",
+        answer: "Pirate matters because Pirate flag gives a clear phrase test for the shared ending.",
+      },
+      {
+        question: "Why is Capture the the key clue in LinkedIn Pinpoint #765?",
+        answer: "Capture the is decisive because Capture the flag is a fixed phrase that makes the ending easy to verify.",
+      },
+    ],
+  }));
+  assert.ok(
+    promotedIssues.some((issue) => issue.level === "warning" && issue.code === "wrongGuesses.genericLabel"),
+    "generic wrong-guess label should stay a warning after publish-blocking promotion",
+  );
+  assert.ok(
+    promotedIssues.some((issue) => issue.level === "warning" && issue.code === "copy.genericReasoningFiller"),
+    "generic reasoning filler should stay a warning after publish-blocking promotion",
+  );
+  assert.equal(
+    promotedIssues.filter(
+      (issue) =>
+        issue.level === "error" &&
+        (issue.code === "wrongGuesses.genericLabel" || issue.code === "copy.genericReasoningFiller"),
+    ).length,
+    0,
+    "generic quality notes must not block publish in the first warning-only phase",
+  );
+
+  console.log("ok: generic false-start quality notes warn without blocking publish");
+}
+
 async function checkTypedCategoryGenerationKeepsGrammarNatural() {
   const generationModulePath = "../lib/puzzle-generation.ts";
   const workerModulePath = "../worker/src/index.ts";
@@ -3474,6 +3562,7 @@ async function main() {
   await checkPhraseFallbackDirection();
   await checkEvidenceContractGuardsMeaningfulV2Fields();
   checkContentContractRequiresThreeCompleteFaqs();
+  checkGenericFalseStartWarningsDoNotBlockPublish();
   await checkTypedCategoryGenerationKeepsGrammarNatural();
   checkWorkerLlmSlotsOnlyDraftNormalizesBeforeValidation();
   await checkValidateDraftDoesNotNormalizeEmptySlots();


### PR DESCRIPTION
## What changed

- Added warning-only checks for generic Pinpoint reasoning filler like `a loose topic list` and `standalone clue meanings`.
- Extended the content contract input so published `wrongGuessCandidates.label / whyPlausible / whyRejected` can be inspected without turning these new notes into publish blockers.
- Added reasoning-article warnings for final rendered `Answer Reasoning` drafts.
- Cleaned stale generic false-start copy in six historical puzzle JSON files: `#730`, `#746`, `#752`, `#758`, `#760`, and `#765`.
- Added a legacy-site reverse-engineering report and a reproducible local stats script for the SiteSucker snapshot.

## Why

The old template structure existed, but the checks mostly verified shape rather than whether false starts sounded like a real solver's wrong turn. That allowed placeholder-style labels to pass and show up in public reasoning copy.

This keeps the first phase warning-only so the daily publish window is not blocked by a new quality rule.

## Validation

- `npm run test:pinpoint-reasoning-article`
- `npm run validate:data`
- `npm run test:pinpoint-guardrails`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `git diff --check`

## Notes

- This PR does not change `lib/seo/metadata.ts`.
- The new generic reasoning checks intentionally do not enter the publish-blocking code set.
