### PR TITLE
Add partner footer links

### DIFF
--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -6,17 +6,39 @@ type FooterProps = {
   isDetailPage?: boolean;
 };
 
+type FooterLink = {
+  label: string;
+  href: string;
+  external?: boolean;
+};
+
+const obbyListLink: FooterLink = {
+  label: "Roblox Codes on ObbyList",
+  href: "https://obbylist.com/",
+  external: true,
+};
+
+const patchesAnswersLink: FooterLink = {
+  label: "Patches Answers Today",
+  href: "https://patchesanswertoday.com/",
+  external: true,
+};
+
 export function Footer({ isDetailPage = false }: FooterProps) {
-  const quickLinks = isDetailPage
+  const quickLinks: FooterLink[] = isDetailPage
     ? [
         { label: "Pro Tips", href: routes.preview },
         { label: "Archive", href: routes.archive },
         { label: "How it works", href: "/#faq" },
         { label: "About", href: routes.about },
+        obbyListLink,
+        patchesAnswersLink,
       ]
     : [
         { label: "Pro Tips", href: routes.preview },
         { label: "Open Full Archive", href: routes.archive },
+        obbyListLink,
+        patchesAnswersLink,
       ];
   const supportLinks = [
     { label: "Email Support", href: supportMailto },
@@ -47,7 +69,11 @@ export function Footer({ isDetailPage = false }: FooterProps) {
               <ul className="footer-link-list footer-link-list-compact">
                 {quickLinks.map((link) => (
                   <li key={`${link.label}-${link.href}`}>
-                    <Link href={link.href} prefetch={false}>{link.label}</Link>
+                    {link.external ? (
+                      <a href={link.href} target="_blank" rel="noopener noreferrer">{link.label}</a>
+                    ) : (
+                      <Link href={link.href} prefetch={false}>{link.label}</Link>
+                    )}
                   </li>
                 ))}
               </ul>

--- a/docs/ITERATION.md
+++ b/docs/ITERATION.md
@@ -168,3 +168,14 @@
 未做：未补强这些 fallback_full 页面到完整 AI 深度稿；未处理 GSC 恢复判断。  
 复查日期：下一次 Phase 0 observer。  
 下一步：明天只读 observer 重点确认 sitemap 和 #787 最新页稳定，不再把 `#775-#786` 当缺口。
+
+## 2026-07-11 合作站点页脚链接上线记录
+
+问题：需要从全站页脚添加指向 ObbyList 和 Patches Answers Today 的 dofollow 链接。
+证据：页脚原来没有这两个入口；Patches Answers Today 只在顶部导航出现。
+本轮边界：只改全站页脚链接、守卫检查和本记录，不改首页 SEO 标题/描述、正文、题库、Worker 和发布规则。
+修改：在页脚 `Quick Links` 增加 `Roblox Codes on ObbyList` 和 `Patches Answers Today`；外链 `rel` 只使用 `noopener noreferrer`，不含 `nofollow` 或 `sponsored`。
+验证：守卫检查、类型检查、lint、完整构建及真实页面检查。
+未做：未把原工作区内其他未提交改动混入本次发布。
+复查日期：本次 Vercel 生产部署完成后立即复查线上 HTML。
+下一步：确认生产域名两个页脚链接都可见，且 `rel` 不含 `nofollow`。

--- a/scripts/check-pinpoint-guardrails.ts
+++ b/scripts/check-pinpoint-guardrails.ts
@@ -126,6 +126,31 @@ async function checkOfficialDomainGuardrail() {
   console.log("ok: official domain guardrail keeps runtime defaults on pinpointanswertoday.app");
 }
 
+async function checkPartnerFooterLinksAreDofollow() {
+  const footerSource = await readProjectFile("components/layout/Footer.tsx");
+
+  assert.match(
+    footerSource,
+    /label:\s*"Roblox Codes on ObbyList"[\s\S]*?href:\s*"https:\/\/obbylist\.com\/"[\s\S]*?external:\s*true/,
+    "footer must include the ObbyList link",
+  );
+  assert.match(
+    footerSource,
+    /label:\s*"Patches Answers Today"[\s\S]*?href:\s*"https:\/\/patchesanswertoday\.com\/"[\s\S]*?external:\s*true/,
+    "footer must include the Patches Answers Today link",
+  );
+  assert.ok(
+    footerSource.includes('rel="noopener noreferrer"'),
+    "external footer links must keep safe new-tab rel values",
+  );
+  assert.ok(
+    !footerSource.includes("nofollow"),
+    "partner footer links must remain dofollow",
+  );
+
+  console.log("ok: partner footer links remain dofollow");
+}
+
 async function withMockWorkerHealth<T>(
   payload: unknown,
   callback: (url: string) => Promise<T>,
@@ -3814,6 +3839,7 @@ async function checkReleaseQueueWorkerIntegration() {
 
 async function main() {
   await checkOfficialDomainGuardrail();
+  await checkPartnerFooterLinksAreDofollow();
   await checkProductionDetailUsesRemoteFirst();
   await checkCurrentPuzzleSkipsNonPublicLiveEntry();
   await checkPublishedSummaryRoute();


### PR DESCRIPTION
## What changed

- Added sitewide footer links to ObbyList and Patches Answers Today.
- Kept both external links dofollow by omitting `nofollow` and `sponsored`.
- Added a guardrail check so the links and rel values do not regress.
- Recorded the release scope in `docs/ITERATION.md`.

## Validation

- `npm run test:pinpoint-guardrails`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
