### PR TITLE
Clean up Pinpoint detail copy joins

### DIFF
--- a/components/detail/PuzzleFullAnalysis.tsx
+++ b/components/detail/PuzzleFullAnalysis.tsx
@@ -36,6 +36,14 @@ type TeachingCard = {
   title: string;
 };
 
+const GENERIC_TEACHING_BODY_PATTERNS = [
+  /\bWhen solving puzzles,\s*(?:consider|look for)\b/i,
+  /\bcommon thread that (?:connects|ties)\b/i,
+  /\bunique aspects of each clue\b/i,
+  /\boverall answer\b/i,
+  /\bseemingly unrelated clues\b/i,
+];
+
 function getFallbackTeachingTitle(body: string, index: number): string {
   const firstSentence = cleanReasoningText(body).split(/[.!?]/)[0]?.trim();
   if (firstSentence && firstSentence.length <= 82) {
@@ -45,8 +53,16 @@ function getFallbackTeachingTitle(body: string, index: number): string {
   return `Solving takeaway ${index + 1}`;
 }
 
+function cleanTeachingTitle(title: string): string {
+  return cleanReasoningText(title)
+    .replace(/\banchors a shared category board with one concrete theme\b/gi, "anchors the answer frame")
+    .replace(/\bunder a shared category board with one concrete theme\b/gi, "under the same answer frame")
+    .trim();
+}
+
 function getTeachingLessonTitle(lesson: PuzzleDetailRecord["lessons"][number], index: number): string {
-  return typeof lesson === "string" ? getFallbackTeachingTitle(lesson, index) : lesson.title;
+  const title = typeof lesson === "string" ? getFallbackTeachingTitle(lesson, index) : lesson.title;
+  return cleanTeachingTitle(title);
 }
 
 function replaceQuotedCluePairs(value: string): string {
@@ -55,8 +71,22 @@ function replaceQuotedCluePairs(value: string): string {
     .replace(/“([^”]+)”\s+and\s+“([^”]+)”/g, "Both clues");
 }
 
+function getTeachingAnchorClue(puzzle: PuzzleDetailRecord): string {
+  return puzzle.turningPoint?.clue || puzzle.solvePath?.breakingClue || puzzle.clues[puzzle.clues.length - 1] || "the turning clue";
+}
+
+function buildSpecificTeachingBody(puzzle: PuzzleDetailRecord): string {
+  const anchorClue = getTeachingAnchorClue(puzzle);
+  const firstClue = puzzle.clues[0] || "the first clue";
+  return `Use ${anchorClue} to re-check ${firstClue}. A strong Pinpoint answer should make the early clues and later clues fit one reading.`;
+}
+
 function cleanTeachingBody(body: string, puzzle: PuzzleDetailRecord): string {
   let cleaned = replaceQuotedCluePairs(cleanReasoningText(body));
+
+  if (GENERIC_TEACHING_BODY_PATTERNS.some((pattern) => pattern.test(cleaned))) {
+    return buildSpecificTeachingBody(puzzle);
+  }
 
   for (const clue of puzzle.clues) {
     if (clue.trim().split(/\s+/).length <= 1) {
@@ -71,6 +101,11 @@ function cleanTeachingBody(body: string, puzzle: PuzzleDetailRecord): string {
 
   return cleaned
     .replace(/\bthat clue\s+and\s+that clue\b/gi, "both clues")
+    .replace(/\bthat clue clue\b/gi, "that clue")
+    .replace(/\bBoth clues both\b/g, "Both clues")
+    .replace(/\bboth clues both\b/g, "both clues")
+    .replace(/(^|[.!?]\s+)that clue\b/gi, "$1That clue")
+    .replace(/(^|[.!?]\s+)both clues\b/gi, "$1Both clues")
     .replace(/\s+/g, " ")
     .trim();
 }

--- a/data/puzzles/pinpoint-answer-766.json
+++ b/data/puzzles/pinpoint-answer-766.json
@@ -42,7 +42,7 @@
     "The answer requires a level of precision that encompasses various elements uniquely associated with Germany.",
     "In hindsight, the clues work together to form a cohesive picture of German culture, history, and geography.",
     "The solve path involved navigating through plausible but incorrect guesses to arrive at the precise answer.",
-    "The key takeaway is the importance of considering the unique aspects of each clue and how they contribute to the overall answer.",
+    "The key takeaway is to use The Berlin Wall to pull the earlier food and travel clues into the same Germany frame.",
     "This puzzle demonstrates how a combination of clues can lead to a specific and precise answer, despite initial broad guesses.",
     "The answer was Things associated with Germany 🇩🇪."
   ],
@@ -58,11 +58,11 @@
     },
     {
       "title": "\"The Berlin Wall\" anchors a shared category board with one concrete theme",
-      "body": "the Berlin Wall is what organizes this board. Once one clue produces a precise natural reading, re-check the earlier clues under that same frame."
+      "body": "The Berlin Wall organizes this board. Once one clue produces a precise natural reading, re-check the earlier clues under that same frame."
     },
     {
       "title": "Use \"The Berlin Wall\" to re-check \"Pretzels\" under a shared category board with one concrete theme",
-      "body": "When solving puzzles, consider the unique aspects of each clue and how they contribute to the overall answer."
+      "body": "Use The Berlin Wall to re-check Pretzels. A strong Pinpoint answer should make the early food clues and later history clues fit one reading."
     }
   ],
   "display": {
@@ -130,7 +130,7 @@
   },
   "turningPoint": {
     "clue": "The Berlin Wall",
-    "whyDecisive": "The Berlin Wall clue makes the answer concrete by introducing a historical and geographical element that is uniquely German.",
+    "whyDecisive": "The Berlin Wall makes the answer concrete by introducing a historical and geographical element that is uniquely German.",
     "whatChangedAfterIt": "Once The Berlin Wall landed, the earlier clues stopped pulling in different directions and started reinforcing the same answer."
   },
   "clueRows": [

--- a/lib/puzzle-generation/content-composer.ts
+++ b/lib/puzzle-generation/content-composer.ts
@@ -1297,6 +1297,18 @@ function sanitizeRejectedGuess(
   };
 }
 
+const GENERIC_PORTABLE_TAKEAWAY_PATTERNS = [
+  /\bWhen solving puzzles,\s*(?:consider|look for)\b/i,
+  /\bcommon thread that (?:connects|ties)\b/i,
+  /\bunique aspects of each clue\b/i,
+  /\boverall answer\b/i,
+  /\bseemingly unrelated clues\b/i,
+];
+
+function isGenericPortableTakeaway(value: string): boolean {
+  return GENERIC_PORTABLE_TAKEAWAY_PATTERNS.some((pattern) => pattern.test(value));
+}
+
 function buildLessons(
   turningPointLabel: string,
   connectorSummary: string,
@@ -1338,7 +1350,9 @@ function buildLessons(
       : "The narrowing clue matters more than the loudest clue";
 
   const lesson2Body = ensureSentence(
-    `${turningPointReference(turningPointLabel)} is what organizes this board. Once one clue produces a precise natural reading, re-check the earlier clues under that same frame.`,
+    turningClue !== "A later clue"
+      ? `${turningClue} organizes this board. Once one clue produces a precise natural reading, re-check the earlier clues under that same frame.`
+      : "One clue organizes this board. Once it produces a precise natural reading, re-check the earlier clues under that same frame.",
   );
 
   const lesson3Title = isPhrase
@@ -1351,12 +1365,22 @@ function buildLessons(
 
   const defaultTakeaway = isPhrase
     ? `A strong Pinpoint answer should explain every clue naturally through ${lowerFirst(connectorSummary)}`
-    : "A strong Pinpoint answer should explain why every clue belongs in the same category.";
+    : turningClue !== "A later clue" && firstClue
+      ? `Use "${turningClue}" to re-check "${firstClue}". A strong Pinpoint answer should make the early clues and later clues fit one reading.`
+      : "A strong Pinpoint answer should explain why every clue belongs in the same category.";
+  const normalizedTakeaway = normalizeText(portableTakeaway);
 
   return [
     { title: lesson1Title, body: lesson1Body },
     { title: lesson2Title, body: lesson2Body },
-    { title: lesson3Title, body: ensureSentence(portableTakeaway || defaultTakeaway) },
+    {
+      title: lesson3Title,
+      body: ensureSentence(
+        normalizedTakeaway && !isGenericPortableTakeaway(normalizedTakeaway)
+          ? normalizedTakeaway
+          : defaultTakeaway,
+      ),
+    },
   ];
 }
 

--- a/lib/puzzles/reasoning-article.ts
+++ b/lib/puzzles/reasoning-article.ts
@@ -89,6 +89,12 @@ export function cleanReasoningText(value: string): string {
     .replace(/\bthe shared answer\b/g, "one answer")
     .replace(/\bmakes one answer concrete enough to test across the full board\b/gi, "makes the missing word easier to test across the full board")
     .replace(/\bstart reading under the same answer\b/gi, "start pointing to the repeated word")
+    .replace(/\bbecause\s+(This|That)\b/g, ". $1")
+    .replace(/\bThis clue clue\b/g, "This clue")
+    .replace(/\bthis clue clue\b/g, "this clue")
+    .replace(/\bthat clue clue\b/g, "that clue")
+    .replace(/\bBoth clues both\b/g, "Both clues")
+    .replace(/\bboth clues both\b/g, "both clues")
     .replace(/\.\.+/g, ".")
     .replace(/\s+/g, " ")
     .trim();
@@ -107,6 +113,19 @@ function firstSentences(value: string | null | undefined, count = 1): string {
 function safeFirstSentences(value: string | null | undefined, answer: string, count = 1): string {
   const sentence = firstSentences(value, count);
   return sentence && !paragraphMentionsAnswer(sentence, answer) ? sentence : "";
+}
+
+function polishFalseStartReason(value: string | null | undefined): string {
+  const cleaned = cleanReasoningText(value ?? "");
+  if (!cleaned) {
+    return "";
+  }
+
+  return `${cleaned[0].toUpperCase()}${cleaned.slice(1)}`
+    .replace(/^This guess falls short because\b/i, "That guess fell short because")
+    .replace(/^This guess fails because\b/i, "That guess failed because")
+    .replace(/^This read falls short because\b/i, "That read fell short because")
+    .trim();
 }
 
 function dedupeParagraphs(paragraphs: string[]): string[] {
@@ -232,6 +251,9 @@ function softenRepeatedClueMention(value: string, clue: string): string {
     .replace(new RegExp(`"(${escapeRegExp(clue)})"`, "gi"), "this clue")
     .replace(new RegExp(`\\b${escapeRegExp(clue)}\\b`, "gi"), "this clue")
     .replace(/(^|[.!?]\s+)this clue\b/g, "$1This clue")
+    .replace(/\bThis clue clue\b/g, "This clue")
+    .replace(/\bthis clue clue\b/g, "this clue")
+    .replace(/\bthat clue clue\b/g, "that clue")
     .replace(/\bThis clue is the clue that\b/g, "This clue")
     .replace(/\bthis clue is the clue that\b/g, "this clue")
     .replace(/\s+/g, " ")
@@ -438,12 +460,13 @@ export function buildReasoningArticleDraft(puzzle: PuzzleDetail): ReasoningArtic
   if (puzzle.solvePath?.firstRead || puzzle.solvePath?.falseStarts[0]) {
     const firstRead = firstSentences(puzzle.solvePath?.firstRead, 1);
     const firstGuess = puzzle.solvePath?.falseStarts[0];
-    const firstWhy = safeFirstSentences(puzzle.solvePath?.whyFalseStartPlausible[0], puzzle.answer, 1);
+    const firstWhy = polishFalseStartReason(
+      safeFirstSentences(puzzle.solvePath?.whyFalseStartPlausible[0], puzzle.answer, 1),
+    );
     const falseStartBullets = buildFalseStartBullets(puzzle);
     const body = [
-      firstGuess
-        ? `My first read drifted toward "${firstGuess}"${firstWhy ? ` because ${firstWhy}` : "."}`
-        : firstRead,
+      firstGuess ? `My first read drifted toward "${firstGuess}".` : firstRead,
+      firstGuess ? firstWhy : "",
       "That was the trap: the early clues were readable on their own, but they did not prove one exact phrase slot yet.",
     ].filter(Boolean);
 

--- a/scripts/check-pinpoint-guardrails.ts
+++ b/scripts/check-pinpoint-guardrails.ts
@@ -28,6 +28,8 @@ import {
   repairSolutionNarrative,
   shouldRepairSolutionNarrative,
 } from "../lib/puzzles/solution-narrative-repair";
+import { getPuzzleBySlug } from "../lib/puzzles/data";
+import { buildReasoningArticleDraft } from "../lib/puzzles/reasoning-article";
 import { resolveWorkerFetchRoute } from "../worker/src/routes/dispatch";
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
@@ -1919,6 +1921,40 @@ function checkGenericFalseStartWarningsDoNotBlockPublish() {
   console.log("ok: generic false-start quality notes warn without blocking publish");
 }
 
+async function checkReasoningArticleAvoidsAwkwardCopyJoins() {
+  const puzzle = await getPuzzleBySlug("pinpoint-answer-766", { allowLiveWorkerFallback: false });
+  assert.ok(puzzle, "pinpoint-answer-766 fixture must exist for reasoning article copy regression");
+
+  const draft = buildReasoningArticleDraft(puzzle);
+  const copy = draft.blocks
+    .flatMap((block) => [block.title ?? "", ...block.body, ...(block.bullets ?? [])])
+    .join(" ");
+
+  const forbiddenPatterns = [
+    /\bbecause\s+(?:This|That)\b/,
+    /\b(?:This|this|that) clue clue\b/,
+    /\bBoth clues both\b/i,
+    /\bWhen solving puzzles,\s*(?:consider|look for)\b/i,
+    /\bunique aspects of each clue\b/i,
+  ];
+
+  for (const pattern of forbiddenPatterns) {
+    assert.doesNotMatch(copy, pattern, `reasoning article copy must avoid awkward generated phrase: ${pattern}`);
+  }
+  assert.match(
+    copy,
+    /My first read drifted toward "european foods"\. That guess fell short because/i,
+    "reasoning article should keep the false-start explanation as clean separate sentences",
+  );
+  assert.match(
+    copy,
+    /This clue makes the answer concrete/i,
+    "reasoning article should collapse repeated turning-clue wording",
+  );
+
+  console.log("ok: reasoning article copy avoids awkward generated joins");
+}
+
 async function checkTypedCategoryGenerationKeepsGrammarNatural() {
   const generationModulePath = "../lib/puzzle-generation.ts";
   const workerModulePath = "../worker/src/index.ts";
@@ -3569,6 +3605,7 @@ async function main() {
   await checkEvidenceContractGuardsMeaningfulV2Fields();
   checkContentContractRequiresThreeCompleteFaqs();
   checkGenericFalseStartWarningsDoNotBlockPublish();
+  await checkReasoningArticleAvoidsAwkwardCopyJoins();
   await checkTypedCategoryGenerationKeepsGrammarNatural();
   checkWorkerLlmSlotsOnlyDraftNormalizesBeforeValidation();
   await checkValidateDraftDoesNotNormalizeEmptySlots();

--- a/scripts/check-pinpoint-rendered-content.ts
+++ b/scripts/check-pinpoint-rendered-content.ts
@@ -37,6 +37,14 @@ type SitemapEntry = {
   lastmod: string;
 };
 
+const FORBIDDEN_RENDERED_COPY_PATTERNS = [
+  /\bbecause\s+(?:This|That)\b/,
+  /\b(?:This|this|that) clue clue\b/,
+  /\bBoth clues both\b/i,
+  /\bWhen solving puzzles,\s*(?:consider|look for)\b/i,
+  /\bunique aspects of each clue\b/i,
+];
+
 const issues: Issue[] = [];
 
 function addIssue(scope: string, message: string) {
@@ -362,6 +370,11 @@ function checkDetailRendered(entry: RegistryEntry, allEntries: RegistryEntry[]) 
   }
   if (!pageText.includes("Answer Reasoning")) {
     addIssue(entry.slug, "Rendered page is missing the Answer Reasoning section.");
+  }
+  for (const pattern of FORBIDDEN_RENDERED_COPY_PATTERNS) {
+    if (pattern.test(pageText)) {
+      addIssue(entry.slug, `Rendered page contains awkward generated copy: ${pattern}`);
+    }
   }
   for (const legacyLabel of [
     "Words & How They Fit",


### PR DESCRIPTION
## Summary
- Fix awkward reasoning joins like `because This...` and repeated phrases like `This clue clue`.
- Clean rendered teaching cards so generic takeaway text becomes clue-specific copy.
- Tune the generation template so future lessons avoid generic `When solving puzzles...` copy.
- Add guardrails for reasoning copy and rendered HTML so obvious bad phrases fail CI.
- Clean today's #766 detail data for the same issue.

## Verification
- npm run validate:data
- npm run test:pinpoint-reasoning-article -- --slug pinpoint-answer-766
- npm run lint
- npm run typecheck
- npm run test:pinpoint-guardrails
- npm run build
- npm run test:pinpoint-rendered
- npm run detail:keyword-audit -- --html .next/server/app/linkedin-pinpoint-answers/pinpoint-answer-766.html --slug pinpoint-answer-766 --top 20
- npm run pinpoint:prepublish-gate -- --slug pinpoint-answer-766 --use-existing-build