### PR TITLE
Keep detail keyword anchor visible

### DIFF
--- a/lib/puzzles/reasoning-article.ts
+++ b/lib/puzzles/reasoning-article.ts
@@ -259,7 +259,7 @@ function buildBoardCheckFitText(puzzle: PuzzleDetail): string {
 }
 
 function buildAnswerBody(puzzle: PuzzleDetail, title: string): string[] {
-  const summary = "This is the cleanest reading because it explains the full board, not just one or two clues.";
+  const summary = `This LinkedIn Pinpoint ${puzzle.number} answer is the cleanest reading because it explains the full board, not just one or two clues.`;
 
   if (title === "Answer") {
     return [`The answer was "${puzzle.answer}".`, summary];
@@ -429,7 +429,7 @@ export function buildReasoningArticleDraft(puzzle: PuzzleDetail): ReasoningArtic
 
   blocks.push({
     body: [
-      "Today's puzzle looked simple at first.",
+      `Today's LinkedIn Pinpoint ${puzzle.number} answer looked simple at first.`,
       `The clue path was ${cluePath}, and the solve had to make every clue read under ${connectorSummary}.`,
     ],
     key: "clue-path",

--- a/scripts/check-pinpoint-guardrails.ts
+++ b/scripts/check-pinpoint-guardrails.ts
@@ -3254,6 +3254,7 @@ async function checkPrepublishGateRunsContentAutoRepairSafely() {
   const prepublishSource = await readFile(resolve(ROOT, "scripts/check-pinpoint-prepublish-gate.ts"), "utf8");
   const releaseSource = await readFile(resolve(ROOT, "scripts/release-production.mjs"), "utf8");
   const workerSource = await readFile(resolve(ROOT, "worker/src/index.ts"), "utf8");
+  const reasoningSource = await readFile(resolve(ROOT, "lib/puzzles/reasoning-article.ts"), "utf8");
   const packageJson = JSON.parse(await readFile(resolve(ROOT, "package.json"), "utf8")) as {
     scripts?: Record<string, string>;
   };
@@ -3279,6 +3280,11 @@ async function checkPrepublishGateRunsContentAutoRepairSafely() {
       workerSource.includes("shouldRepairSolutionNarrative(detailRecord)") &&
       workerSource.includes("repairSolutionNarrative({ detail: detailRecord }).detail"),
     "Worker must run the shared solution narrative repair only when public detail JSON needs it",
+  );
+  assert.ok(
+    reasoningSource.includes("Today's LinkedIn Pinpoint ${puzzle.number} answer") &&
+      reasoningSource.includes("This LinkedIn Pinpoint ${puzzle.number} answer"),
+    "detail reasoning article must keep two visible LinkedIn Pinpoint answer anchors for non-blocking keyword balance",
   );
 
   const repair = repairSolutionNarrative({


### PR DESCRIPTION
## Summary
- Add two natural visible anchors for `LinkedIn Pinpoint #N answer` in detail reasoning copy.
- Keep the daily publish flow non-blocking, but make keyword balance less dependent on generated content.
- Add a guardrail so future edits cannot quietly remove both anchors.

## Verification
- npm run lint
- npm run typecheck
- npm run test:pinpoint-guardrails
- npm run detail:keyword-audit -- --html .next/server/app/linkedin-pinpoint-answers/pinpoint-answer-766.html --slug pinpoint-answer-766 --top 20
- npm run pinpoint:prepublish-gate -- --slug pinpoint-answer-766 --use-existing-build