### PR TITLE
Backfill Pinpoint #788-#802

### DIFF
--- a/data/puzzles/pinpoint-answer-788.json
+++ b/data/puzzles/pinpoint-answer-788.json
@@ -1,0 +1,214 @@
+{
+  "puzzleNumber": 788,
+  "slug": "pinpoint-answer-788",
+  "publishDate": "2026-06-27",
+  "isoDate": "2026-06-27",
+  "detailState": "fallback_full",
+  "bodyMode": "standard",
+  "pageExperienceMode": "full-analysis",
+  "questionType": "category",
+  "difficultyBand": "hard",
+  "clues": [
+    "Go (🇯🇵)",
+    "Lima (🇵🇭)",
+    "Fünf (🇩🇪)",
+    "Cinq (🇫🇷)",
+    "Cinco (this one's Spanish: 🇪🇸)"
+  ],
+  "answer": "The number “five” in different languages (Japanese, Tagalog, German, French, Spanish)",
+  "category": "The number “five” in different languages (Japanese, Tagalog, German, French, Spanish)",
+  "wordHints": {
+    "Go (🇯🇵)": "The Japanese flag narrows “Go” to the Japanese reading for the number five rather than the English command.",
+    "Lima (🇵🇭)": "“Lima” is the Tagalog word for five, and the Philippines flag identifies the intended language instead of the city.",
+    "Fünf (🇩🇪)": "“Fünf” directly names the number five in German, giving the board a clear translation pattern.",
+    "Cinq (🇫🇷)": "“Cinq” is the standard French word for five, confirming that each clue is the same number in another language.",
+    "Cinco (this one's Spanish: 🇪🇸)": "“Cinco” means five in Spanish, and the clue supplies the final language marker needed to close the set."
+  },
+  "spoilerHints": {
+    "Go (🇯🇵)": "Go (🇯🇵) should be tested as part of the number “five” in different languages (japanese, tagalog, german, french, spanish), not as a standalone reference.",
+    "Lima (🇵🇭)": "Keep Lima (🇵🇭) in mind, then see whether Cinco (this one's Spanish: 🇪🇸) supports the same answer.",
+    "Fünf (🇩🇪)": "Fünf (🇩🇪) works best after the board narrows toward the number “five” in different languages (japanese, tagalog, german, french, spanish).",
+    "Cinq (🇫🇷)": "Cinq (🇫🇷) should be tested as part of the number “five” in different languages (japanese, tagalog, german, french, spanish), not as a standalone reference.",
+    "Cinco (this one's Spanish: 🇪🇸)": "Cinco (this one's Spanish: 🇪🇸) is the clue that makes the number “five” in different languages (japanese, tagalog, german, french, spanish) concrete enough to test across the full board."
+  },
+  "articleBlocks": [
+    "The opening pair, Go (🇯🇵) and Lima (🇵🇭), leaves more than one reasonable route. Read without the rest of the board, they can suggest international place names instead of the exact connection. At that stage, none of those first impressions explains Fünf (🇩🇪), Cinq (🇫🇷), and Cinco (this one's Spanish: 🇪🇸) with the same precision. The useful move is to keep several readings open, wait for the clue that supplies a repeatable test, and then check every earlier clue against that same narrow rule.",
+    "international place names is tempting because Go and Lima can look like place or travel references before the flags are treated as language labels. That idea remains incomplete once Fünf (🇩🇪) is added and the clues need one repeatable explanation.",
+    "A second possibility is short foreign words. The clues are all foreign-language terms, but that description is too broad because every term translates to the same number. The board therefore needs a narrower rule that can account for every clue without changing direction halfway through.",
+    "Fünf (🇩🇪) is the turning clue. Its clean reading as German: fünf means five makes five expressed in five different languages concrete enough to test against the earlier entries.",
+    "Japanese: go means five, Tagalog: lima means five, German: fünf means five, French: cinq means five, Spanish: cinco means five all survive the same check. That full-board agreement rules out the broader first impressions and keeps the solution at one level of specificity.",
+    "The answer is The number “five” in different languages (Japanese, Tagalog, German, French, Spanish). More precisely, the puzzle resolves as the same number translated into five named languages, not foreign words in general, which explains why every reveal belongs in the final set."
+  ],
+  "solutionNarrative": [
+    "I began with Go (🇯🇵) and Lima (🇵🇭) and tested international place names. It was a fair first read because go and Lima can look like place or travel references before the flags are treated as language labels. I kept it provisional rather than forcing the remaining clues into it.",
+    "When Fünf (🇩🇪) appeared, I also considered short foreign words. That alternative described part of the surface, but it still did not provide one exact rule for Cinq (🇫🇷) and Cinco (this one's Spanish: 🇪🇸).",
+    "The decisive step came from Fünf (🇩🇪). Reading it as German: fünf means five gave me a precise test, so I went back through Japanese: go means five, Tagalog: lima means five, German: fünf means five, French: cinq means five and checked the same relationship each time.",
+    "After all five checks held, I could reject both early guesses. The answer was The number “five” in different languages (Japanese, Tagalog, German, French, Spanish), with the important distinction that this is the same number translated into five named languages, not foreign words in general."
+  ],
+  "lessons": [
+    {
+      "title": "Do not lock onto Go (🇯🇵) too early",
+      "body": "Go (🇯🇵) can support international place names, so wait until another clue supplies a rule that repeats across the entire board."
+    },
+    {
+      "title": "Fünf (🇩🇪) supplies the strongest test",
+      "body": "Once Fünf (🇩🇪) reads as German: fünf means five, apply that exact relationship to the earlier clues instead of relying on a broad topic match."
+    },
+    {
+      "title": "Pinpoint 788 needs five clean confirmations",
+      "body": "The solution is secure only when German: fünf means five, French: cinq means five, Spanish: cinco means five fit the same rule naturally and do not require separate exceptions."
+    }
+  ],
+  "display": {
+    "connectorSummary": "a category board focused on the",
+    "fastStrategy": "Go (🇯🇵) can support international place names, so wait until another clue supplies a rule that repeats across the entire board.",
+    "clueTableRows": [
+      {
+        "clue": "Go (🇯🇵)",
+        "examplePhrase": "Japanese: go means five",
+        "connectionExplained": "The Japanese flag narrows “Go” to the Japanese reading for the number five rather than the English command."
+      },
+      {
+        "clue": "Lima (🇵🇭)",
+        "examplePhrase": "Tagalog: lima means five",
+        "connectionExplained": "“Lima” is the Tagalog word for five, and the Philippines flag identifies the intended language instead of the city."
+      },
+      {
+        "clue": "Fünf (🇩🇪)",
+        "examplePhrase": "German: fünf means five",
+        "connectionExplained": "“Fünf” directly names the number five in German, giving the board a clear translation pattern."
+      },
+      {
+        "clue": "Cinq (🇫🇷)",
+        "examplePhrase": "French: cinq means five",
+        "connectionExplained": "“Cinq” is the standard French word for five, confirming that each clue is the same number in another language."
+      },
+      {
+        "clue": "Cinco (this one's Spanish: 🇪🇸)",
+        "examplePhrase": "Spanish: cinco means five",
+        "connectionExplained": "“Cinco” means five in Spanish, and the clue supplies the final language marker needed to close the set."
+      }
+    ]
+  },
+  "faqs": [
+    {
+      "question": "How does “Go (🇯🇵)” reveal the final category in LinkedIn Pinpoint #788?",
+      "answer": "The exact answer is The number “five” in different languages (Japanese, Tagalog, German, French, Spanish). The Japanese flag narrows “Go” to the Japanese reading for the number five rather than the English command. This reading also matches the connection used by the other four clues."
+    },
+    {
+      "question": "How do Go (🇯🇵) and Lima (🇵🇭) connect in Pinpoint #788?",
+      "answer": "Go (🇯🇵) resolves as Japanese: go means five, while Lima (🇵🇭) resolves as Tagalog: lima means five. Both support the same final answer."
+    },
+    {
+      "question": "Why is Fünf (🇩🇪) important in Pinpoint #788?",
+      "answer": "Fünf (🇩🇪) is decisive because “Fünf” directly names the number five in German, giving the board a clear translation pattern. That reading gives a precise check for the other four clues."
+    }
+  ],
+  "solvePath": {
+    "firstRead": "The opening pair, Go (🇯🇵) and Lima (🇵🇭), leaves more than one reasonable route. Read without the rest of the board, they can suggest international place names instead of the exact connection. At that stage, none of those first impressions explains Fünf (🇩🇪), Cinq (🇫🇷), and Cinco (this one's Spanish: 🇪🇸) with the same precision. The useful move is to keep several readings open, wait for the clue that supplies a repeatable test, and then check every earlier clue against that same narrow rule.",
+    "falseStarts": [
+      "international place names",
+      "short foreign words"
+    ],
+    "whyFalseStartPlausible": [
+      "Go and Lima can look like place or travel references before the flags are treated as language labels.",
+      "The clues are all foreign-language terms, but that description is too broad because every term translates to the same number."
+    ],
+    "breakingClue": "Fünf (🇩🇪)",
+    "pivot": "The decisive step came from Fünf (🇩🇪). Reading it as German: fünf means five gave me a precise test, so I went back through Japanese: go means five, Tagalog: lima means five, German: fünf means five, French: cinq means five and checked the same relationship each time.",
+    "fullBoardConfirmation": "Japanese: go means five, Tagalog: lima means five, German: fünf means five, French: cinq means five, Spanish: cinco means five all survive the same check. That full-board agreement rules out the broader first impressions and keeps the solution at one level of specificity."
+  },
+  "turningPoint": {
+    "clue": "Fünf (🇩🇪)",
+    "whyDecisive": "Fünf (🇩🇪) resolves cleanly as German: fünf means five, making five expressed in five different languages specific enough to test across all five clues.",
+    "whatChangedAfterIt": "After Fünf (🇩🇪), the earlier clues could be checked through the same precise relationship instead of two broad surface guesses."
+  },
+  "clueRows": [
+    {
+      "clue": "Go (🇯🇵)",
+      "surfaceMisread": "international place names",
+      "resolvedPhraseOrMember": "Japanese: go means five",
+      "nonObviousWhy": "The Japanese flag narrows “Go” to the Japanese reading for the number five rather than the English command.",
+      "searchableContext": "Japanese: go means five"
+    },
+    {
+      "clue": "Lima (🇵🇭)",
+      "surfaceMisread": "short foreign words",
+      "resolvedPhraseOrMember": "Tagalog: lima means five",
+      "nonObviousWhy": "“Lima” is the Tagalog word for five, and the Philippines flag identifies the intended language instead of the city.",
+      "searchableContext": "Tagalog: lima means five"
+    },
+    {
+      "clue": "Fünf (🇩🇪)",
+      "surfaceMisread": "international place names",
+      "resolvedPhraseOrMember": "German: fünf means five",
+      "nonObviousWhy": "“Fünf” directly names the number five in German, giving the board a clear translation pattern.",
+      "searchableContext": "German: fünf means five"
+    },
+    {
+      "clue": "Cinq (🇫🇷)",
+      "surfaceMisread": "short foreign words",
+      "resolvedPhraseOrMember": "French: cinq means five",
+      "nonObviousWhy": "“Cinq” is the standard French word for five, confirming that each clue is the same number in another language.",
+      "searchableContext": "French: cinq means five"
+    },
+    {
+      "clue": "Cinco (this one's Spanish: 🇪🇸)",
+      "surfaceMisread": "international place names",
+      "resolvedPhraseOrMember": "Spanish: cinco means five",
+      "nonObviousWhy": "“Cinco” means five in Spanish, and the clue supplies the final language marker needed to close the set.",
+      "searchableContext": "Spanish: cinco means five"
+    }
+  ],
+  "faqItems": [
+    {
+      "intentType": "solve_strategy",
+      "question": "How does “Go (🇯🇵)” reveal the final category in LinkedIn Pinpoint #788?",
+      "answer": "The exact answer is The number “five” in different languages (Japanese, Tagalog, German, French, Spanish). The Japanese flag narrows “Go” to the Japanese reading for the number five rather than the English command. This reading also matches the connection used by the other four clues.",
+      "tiedClue": "Go (🇯🇵)"
+    },
+    {
+      "intentType": "solve_strategy",
+      "question": "How do Go (🇯🇵) and Lima (🇵🇭) connect in Pinpoint #788?",
+      "answer": "Go (🇯🇵) resolves as Japanese: go means five, while Lima (🇵🇭) resolves as Tagalog: lima means five. Both support the same final answer.",
+      "tiedClue": "Go (🇯🇵)"
+    },
+    {
+      "intentType": "clue_background",
+      "question": "Why is Fünf (🇩🇪) important in Pinpoint #788?",
+      "answer": "Fünf (🇩🇪) is decisive because “Fünf” directly names the number five in German, giving the board a clear translation pattern. That reading gives a precise check for the other four clues.",
+      "tiedClue": "Fünf (🇩🇪)"
+    }
+  ],
+  "uniquenessSignals": {
+    "angle": "five expressed in five different languages",
+    "relatedEntities": [
+      "Japanese: go means five",
+      "Tagalog: lima means five",
+      "German: fünf means five",
+      "French: cinq means five",
+      "Spanish: cinco means five"
+    ],
+    "doNotRepeatPatterns": [
+      "five expressed in five different languages",
+      "Japanese: go means five",
+      "Tagalog: lima means five",
+      "German: fünf means five",
+      "French: cinq means five"
+    ]
+  },
+  "wrongGuessCandidates": [
+    {
+      "label": "international place names",
+      "whyPlausible": "Go and Lima can look like place or travel references before the flags are treated as language labels.",
+      "whyRejected": "Fünf (🇩🇪) and the full five-clue check point more precisely to The number “five” in different languages (Japanese, Tagalog, German, French, Spanish)."
+    },
+    {
+      "label": "short foreign words",
+      "whyPlausible": "The clues are all foreign-language terms, but that description is too broad because every term translates to the same number.",
+      "whyRejected": "Fünf (🇩🇪) and the full five-clue check point more precisely to The number “five” in different languages (Japanese, Tagalog, German, French, Spanish)."
+    }
+  ],
+  "setValidationSummary": "Japanese: go means five; Tagalog: lima means five; German: fünf means five; French: cinq means five; Spanish: cinco means five all support five expressed in five different languages, so the answer holds across every clue rather than only the opening pair.",
+  "categoryPrecisionNote": "the same number translated into five named languages, not foreign words in general"
+}

--- a/data/puzzles/pinpoint-answer-789.json
+++ b/data/puzzles/pinpoint-answer-789.json
@@ -1,0 +1,219 @@
+{
+  "puzzleNumber": 789,
+  "slug": "pinpoint-answer-789",
+  "publishDate": "2026-06-28",
+  "isoDate": "2026-06-28",
+  "detailState": "fallback_full",
+  "bodyMode": "standard",
+  "pageExperienceMode": "full-analysis",
+  "questionType": "phrase",
+  "difficultyBand": "hard",
+  "clues": [
+    "Face",
+    "Your breath",
+    "The day",
+    "Someone's skin",
+    "For a rainy day"
+  ],
+  "answer": "Words that come after “save”",
+  "category": "Words that come after “save”",
+  "wordHints": {
+    "Face": "“Save face” is the familiar expression about avoiding embarrassment or protecting dignity.",
+    "Your breath": "“Save your breath” is a common saying used when speaking would not change the outcome.",
+    "The day": "“Save the day” means rescuing a situation at the moment help is needed most.",
+    "Someone's skin": "“Save someone’s skin” is an idiom for rescuing that person from danger or serious trouble.",
+    "For a rainy day": "“Save for a rainy day” means setting resources aside for a future period of need."
+  },
+  "spoilerHints": {
+    "Face": "Try reading Face as part of a familiar phrase in words that come after “save” (in common sayings) instead of as a standalone word.",
+    "Your breath": "Your breath works better once you test a fixed phrase pattern rather than a broad topic.",
+    "The day": "Look for a natural expression that absorbs The day cleanly before locking the board.",
+    "Someone's skin": "Try reading Someone's skin as part of a familiar phrase in words that come after “save” (in common sayings) instead of as a standalone word.",
+    "For a rainy day": "For a rainy day is the clue that makes the phrase pattern in words that come after “save” (in common sayings) concrete enough to test."
+  },
+  "articleBlocks": [
+    "The opening pair, Face and Your breath, leaves more than one reasonable route. Read without the rest of the board, they can suggest things people protect instead of the exact connection. At that stage, none of those first impressions explains The day, Someone's skin, and For a rainy day with the same precision. The useful move is to keep several readings open, wait for the clue that supplies a repeatable test, and then check every earlier clue against that same narrow rule.",
+    "things people protect is tempting because Face, breath, and skin can sound like things to protect, but that does not explain the exact wording of the longer clues. That idea remains incomplete once The day is added and the clues need one repeatable explanation.",
+    "A second possibility is advice about planning ahead. The final clue suggests saving money for later, but the whole board is built from sayings that begin with the same verb. The board therefore needs a narrower rule that can account for every clue without changing direction halfway through.",
+    "The day is the turning clue. Its clean reading as save the day makes familiar sayings that begin with the verb save concrete enough to test against the earlier entries.",
+    "save face, save your breath, save the day, save someone's skin, save for a rainy day all survive the same check. That full-board agreement rules out the broader first impressions and keeps the solution at one level of specificity.",
+    "The answer is Words that come after “save”. More precisely, the puzzle resolves as one shared opening word placed before every clue to form a recognized saying, which explains why every reveal belongs in the final set."
+  ],
+  "solutionNarrative": [
+    "I began with Face and Your breath and tested things people protect. It was a fair first read because face, breath, and skin can sound like things to protect, but that does not explain the exact wording of the longer clues. I kept it provisional rather than forcing the remaining clues into it.",
+    "When The day appeared, I also considered advice about planning ahead. That alternative described part of the surface, but it still did not provide one exact rule for Someone's skin and For a rainy day.",
+    "The decisive step came from The day. Reading it as save the day gave me a precise test, so I went back through save face, save your breath, save the day, save someone's skin and checked the same relationship each time.",
+    "After all five checks held, I could reject both early guesses. The answer was Words that come after “save”, with the important distinction that this is one shared opening word placed before every clue to form a recognized saying."
+  ],
+  "lessons": [
+    {
+      "title": "Do not lock onto Face too early",
+      "body": "Face can support things people protect, so wait until another clue supplies a rule that repeats across the entire board."
+    },
+    {
+      "title": "The day supplies the strongest test",
+      "body": "Once The day reads as save the day, apply that exact relationship to the earlier clues instead of relying on a broad topic match."
+    },
+    {
+      "title": "Pinpoint 789 needs five clean confirmations",
+      "body": "The solution is secure only when save the day, save someone's skin, save for a rainy day fit the same rule naturally and do not require separate exceptions."
+    }
+  ],
+  "display": {
+    "connectorSummary": "familiar phrases and everyday terms built with one shared opening word",
+    "fastStrategy": "Face can support things people protect, so wait until another clue supplies a rule that repeats across the entire board.",
+    "clueTableRows": [
+      {
+        "clue": "Face",
+        "examplePhrase": "save face",
+        "connectionExplained": "“Save face” is the familiar expression about avoiding embarrassment or protecting dignity."
+      },
+      {
+        "clue": "Your breath",
+        "examplePhrase": "save your breath",
+        "connectionExplained": "“Save your breath” is a common saying used when speaking would not change the outcome."
+      },
+      {
+        "clue": "The day",
+        "examplePhrase": "save the day",
+        "connectionExplained": "“Save the day” means rescuing a situation at the moment help is needed most."
+      },
+      {
+        "clue": "Someone's skin",
+        "examplePhrase": "save someone's skin",
+        "connectionExplained": "“Save someone’s skin” is an idiom for rescuing that person from danger or serious trouble."
+      },
+      {
+        "clue": "For a rainy day",
+        "examplePhrase": "save for a rainy day",
+        "connectionExplained": "“Save for a rainy day” means setting resources aside for a future period of need."
+      }
+    ]
+  },
+  "faqs": [
+    {
+      "question": "How does “Face” reveal the final category in LinkedIn Pinpoint #789?",
+      "answer": "The exact answer is Words that come after “save”. “Save face” is the familiar expression about avoiding embarrassment or protecting dignity. This reading also matches the connection used by the other four clues."
+    },
+    {
+      "question": "How do Face and Your breath connect in Pinpoint #789?",
+      "answer": "Face resolves as save face, while Your breath resolves as save your breath. Both support the same final answer."
+    },
+    {
+      "question": "Why is The day important in Pinpoint #789?",
+      "answer": "The day is decisive because “Save the day” means rescuing a situation at the moment help is needed most. That reading gives a precise check for the other four clues."
+    }
+  ],
+  "solvePath": {
+    "firstRead": "The opening pair, Face and Your breath, leaves more than one reasonable route. Read without the rest of the board, they can suggest things people protect instead of the exact connection. At that stage, none of those first impressions explains The day, Someone's skin, and For a rainy day with the same precision. The useful move is to keep several readings open, wait for the clue that supplies a repeatable test, and then check every earlier clue against that same narrow rule.",
+    "falseStarts": [
+      "things people protect",
+      "advice about planning ahead"
+    ],
+    "whyFalseStartPlausible": [
+      "Face, breath, and skin can sound like things to protect, but that does not explain the exact wording of the longer clues.",
+      "The final clue suggests saving money for later, but the whole board is built from sayings that begin with the same verb."
+    ],
+    "breakingClue": "The day",
+    "pivot": "The decisive step came from The day. Reading it as save the day gave me a precise test, so I went back through save face, save your breath, save the day, save someone's skin and checked the same relationship each time.",
+    "fullBoardConfirmation": "save face, save your breath, save the day, save someone's skin, save for a rainy day all survive the same check. That full-board agreement rules out the broader first impressions and keeps the solution at one level of specificity."
+  },
+  "turningPoint": {
+    "clue": "The day",
+    "whyDecisive": "The day resolves cleanly as save the day, making familiar sayings that begin with the verb save specific enough to test across all five clues.",
+    "whatChangedAfterIt": "After The day, the earlier clues could be checked through the same precise relationship instead of two broad surface guesses."
+  },
+  "clueRows": [
+    {
+      "clue": "Face",
+      "surfaceMisread": "things people protect",
+      "resolvedPhraseOrMember": "save face",
+      "nonObviousWhy": "“Save face” is the familiar expression about avoiding embarrassment or protecting dignity.",
+      "searchableContext": "save face",
+      "phraseExample": "save face"
+    },
+    {
+      "clue": "Your breath",
+      "surfaceMisread": "advice about planning ahead",
+      "resolvedPhraseOrMember": "save your breath",
+      "nonObviousWhy": "“Save your breath” is a common saying used when speaking would not change the outcome.",
+      "searchableContext": "save your breath",
+      "phraseExample": "save your breath"
+    },
+    {
+      "clue": "The day",
+      "surfaceMisread": "things people protect",
+      "resolvedPhraseOrMember": "save the day",
+      "nonObviousWhy": "“Save the day” means rescuing a situation at the moment help is needed most.",
+      "searchableContext": "save the day",
+      "phraseExample": "save the day"
+    },
+    {
+      "clue": "Someone's skin",
+      "surfaceMisread": "advice about planning ahead",
+      "resolvedPhraseOrMember": "save someone's skin",
+      "nonObviousWhy": "“Save someone’s skin” is an idiom for rescuing that person from danger or serious trouble.",
+      "searchableContext": "save someone's skin",
+      "phraseExample": "save someone's skin"
+    },
+    {
+      "clue": "For a rainy day",
+      "surfaceMisread": "things people protect",
+      "resolvedPhraseOrMember": "save for a rainy day",
+      "nonObviousWhy": "“Save for a rainy day” means setting resources aside for a future period of need.",
+      "searchableContext": "save for a rainy day",
+      "phraseExample": "save for a rainy day"
+    }
+  ],
+  "faqItems": [
+    {
+      "intentType": "solve_strategy",
+      "question": "How does “Face” reveal the final category in LinkedIn Pinpoint #789?",
+      "answer": "The exact answer is Words that come after “save”. “Save face” is the familiar expression about avoiding embarrassment or protecting dignity. This reading also matches the connection used by the other four clues.",
+      "tiedClue": "Face"
+    },
+    {
+      "intentType": "solve_strategy",
+      "question": "How do Face and Your breath connect in Pinpoint #789?",
+      "answer": "Face resolves as save face, while Your breath resolves as save your breath. Both support the same final answer.",
+      "tiedClue": "Face"
+    },
+    {
+      "intentType": "clue_background",
+      "question": "Why is The day important in Pinpoint #789?",
+      "answer": "The day is decisive because “Save the day” means rescuing a situation at the moment help is needed most. That reading gives a precise check for the other four clues.",
+      "tiedClue": "The day"
+    }
+  ],
+  "uniquenessSignals": {
+    "angle": "familiar sayings that begin with the verb save",
+    "relatedEntities": [
+      "save face",
+      "save your breath",
+      "save the day",
+      "save someone's skin",
+      "save for a rainy day"
+    ],
+    "doNotRepeatPatterns": [
+      "familiar sayings that begin with the verb save",
+      "save face",
+      "save your breath",
+      "save the day",
+      "save someone's skin"
+    ]
+  },
+  "wrongGuessCandidates": [
+    {
+      "label": "things people protect",
+      "whyPlausible": "Face, breath, and skin can sound like things to protect, but that does not explain the exact wording of the longer clues.",
+      "whyRejected": "The day and the full five-clue check point more precisely to Words that come after “save”."
+    },
+    {
+      "label": "advice about planning ahead",
+      "whyPlausible": "The final clue suggests saving money for later, but the whole board is built from sayings that begin with the same verb.",
+      "whyRejected": "The day and the full five-clue check point more precisely to Words that come after “save”."
+    }
+  ],
+  "setValidationSummary": "save face; save your breath; save the day; save someone's skin; save for a rainy day all support familiar sayings that begin with the verb save, so the answer holds across every clue rather than only the opening pair.",
+  "categoryPrecisionNote": "one shared opening word placed before every clue to form a recognized saying"
+}

--- a/data/puzzles/pinpoint-answer-790.json
+++ b/data/puzzles/pinpoint-answer-790.json
@@ -1,0 +1,214 @@
+{
+  "puzzleNumber": 790,
+  "slug": "pinpoint-answer-790",
+  "publishDate": "2026-06-29",
+  "isoDate": "2026-06-29",
+  "detailState": "fallback_full",
+  "bodyMode": "standard",
+  "pageExperienceMode": "full-analysis",
+  "questionType": "category",
+  "difficultyBand": "hard",
+  "clues": [
+    "Sink",
+    "Pan",
+    "Whisk",
+    "Fridge",
+    "Oven"
+  ],
+  "answer": "Things found in a kitchen",
+  "category": "Things found in a kitchen",
+  "wordHints": {
+    "Sink": "A sink is a fixed kitchen fixture used for water, rinsing ingredients, and washing dishes.",
+    "Pan": "A pan is standard cookware used on a stovetop for frying, sautéing, or heating food.",
+    "Whisk": "A whisk is a handheld kitchen tool for mixing ingredients and adding air to a mixture.",
+    "Fridge": "A fridge keeps food and drinks cold and is one of the main appliances in a kitchen.",
+    "Oven": "An oven is the enclosed kitchen appliance used for baking, roasting, and heating food."
+  },
+  "spoilerHints": {
+    "Sink": "Sink should be tested as part of things found in a kitchen, not as a standalone reference.",
+    "Pan": "Keep Pan in mind, then see whether Fridge supports the same answer.",
+    "Whisk": "Whisk works best after the board narrows toward things found in a kitchen.",
+    "Fridge": "Fridge is the clue that makes things found in a kitchen concrete enough to test across the full board.",
+    "Oven": "Keep Oven in mind, then see whether Fridge supports the same answer."
+  },
+  "articleBlocks": [
+    "The opening pair, Sink and Pan, leaves more than one reasonable route. Read without the rest of the board, they can suggest things used while cooking instead of the exact connection. At that stage, none of those first impressions explains Whisk, Fridge, and Oven with the same precision. The useful move is to keep several readings open, wait for the clue that supplies a repeatable test, and then check every earlier clue against that same narrow rule.",
+    "things used while cooking is tempting because Pan, whisk, and oven support a cooking-only guess, but a sink and fridge broaden the set beyond active cooking tools. That idea remains incomplete once Whisk is added and the clues need one repeatable explanation.",
+    "A second possibility is common household equipment. Every clue can appear somewhere in a home, but the kitchen is the one room that naturally contains all five together. The board therefore needs a narrower rule that can account for every clue without changing direction halfway through.",
+    "Fridge is the turning clue. Its clean reading as refrigerator makes fixtures, cookware, tools, and appliances found together in a kitchen concrete enough to test against the earlier entries.",
+    "kitchen sink, cooking pan, kitchen whisk, refrigerator, kitchen oven all survive the same check. That full-board agreement rules out the broader first impressions and keeps the solution at one level of specificity.",
+    "The answer is Things found in a kitchen. More precisely, the puzzle resolves as objects normally located in a kitchen rather than household equipment in general, which explains why every reveal belongs in the final set."
+  ],
+  "solutionNarrative": [
+    "I began with Sink and Pan and tested things used while cooking. It was a fair first read because pan, whisk, and oven support a cooking-only guess, but a sink and fridge broaden the set beyond active cooking tools. I kept it provisional rather than forcing the remaining clues into it.",
+    "When Whisk appeared, I also considered common household equipment. That alternative described part of the surface, but it still did not provide one exact rule for Fridge and Oven.",
+    "The decisive step came from Fridge. Reading it as refrigerator gave me a precise test, so I went back through kitchen sink, cooking pan, kitchen whisk, refrigerator and checked the same relationship each time.",
+    "After all five checks held, I could reject both early guesses. The answer was Things found in a kitchen, with the important distinction that this is objects normally located in a kitchen rather than household equipment in general."
+  ],
+  "lessons": [
+    {
+      "title": "Do not lock onto Sink too early",
+      "body": "Sink can support things used while cooking, so wait until another clue supplies a rule that repeats across the entire board."
+    },
+    {
+      "title": "Fridge supplies the strongest test",
+      "body": "Once Fridge reads as refrigerator, apply that exact relationship to the earlier clues instead of relying on a broad topic match."
+    },
+    {
+      "title": "Pinpoint 790 needs five clean confirmations",
+      "body": "The solution is secure only when kitchen whisk, refrigerator, kitchen oven fit the same rule naturally and do not require separate exceptions."
+    }
+  ],
+  "display": {
+    "connectorSummary": "a category board focused on things",
+    "fastStrategy": "Sink can support things used while cooking, so wait until another clue supplies a rule that repeats across the entire board.",
+    "clueTableRows": [
+      {
+        "clue": "Sink",
+        "examplePhrase": "kitchen sink",
+        "connectionExplained": "A sink is a fixed kitchen fixture used for water, rinsing ingredients, and washing dishes."
+      },
+      {
+        "clue": "Pan",
+        "examplePhrase": "cooking pan",
+        "connectionExplained": "A pan is standard cookware used on a stovetop for frying, sautéing, or heating food."
+      },
+      {
+        "clue": "Whisk",
+        "examplePhrase": "kitchen whisk",
+        "connectionExplained": "A whisk is a handheld kitchen tool for mixing ingredients and adding air to a mixture."
+      },
+      {
+        "clue": "Fridge",
+        "examplePhrase": "refrigerator",
+        "connectionExplained": "A fridge keeps food and drinks cold and is one of the main appliances in a kitchen."
+      },
+      {
+        "clue": "Oven",
+        "examplePhrase": "kitchen oven",
+        "connectionExplained": "An oven is the enclosed kitchen appliance used for baking, roasting, and heating food."
+      }
+    ]
+  },
+  "faqs": [
+    {
+      "question": "How does “Sink” reveal the final category in LinkedIn Pinpoint #790?",
+      "answer": "The exact answer is Things found in a kitchen. A sink is a fixed kitchen fixture used for water, rinsing ingredients, and washing dishes. This reading also matches the connection used by the other four clues."
+    },
+    {
+      "question": "How do Sink and Pan connect in Pinpoint #790?",
+      "answer": "Sink resolves as kitchen sink, while Pan resolves as cooking pan. Both support the same final answer."
+    },
+    {
+      "question": "Why is Fridge important in Pinpoint #790?",
+      "answer": "Fridge is decisive because A fridge keeps food and drinks cold and is one of the main appliances in a kitchen. That reading gives a precise check for the other four clues."
+    }
+  ],
+  "solvePath": {
+    "firstRead": "The opening pair, Sink and Pan, leaves more than one reasonable route. Read without the rest of the board, they can suggest things used while cooking instead of the exact connection. At that stage, none of those first impressions explains Whisk, Fridge, and Oven with the same precision. The useful move is to keep several readings open, wait for the clue that supplies a repeatable test, and then check every earlier clue against that same narrow rule.",
+    "falseStarts": [
+      "things used while cooking",
+      "common household equipment"
+    ],
+    "whyFalseStartPlausible": [
+      "Pan, whisk, and oven support a cooking-only guess, but a sink and fridge broaden the set beyond active cooking tools.",
+      "Every clue can appear somewhere in a home, but the kitchen is the one room that naturally contains all five together."
+    ],
+    "breakingClue": "Fridge",
+    "pivot": "The decisive step came from Fridge. Reading it as refrigerator gave me a precise test, so I went back through kitchen sink, cooking pan, kitchen whisk, refrigerator and checked the same relationship each time.",
+    "fullBoardConfirmation": "kitchen sink, cooking pan, kitchen whisk, refrigerator, kitchen oven all survive the same check. That full-board agreement rules out the broader first impressions and keeps the solution at one level of specificity."
+  },
+  "turningPoint": {
+    "clue": "Fridge",
+    "whyDecisive": "Fridge resolves cleanly as refrigerator, making fixtures, cookware, tools, and appliances found together in a kitchen specific enough to test across all five clues.",
+    "whatChangedAfterIt": "After Fridge, the earlier clues could be checked through the same precise relationship instead of two broad surface guesses."
+  },
+  "clueRows": [
+    {
+      "clue": "Sink",
+      "surfaceMisread": "things used while cooking",
+      "resolvedPhraseOrMember": "kitchen sink",
+      "nonObviousWhy": "A sink is a fixed kitchen fixture used for water, rinsing ingredients, and washing dishes.",
+      "searchableContext": "kitchen sink"
+    },
+    {
+      "clue": "Pan",
+      "surfaceMisread": "common household equipment",
+      "resolvedPhraseOrMember": "cooking pan",
+      "nonObviousWhy": "A pan is standard cookware used on a stovetop for frying, sautéing, or heating food.",
+      "searchableContext": "cooking pan"
+    },
+    {
+      "clue": "Whisk",
+      "surfaceMisread": "things used while cooking",
+      "resolvedPhraseOrMember": "kitchen whisk",
+      "nonObviousWhy": "A whisk is a handheld kitchen tool for mixing ingredients and adding air to a mixture.",
+      "searchableContext": "kitchen whisk"
+    },
+    {
+      "clue": "Fridge",
+      "surfaceMisread": "common household equipment",
+      "resolvedPhraseOrMember": "refrigerator",
+      "nonObviousWhy": "A fridge keeps food and drinks cold and is one of the main appliances in a kitchen.",
+      "searchableContext": "refrigerator"
+    },
+    {
+      "clue": "Oven",
+      "surfaceMisread": "things used while cooking",
+      "resolvedPhraseOrMember": "kitchen oven",
+      "nonObviousWhy": "An oven is the enclosed kitchen appliance used for baking, roasting, and heating food.",
+      "searchableContext": "kitchen oven"
+    }
+  ],
+  "faqItems": [
+    {
+      "intentType": "solve_strategy",
+      "question": "How does “Sink” reveal the final category in LinkedIn Pinpoint #790?",
+      "answer": "The exact answer is Things found in a kitchen. A sink is a fixed kitchen fixture used for water, rinsing ingredients, and washing dishes. This reading also matches the connection used by the other four clues.",
+      "tiedClue": "Sink"
+    },
+    {
+      "intentType": "solve_strategy",
+      "question": "How do Sink and Pan connect in Pinpoint #790?",
+      "answer": "Sink resolves as kitchen sink, while Pan resolves as cooking pan. Both support the same final answer.",
+      "tiedClue": "Sink"
+    },
+    {
+      "intentType": "clue_background",
+      "question": "Why is Fridge important in Pinpoint #790?",
+      "answer": "Fridge is decisive because A fridge keeps food and drinks cold and is one of the main appliances in a kitchen. That reading gives a precise check for the other four clues.",
+      "tiedClue": "Fridge"
+    }
+  ],
+  "uniquenessSignals": {
+    "angle": "fixtures, cookware, tools, and appliances found together in a kitchen",
+    "relatedEntities": [
+      "kitchen sink",
+      "cooking pan",
+      "kitchen whisk",
+      "refrigerator",
+      "kitchen oven"
+    ],
+    "doNotRepeatPatterns": [
+      "fixtures, cookware, tools, and appliances found together in a kitchen",
+      "kitchen sink",
+      "cooking pan",
+      "kitchen whisk",
+      "refrigerator"
+    ]
+  },
+  "wrongGuessCandidates": [
+    {
+      "label": "things used while cooking",
+      "whyPlausible": "Pan, whisk, and oven support a cooking-only guess, but a sink and fridge broaden the set beyond active cooking tools.",
+      "whyRejected": "Fridge and the full five-clue check point more precisely to Things found in a kitchen."
+    },
+    {
+      "label": "common household equipment",
+      "whyPlausible": "Every clue can appear somewhere in a home, but the kitchen is the one room that naturally contains all five together.",
+      "whyRejected": "Fridge and the full five-clue check point more precisely to Things found in a kitchen."
+    }
+  ],
+  "setValidationSummary": "kitchen sink; cooking pan; kitchen whisk; refrigerator; kitchen oven all support fixtures, cookware, tools, and appliances found together in a kitchen, so the answer holds across every clue rather than only the opening pair.",
+  "categoryPrecisionNote": "objects normally located in a kitchen rather than household equipment in general"
+}

--- a/data/puzzles/pinpoint-answer-791.json
+++ b/data/puzzles/pinpoint-answer-791.json
@@ -1,0 +1,214 @@
+{
+  "puzzleNumber": 791,
+  "slug": "pinpoint-answer-791",
+  "publishDate": "2026-06-30",
+  "isoDate": "2026-06-30",
+  "detailState": "fallback_full",
+  "bodyMode": "standard",
+  "pageExperienceMode": "full-analysis",
+  "questionType": "category",
+  "difficultyBand": "hard",
+  "clues": [
+    "Lantern",
+    "Sleeping bag",
+    "Portable stove",
+    "Water filter",
+    "Tent"
+  ],
+  "answer": "Things brought on a camping trip",
+  "category": "Things brought on a camping trip",
+  "wordHints": {
+    "Lantern": "A lantern provides portable light around a campsite after daylight fades.",
+    "Sleeping bag": "A sleeping bag supplies insulated bedding that can be packed and carried outdoors.",
+    "Portable stove": "A portable stove lets campers heat food or water without relying on a full kitchen.",
+    "Water filter": "A water filter helps make collected outdoor water safer to drink during a trip.",
+    "Tent": "A tent provides the portable shelter that defines a conventional camping setup."
+  },
+  "spoilerHints": {
+    "Lantern": "Lantern should be tested as part of things brought on a camping trip, not as a standalone reference.",
+    "Sleeping bag": "Keep Sleeping bag in mind, then see whether Portable stove supports the same answer.",
+    "Portable stove": "Portable stove is the clue that makes things brought on a camping trip concrete enough to test across the full board.",
+    "Water filter": "Water filter should be tested as part of things brought on a camping trip, not as a standalone reference.",
+    "Tent": "Keep Tent in mind, then see whether Portable stove supports the same answer."
+  },
+  "articleBlocks": [
+    "The opening pair, Lantern and Sleeping bag, leaves more than one reasonable route. Read without the rest of the board, they can suggest emergency preparedness supplies instead of the exact connection. At that stage, none of those first impressions explains Portable stove, Water filter, and Tent with the same precision. The useful move is to keep several readings open, wait for the clue that supplies a repeatable test, and then check every earlier clue against that same narrow rule.",
+    "emergency preparedness supplies is tempting because Several clues belong in an emergency kit, but a tent and sleeping bag point more directly to an overnight camping trip. That idea remains incomplete once Portable stove is added and the clues need one repeatable explanation.",
+    "A second possibility is outdoor survival equipment. Water filters and stoves can support a survival theme, yet the full set is ordinary camping gear rather than specialist rescue equipment. The board therefore needs a narrower rule that can account for every clue without changing direction halfway through.",
+    "Tent is the turning clue. Its clean reading as camping tent makes portable gear commonly packed for an overnight camping trip concrete enough to test against the earlier entries.",
+    "camp lantern, camping sleeping bag, portable camp stove, camping water filter, camping tent all survive the same check. That full-board agreement rules out the broader first impressions and keeps the solution at one level of specificity.",
+    "The answer is Things brought on a camping trip. More precisely, the puzzle resolves as items deliberately brought camping, not outdoor equipment in any setting, which explains why every reveal belongs in the final set."
+  ],
+  "solutionNarrative": [
+    "I began with Lantern and Sleeping bag and tested emergency preparedness supplies. It was a fair first read because several clues belong in an emergency kit, but a tent and sleeping bag point more directly to an overnight camping trip. I kept it provisional rather than forcing the remaining clues into it.",
+    "When Portable stove appeared, I also considered outdoor survival equipment. That alternative described part of the surface, but it still did not provide one exact rule for Water filter and Tent.",
+    "The decisive step came from Tent. Reading it as camping tent gave me a precise test, so I went back through camp lantern, camping sleeping bag, portable camp stove, camping water filter and checked the same relationship each time.",
+    "After all five checks held, I could reject both early guesses. The answer was Things brought on a camping trip, with the important distinction that this is items deliberately brought camping, not outdoor equipment in any setting."
+  ],
+  "lessons": [
+    {
+      "title": "Do not lock onto Lantern too early",
+      "body": "Lantern can support emergency preparedness supplies, so wait until another clue supplies a rule that repeats across the entire board."
+    },
+    {
+      "title": "Tent supplies the strongest test",
+      "body": "Once Tent reads as camping tent, apply that exact relationship to the earlier clues instead of relying on a broad topic match."
+    },
+    {
+      "title": "Pinpoint 791 needs five clean confirmations",
+      "body": "The solution is secure only when portable camp stove, camping water filter, camping tent fit the same rule naturally and do not require separate exceptions."
+    }
+  ],
+  "display": {
+    "connectorSummary": "a category board focused on things",
+    "fastStrategy": "Lantern can support emergency preparedness supplies, so wait until another clue supplies a rule that repeats across the entire board.",
+    "clueTableRows": [
+      {
+        "clue": "Lantern",
+        "examplePhrase": "camp lantern",
+        "connectionExplained": "A lantern provides portable light around a campsite after daylight fades."
+      },
+      {
+        "clue": "Sleeping bag",
+        "examplePhrase": "camping sleeping bag",
+        "connectionExplained": "A sleeping bag supplies insulated bedding that can be packed and carried outdoors."
+      },
+      {
+        "clue": "Portable stove",
+        "examplePhrase": "portable camp stove",
+        "connectionExplained": "A portable stove lets campers heat food or water without relying on a full kitchen."
+      },
+      {
+        "clue": "Water filter",
+        "examplePhrase": "camping water filter",
+        "connectionExplained": "A water filter helps make collected outdoor water safer to drink during a trip."
+      },
+      {
+        "clue": "Tent",
+        "examplePhrase": "camping tent",
+        "connectionExplained": "A tent provides the portable shelter that defines a conventional camping setup."
+      }
+    ]
+  },
+  "faqs": [
+    {
+      "question": "How does “Lantern” reveal the final category in LinkedIn Pinpoint #791?",
+      "answer": "The exact answer is Things brought on a camping trip. A lantern provides portable light around a campsite after daylight fades. This reading also matches the connection used by the other four clues."
+    },
+    {
+      "question": "How do Lantern and Sleeping bag connect in Pinpoint #791?",
+      "answer": "Lantern resolves as camp lantern, while Sleeping bag resolves as camping sleeping bag. Both support the same final answer."
+    },
+    {
+      "question": "Why is Tent important in Pinpoint #791?",
+      "answer": "Tent is decisive because A tent provides the portable shelter that defines a conventional camping setup. That reading gives a precise check for the other four clues."
+    }
+  ],
+  "solvePath": {
+    "firstRead": "The opening pair, Lantern and Sleeping bag, leaves more than one reasonable route. Read without the rest of the board, they can suggest emergency preparedness supplies instead of the exact connection. At that stage, none of those first impressions explains Portable stove, Water filter, and Tent with the same precision. The useful move is to keep several readings open, wait for the clue that supplies a repeatable test, and then check every earlier clue against that same narrow rule.",
+    "falseStarts": [
+      "emergency preparedness supplies",
+      "outdoor survival equipment"
+    ],
+    "whyFalseStartPlausible": [
+      "Several clues belong in an emergency kit, but a tent and sleeping bag point more directly to an overnight camping trip.",
+      "Water filters and stoves can support a survival theme, yet the full set is ordinary camping gear rather than specialist rescue equipment."
+    ],
+    "breakingClue": "Tent",
+    "pivot": "The decisive step came from Tent. Reading it as camping tent gave me a precise test, so I went back through camp lantern, camping sleeping bag, portable camp stove, camping water filter and checked the same relationship each time.",
+    "fullBoardConfirmation": "camp lantern, camping sleeping bag, portable camp stove, camping water filter, camping tent all survive the same check. That full-board agreement rules out the broader first impressions and keeps the solution at one level of specificity."
+  },
+  "turningPoint": {
+    "clue": "Tent",
+    "whyDecisive": "Tent resolves cleanly as camping tent, making portable gear commonly packed for an overnight camping trip specific enough to test across all five clues.",
+    "whatChangedAfterIt": "After Tent, the earlier clues could be checked through the same precise relationship instead of two broad surface guesses."
+  },
+  "clueRows": [
+    {
+      "clue": "Lantern",
+      "surfaceMisread": "emergency preparedness supplies",
+      "resolvedPhraseOrMember": "camp lantern",
+      "nonObviousWhy": "A lantern provides portable light around a campsite after daylight fades.",
+      "searchableContext": "camp lantern"
+    },
+    {
+      "clue": "Sleeping bag",
+      "surfaceMisread": "outdoor survival equipment",
+      "resolvedPhraseOrMember": "camping sleeping bag",
+      "nonObviousWhy": "A sleeping bag supplies insulated bedding that can be packed and carried outdoors.",
+      "searchableContext": "camping sleeping bag"
+    },
+    {
+      "clue": "Portable stove",
+      "surfaceMisread": "emergency preparedness supplies",
+      "resolvedPhraseOrMember": "portable camp stove",
+      "nonObviousWhy": "A portable stove lets campers heat food or water without relying on a full kitchen.",
+      "searchableContext": "portable camp stove"
+    },
+    {
+      "clue": "Water filter",
+      "surfaceMisread": "outdoor survival equipment",
+      "resolvedPhraseOrMember": "camping water filter",
+      "nonObviousWhy": "A water filter helps make collected outdoor water safer to drink during a trip.",
+      "searchableContext": "camping water filter"
+    },
+    {
+      "clue": "Tent",
+      "surfaceMisread": "emergency preparedness supplies",
+      "resolvedPhraseOrMember": "camping tent",
+      "nonObviousWhy": "A tent provides the portable shelter that defines a conventional camping setup.",
+      "searchableContext": "camping tent"
+    }
+  ],
+  "faqItems": [
+    {
+      "intentType": "solve_strategy",
+      "question": "How does “Lantern” reveal the final category in LinkedIn Pinpoint #791?",
+      "answer": "The exact answer is Things brought on a camping trip. A lantern provides portable light around a campsite after daylight fades. This reading also matches the connection used by the other four clues.",
+      "tiedClue": "Lantern"
+    },
+    {
+      "intentType": "solve_strategy",
+      "question": "How do Lantern and Sleeping bag connect in Pinpoint #791?",
+      "answer": "Lantern resolves as camp lantern, while Sleeping bag resolves as camping sleeping bag. Both support the same final answer.",
+      "tiedClue": "Lantern"
+    },
+    {
+      "intentType": "clue_background",
+      "question": "Why is Tent important in Pinpoint #791?",
+      "answer": "Tent is decisive because A tent provides the portable shelter that defines a conventional camping setup. That reading gives a precise check for the other four clues.",
+      "tiedClue": "Tent"
+    }
+  ],
+  "uniquenessSignals": {
+    "angle": "portable gear commonly packed for an overnight camping trip",
+    "relatedEntities": [
+      "camp lantern",
+      "camping sleeping bag",
+      "portable camp stove",
+      "camping water filter",
+      "camping tent"
+    ],
+    "doNotRepeatPatterns": [
+      "portable gear commonly packed for an overnight camping trip",
+      "camp lantern",
+      "camping sleeping bag",
+      "portable camp stove",
+      "camping water filter"
+    ]
+  },
+  "wrongGuessCandidates": [
+    {
+      "label": "emergency preparedness supplies",
+      "whyPlausible": "Several clues belong in an emergency kit, but a tent and sleeping bag point more directly to an overnight camping trip.",
+      "whyRejected": "Tent and the full five-clue check point more precisely to Things brought on a camping trip."
+    },
+    {
+      "label": "outdoor survival equipment",
+      "whyPlausible": "Water filters and stoves can support a survival theme, yet the full set is ordinary camping gear rather than specialist rescue equipment.",
+      "whyRejected": "Tent and the full five-clue check point more precisely to Things brought on a camping trip."
+    }
+  ],
+  "setValidationSummary": "camp lantern; camping sleeping bag; portable camp stove; camping water filter; camping tent all support portable gear commonly packed for an overnight camping trip, so the answer holds across every clue rather than only the opening pair.",
+  "categoryPrecisionNote": "items deliberately brought camping, not outdoor equipment in any setting"
+}

--- a/data/puzzles/pinpoint-answer-792.json
+++ b/data/puzzles/pinpoint-answer-792.json
@@ -1,0 +1,214 @@
+{
+  "puzzleNumber": 792,
+  "slug": "pinpoint-answer-792",
+  "publishDate": "2026-07-01",
+  "isoDate": "2026-07-01",
+  "detailState": "fallback_full",
+  "bodyMode": "standard",
+  "pageExperienceMode": "full-analysis",
+  "questionType": "category",
+  "difficultyBand": "hard",
+  "clues": [
+    "Pronunciation",
+    "Etymology",
+    "Part of speech",
+    "Example sentence",
+    "Definition"
+  ],
+  "answer": "Parts of a dictionary entry",
+  "category": "Parts of a dictionary entry",
+  "wordHints": {
+    "Pronunciation": "A pronunciation guide shows readers how the headword is spoken, often with phonetic symbols.",
+    "Etymology": "Etymology explains the history and linguistic origin of the word listed in the entry.",
+    "Part of speech": "The part-of-speech label identifies whether the headword functions as a noun, verb, adjective, or another class.",
+    "Example sentence": "An example sentence demonstrates how the word is used naturally in context.",
+    "Definition": "The definition states the meaning of the headword and is the central part of the entry."
+  },
+  "spoilerHints": {
+    "Pronunciation": "Pronunciation should be tested as part of parts of a dictionary entry, not as a standalone reference.",
+    "Etymology": "Keep Etymology in mind, then see whether Part of speech supports the same answer.",
+    "Part of speech": "Part of speech is the clue that makes parts of a dictionary entry concrete enough to test across the full board.",
+    "Example sentence": "Example sentence should be tested as part of parts of a dictionary entry, not as a standalone reference.",
+    "Definition": "Keep Definition in mind, then see whether Part of speech supports the same answer."
+  },
+  "articleBlocks": [
+    "The opening pair, Pronunciation and Etymology, leaves more than one reasonable route. Read without the rest of the board, they can suggest parts of a language lesson instead of the exact connection. At that stage, none of those first impressions explains Part of speech, Example sentence, and Definition with the same precision. The useful move is to keep several readings open, wait for the clue that supplies a repeatable test, and then check every earlier clue against that same narrow rule.",
+    "parts of a language lesson is tempting because All five can appear in language teaching, but their standard packaged form is specifically a dictionary entry. That idea remains incomplete once Part of speech is added and the clues need one repeatable explanation.",
+    "A second possibility is information about a word. The clues are kinds of word information, yet “part of speech” and “definition” point to the structured entry format. The board therefore needs a narrower rule that can account for every clue without changing direction halfway through.",
+    "Part of speech is the turning clue. Its clean reading as part-of-speech label makes standard fields presented together for one headword in a dictionary concrete enough to test against the earlier entries.",
+    "pronunciation guide, word etymology, part-of-speech label, usage example sentence, word definition all survive the same check. That full-board agreement rules out the broader first impressions and keeps the solution at one level of specificity.",
+    "The answer is Parts of a dictionary entry. More precisely, the puzzle resolves as named fields inside a dictionary entry rather than language information generally, which explains why every reveal belongs in the final set."
+  ],
+  "solutionNarrative": [
+    "I began with Pronunciation and Etymology and tested parts of a language lesson. It was a fair first read because all five can appear in language teaching, but their standard packaged form is specifically a dictionary entry. I kept it provisional rather than forcing the remaining clues into it.",
+    "When Part of speech appeared, I also considered information about a word. That alternative described part of the surface, but it still did not provide one exact rule for Example sentence and Definition.",
+    "The decisive step came from Part of speech. Reading it as part-of-speech label gave me a precise test, so I went back through pronunciation guide, word etymology, part-of-speech label, usage example sentence and checked the same relationship each time.",
+    "After all five checks held, I could reject both early guesses. The answer was Parts of a dictionary entry, with the important distinction that this is named fields inside a dictionary entry rather than language information generally."
+  ],
+  "lessons": [
+    {
+      "title": "Do not lock onto Pronunciation too early",
+      "body": "Pronunciation can support parts of a language lesson, so wait until another clue supplies a rule that repeats across the entire board."
+    },
+    {
+      "title": "Part of speech supplies the strongest test",
+      "body": "Once Part of speech reads as part-of-speech label, apply that exact relationship to the earlier clues instead of relying on a broad topic match."
+    },
+    {
+      "title": "Pinpoint 792 needs five clean confirmations",
+      "body": "The solution is secure only when part-of-speech label, usage example sentence, word definition fit the same rule naturally and do not require separate exceptions."
+    }
+  ],
+  "display": {
+    "connectorSummary": "a category board focused on parts",
+    "fastStrategy": "Pronunciation can support parts of a language lesson, so wait until another clue supplies a rule that repeats across the entire board.",
+    "clueTableRows": [
+      {
+        "clue": "Pronunciation",
+        "examplePhrase": "pronunciation guide",
+        "connectionExplained": "A pronunciation guide shows readers how the headword is spoken, often with phonetic symbols."
+      },
+      {
+        "clue": "Etymology",
+        "examplePhrase": "word etymology",
+        "connectionExplained": "Etymology explains the history and linguistic origin of the word listed in the entry."
+      },
+      {
+        "clue": "Part of speech",
+        "examplePhrase": "part-of-speech label",
+        "connectionExplained": "The part-of-speech label identifies whether the headword functions as a noun, verb, adjective, or another class."
+      },
+      {
+        "clue": "Example sentence",
+        "examplePhrase": "usage example sentence",
+        "connectionExplained": "An example sentence demonstrates how the word is used naturally in context."
+      },
+      {
+        "clue": "Definition",
+        "examplePhrase": "word definition",
+        "connectionExplained": "The definition states the meaning of the headword and is the central part of the entry."
+      }
+    ]
+  },
+  "faqs": [
+    {
+      "question": "How does “Pronunciation” reveal the final category in LinkedIn Pinpoint #792?",
+      "answer": "The exact answer is Parts of a dictionary entry. A pronunciation guide shows readers how the headword is spoken, often with phonetic symbols. This reading also matches the connection used by the other four clues."
+    },
+    {
+      "question": "How do Pronunciation and Etymology connect in Pinpoint #792?",
+      "answer": "Pronunciation resolves as pronunciation guide, while Etymology resolves as word etymology. Both support the same final answer."
+    },
+    {
+      "question": "Why is Part of speech important in Pinpoint #792?",
+      "answer": "Part of speech is decisive because The part-of-speech label identifies whether the headword functions as a noun, verb, adjective, or another class. That reading gives a precise check for the other four clues."
+    }
+  ],
+  "solvePath": {
+    "firstRead": "The opening pair, Pronunciation and Etymology, leaves more than one reasonable route. Read without the rest of the board, they can suggest parts of a language lesson instead of the exact connection. At that stage, none of those first impressions explains Part of speech, Example sentence, and Definition with the same precision. The useful move is to keep several readings open, wait for the clue that supplies a repeatable test, and then check every earlier clue against that same narrow rule.",
+    "falseStarts": [
+      "parts of a language lesson",
+      "information about a word"
+    ],
+    "whyFalseStartPlausible": [
+      "All five can appear in language teaching, but their standard packaged form is specifically a dictionary entry.",
+      "The clues are kinds of word information, yet “part of speech” and “definition” point to the structured entry format."
+    ],
+    "breakingClue": "Part of speech",
+    "pivot": "The decisive step came from Part of speech. Reading it as part-of-speech label gave me a precise test, so I went back through pronunciation guide, word etymology, part-of-speech label, usage example sentence and checked the same relationship each time.",
+    "fullBoardConfirmation": "pronunciation guide, word etymology, part-of-speech label, usage example sentence, word definition all survive the same check. That full-board agreement rules out the broader first impressions and keeps the solution at one level of specificity."
+  },
+  "turningPoint": {
+    "clue": "Part of speech",
+    "whyDecisive": "Part of speech resolves cleanly as part-of-speech label, making standard fields presented together for one headword in a dictionary specific enough to test across all five clues.",
+    "whatChangedAfterIt": "After Part of speech, the earlier clues could be checked through the same precise relationship instead of two broad surface guesses."
+  },
+  "clueRows": [
+    {
+      "clue": "Pronunciation",
+      "surfaceMisread": "parts of a language lesson",
+      "resolvedPhraseOrMember": "pronunciation guide",
+      "nonObviousWhy": "A pronunciation guide shows readers how the headword is spoken, often with phonetic symbols.",
+      "searchableContext": "pronunciation guide"
+    },
+    {
+      "clue": "Etymology",
+      "surfaceMisread": "information about a word",
+      "resolvedPhraseOrMember": "word etymology",
+      "nonObviousWhy": "Etymology explains the history and linguistic origin of the word listed in the entry.",
+      "searchableContext": "word etymology"
+    },
+    {
+      "clue": "Part of speech",
+      "surfaceMisread": "parts of a language lesson",
+      "resolvedPhraseOrMember": "part-of-speech label",
+      "nonObviousWhy": "The part-of-speech label identifies whether the headword functions as a noun, verb, adjective, or another class.",
+      "searchableContext": "part-of-speech label"
+    },
+    {
+      "clue": "Example sentence",
+      "surfaceMisread": "information about a word",
+      "resolvedPhraseOrMember": "usage example sentence",
+      "nonObviousWhy": "An example sentence demonstrates how the word is used naturally in context.",
+      "searchableContext": "usage example sentence"
+    },
+    {
+      "clue": "Definition",
+      "surfaceMisread": "parts of a language lesson",
+      "resolvedPhraseOrMember": "word definition",
+      "nonObviousWhy": "The definition states the meaning of the headword and is the central part of the entry.",
+      "searchableContext": "word definition"
+    }
+  ],
+  "faqItems": [
+    {
+      "intentType": "solve_strategy",
+      "question": "How does “Pronunciation” reveal the final category in LinkedIn Pinpoint #792?",
+      "answer": "The exact answer is Parts of a dictionary entry. A pronunciation guide shows readers how the headword is spoken, often with phonetic symbols. This reading also matches the connection used by the other four clues.",
+      "tiedClue": "Pronunciation"
+    },
+    {
+      "intentType": "solve_strategy",
+      "question": "How do Pronunciation and Etymology connect in Pinpoint #792?",
+      "answer": "Pronunciation resolves as pronunciation guide, while Etymology resolves as word etymology. Both support the same final answer.",
+      "tiedClue": "Pronunciation"
+    },
+    {
+      "intentType": "clue_background",
+      "question": "Why is Part of speech important in Pinpoint #792?",
+      "answer": "Part of speech is decisive because The part-of-speech label identifies whether the headword functions as a noun, verb, adjective, or another class. That reading gives a precise check for the other four clues.",
+      "tiedClue": "Part of speech"
+    }
+  ],
+  "uniquenessSignals": {
+    "angle": "standard fields presented together for one headword in a dictionary",
+    "relatedEntities": [
+      "pronunciation guide",
+      "word etymology",
+      "part-of-speech label",
+      "usage example sentence",
+      "word definition"
+    ],
+    "doNotRepeatPatterns": [
+      "standard fields presented together for one headword in a dictionary",
+      "pronunciation guide",
+      "word etymology",
+      "part-of-speech label",
+      "usage example sentence"
+    ]
+  },
+  "wrongGuessCandidates": [
+    {
+      "label": "parts of a language lesson",
+      "whyPlausible": "All five can appear in language teaching, but their standard packaged form is specifically a dictionary entry.",
+      "whyRejected": "Part of speech and the full five-clue check point more precisely to Parts of a dictionary entry."
+    },
+    {
+      "label": "information about a word",
+      "whyPlausible": "The clues are kinds of word information, yet “part of speech” and “definition” point to the structured entry format.",
+      "whyRejected": "Part of speech and the full five-clue check point more precisely to Parts of a dictionary entry."
+    }
+  ],
+  "setValidationSummary": "pronunciation guide; word etymology; part-of-speech label; usage example sentence; word definition all support standard fields presented together for one headword in a dictionary, so the answer holds across every clue rather than only the opening pair.",
+  "categoryPrecisionNote": "named fields inside a dictionary entry rather than language information generally"
+}

--- a/data/puzzles/pinpoint-answer-793.json
+++ b/data/puzzles/pinpoint-answer-793.json
@@ -1,0 +1,219 @@
+{
+  "puzzleNumber": 793,
+  "slug": "pinpoint-answer-793",
+  "publishDate": "2026-07-02",
+  "isoDate": "2026-07-02",
+  "detailState": "fallback_full",
+  "bodyMode": "standard",
+  "pageExperienceMode": "full-analysis",
+  "questionType": "phrase",
+  "difficultyBand": "hard",
+  "clues": [
+    "Supreme",
+    "Food",
+    "Tennis",
+    "Contempt of",
+    "The ball is in your"
+  ],
+  "answer": "Words that come before “court”",
+  "category": "Words that come before “court”",
+  "wordHints": {
+    "Supreme": "“Supreme Court” is the familiar name for the highest court in a judicial system.",
+    "Food": "A “food court” is a shared dining area containing several food vendors.",
+    "Tennis": "A “tennis court” is the marked playing surface used for a tennis match.",
+    "Contempt of": "“Contempt of court” is the established legal phrase for conduct that disobeys or disrespects a court.",
+    "The ball is in your": "“The ball is in your court” is the idiom meaning that the next decision or action belongs to you."
+  },
+  "spoilerHints": {
+    "Supreme": "Try reading Supreme as part of a familiar phrase in words that come before “court” instead of as a standalone word.",
+    "Food": "Food works better once you test a fixed phrase pattern rather than a broad topic.",
+    "Tennis": "Look for a natural expression that absorbs Tennis cleanly before locking the board.",
+    "Contempt of": "Try reading Contempt of as part of a familiar phrase in words that come before “court” instead of as a standalone word.",
+    "The ball is in your": "The ball is in your is the clue that makes the phrase pattern in words that come before “court” concrete enough to test."
+  },
+  "articleBlocks": [
+    "The opening pair, Supreme and Food, leaves more than one reasonable route. Read without the rest of the board, they can suggest legal institutions instead of the exact connection. At that stage, none of those first impressions explains Tennis, Contempt of, and The ball is in your with the same precision. The useful move is to keep several readings open, wait for the clue that supplies a repeatable test, and then check every earlier clue against that same narrow rule.",
+    "legal institutions is tempting because Supreme and contempt of both suggest law, but food and tennis do not belong to a legal-only category. That idea remains incomplete once Tennis is added and the clues need one repeatable explanation.",
+    "A second possibility is places used for games. Tennis and the ball suggest sport, yet the exact shared feature is the same ending word across phrases from different settings. The board therefore needs a narrower rule that can account for every clue without changing direction halfway through.",
+    "Contempt of is the turning clue. Its clean reading as contempt of court makes familiar names, compounds, and sayings completed by the word court concrete enough to test against the earlier entries.",
+    "Supreme Court, food court, tennis court, contempt of court, the ball is in your court all survive the same check. That full-board agreement rules out the broader first impressions and keeps the solution at one level of specificity.",
+    "The answer is Words that come before “court”. More precisely, the puzzle resolves as one shared ending word after each clue, not a mixed category about law or sports, which explains why every reveal belongs in the final set."
+  ],
+  "solutionNarrative": [
+    "I began with Supreme and Food and tested legal institutions. It was a fair first read because supreme and contempt of both suggest law, but food and tennis do not belong to a legal-only category. I kept it provisional rather than forcing the remaining clues into it.",
+    "When Tennis appeared, I also considered places used for games. That alternative described part of the surface, but it still did not provide one exact rule for Contempt of and The ball is in your.",
+    "The decisive step came from Contempt of. Reading it as contempt of court gave me a precise test, so I went back through Supreme Court, food court, tennis court, contempt of court and checked the same relationship each time.",
+    "After all five checks held, I could reject both early guesses. The answer was Words that come before “court”, with the important distinction that this is one shared ending word after each clue, not a mixed category about law or sports."
+  ],
+  "lessons": [
+    {
+      "title": "Do not lock onto Supreme too early",
+      "body": "Supreme can support legal institutions, so wait until another clue supplies a rule that repeats across the entire board."
+    },
+    {
+      "title": "Contempt of supplies the strongest test",
+      "body": "Once Contempt of reads as contempt of court, apply that exact relationship to the earlier clues instead of relying on a broad topic match."
+    },
+    {
+      "title": "Pinpoint 793 needs five clean confirmations",
+      "body": "The solution is secure only when tennis court, contempt of court, the ball is in your court fit the same rule naturally and do not require separate exceptions."
+    }
+  ],
+  "display": {
+    "connectorSummary": "familiar phrases completed by one shared ending word",
+    "fastStrategy": "Supreme can support legal institutions, so wait until another clue supplies a rule that repeats across the entire board.",
+    "clueTableRows": [
+      {
+        "clue": "Supreme",
+        "examplePhrase": "Supreme Court",
+        "connectionExplained": "“Supreme Court” is the familiar name for the highest court in a judicial system."
+      },
+      {
+        "clue": "Food",
+        "examplePhrase": "food court",
+        "connectionExplained": "A “food court” is a shared dining area containing several food vendors."
+      },
+      {
+        "clue": "Tennis",
+        "examplePhrase": "tennis court",
+        "connectionExplained": "A “tennis court” is the marked playing surface used for a tennis match."
+      },
+      {
+        "clue": "Contempt of",
+        "examplePhrase": "contempt of court",
+        "connectionExplained": "“Contempt of court” is the established legal phrase for conduct that disobeys or disrespects a court."
+      },
+      {
+        "clue": "The ball is in your",
+        "examplePhrase": "the ball is in your court",
+        "connectionExplained": "“The ball is in your court” is the idiom meaning that the next decision or action belongs to you."
+      }
+    ]
+  },
+  "faqs": [
+    {
+      "question": "How does “Supreme” reveal the final category in LinkedIn Pinpoint #793?",
+      "answer": "The exact answer is Words that come before “court”. “Supreme Court” is the familiar name for the highest court in a judicial system. This reading also matches the connection used by the other four clues."
+    },
+    {
+      "question": "How do Supreme and Food connect in Pinpoint #793?",
+      "answer": "Supreme resolves as Supreme Court, while Food resolves as food court. Both support the same final answer."
+    },
+    {
+      "question": "Why is Contempt of important in Pinpoint #793?",
+      "answer": "Contempt of is decisive because “Contempt of court” is the established legal phrase for conduct that disobeys or disrespects a court. That reading gives a precise check for the other four clues."
+    }
+  ],
+  "solvePath": {
+    "firstRead": "The opening pair, Supreme and Food, leaves more than one reasonable route. Read without the rest of the board, they can suggest legal institutions instead of the exact connection. At that stage, none of those first impressions explains Tennis, Contempt of, and The ball is in your with the same precision. The useful move is to keep several readings open, wait for the clue that supplies a repeatable test, and then check every earlier clue against that same narrow rule.",
+    "falseStarts": [
+      "legal institutions",
+      "places used for games"
+    ],
+    "whyFalseStartPlausible": [
+      "Supreme and contempt of both suggest law, but food and tennis do not belong to a legal-only category.",
+      "Tennis and the ball suggest sport, yet the exact shared feature is the same ending word across phrases from different settings."
+    ],
+    "breakingClue": "Contempt of",
+    "pivot": "The decisive step came from Contempt of. Reading it as contempt of court gave me a precise test, so I went back through Supreme Court, food court, tennis court, contempt of court and checked the same relationship each time.",
+    "fullBoardConfirmation": "Supreme Court, food court, tennis court, contempt of court, the ball is in your court all survive the same check. That full-board agreement rules out the broader first impressions and keeps the solution at one level of specificity."
+  },
+  "turningPoint": {
+    "clue": "Contempt of",
+    "whyDecisive": "Contempt of resolves cleanly as contempt of court, making familiar names, compounds, and sayings completed by the word court specific enough to test across all five clues.",
+    "whatChangedAfterIt": "After Contempt of, the earlier clues could be checked through the same precise relationship instead of two broad surface guesses."
+  },
+  "clueRows": [
+    {
+      "clue": "Supreme",
+      "surfaceMisread": "legal institutions",
+      "resolvedPhraseOrMember": "Supreme Court",
+      "nonObviousWhy": "“Supreme Court” is the familiar name for the highest court in a judicial system.",
+      "searchableContext": "Supreme Court",
+      "phraseExample": "Supreme Court"
+    },
+    {
+      "clue": "Food",
+      "surfaceMisread": "places used for games",
+      "resolvedPhraseOrMember": "food court",
+      "nonObviousWhy": "A “food court” is a shared dining area containing several food vendors.",
+      "searchableContext": "food court",
+      "phraseExample": "food court"
+    },
+    {
+      "clue": "Tennis",
+      "surfaceMisread": "legal institutions",
+      "resolvedPhraseOrMember": "tennis court",
+      "nonObviousWhy": "A “tennis court” is the marked playing surface used for a tennis match.",
+      "searchableContext": "tennis court",
+      "phraseExample": "tennis court"
+    },
+    {
+      "clue": "Contempt of",
+      "surfaceMisread": "places used for games",
+      "resolvedPhraseOrMember": "contempt of court",
+      "nonObviousWhy": "“Contempt of court” is the established legal phrase for conduct that disobeys or disrespects a court.",
+      "searchableContext": "contempt of court",
+      "phraseExample": "contempt of court"
+    },
+    {
+      "clue": "The ball is in your",
+      "surfaceMisread": "legal institutions",
+      "resolvedPhraseOrMember": "the ball is in your court",
+      "nonObviousWhy": "“The ball is in your court” is the idiom meaning that the next decision or action belongs to you.",
+      "searchableContext": "the ball is in your court",
+      "phraseExample": "the ball is in your court"
+    }
+  ],
+  "faqItems": [
+    {
+      "intentType": "solve_strategy",
+      "question": "How does “Supreme” reveal the final category in LinkedIn Pinpoint #793?",
+      "answer": "The exact answer is Words that come before “court”. “Supreme Court” is the familiar name for the highest court in a judicial system. This reading also matches the connection used by the other four clues.",
+      "tiedClue": "Supreme"
+    },
+    {
+      "intentType": "solve_strategy",
+      "question": "How do Supreme and Food connect in Pinpoint #793?",
+      "answer": "Supreme resolves as Supreme Court, while Food resolves as food court. Both support the same final answer.",
+      "tiedClue": "Supreme"
+    },
+    {
+      "intentType": "clue_background",
+      "question": "Why is Contempt of important in Pinpoint #793?",
+      "answer": "Contempt of is decisive because “Contempt of court” is the established legal phrase for conduct that disobeys or disrespects a court. That reading gives a precise check for the other four clues.",
+      "tiedClue": "Contempt of"
+    }
+  ],
+  "uniquenessSignals": {
+    "angle": "familiar names, compounds, and sayings completed by the word court",
+    "relatedEntities": [
+      "Supreme Court",
+      "food court",
+      "tennis court",
+      "contempt of court",
+      "the ball is in your court"
+    ],
+    "doNotRepeatPatterns": [
+      "familiar names, compounds, and sayings completed by the word court",
+      "Supreme Court",
+      "food court",
+      "tennis court",
+      "contempt of court"
+    ]
+  },
+  "wrongGuessCandidates": [
+    {
+      "label": "legal institutions",
+      "whyPlausible": "Supreme and contempt of both suggest law, but food and tennis do not belong to a legal-only category.",
+      "whyRejected": "Contempt of and the full five-clue check point more precisely to Words that come before “court”."
+    },
+    {
+      "label": "places used for games",
+      "whyPlausible": "Tennis and the ball suggest sport, yet the exact shared feature is the same ending word across phrases from different settings.",
+      "whyRejected": "Contempt of and the full five-clue check point more precisely to Words that come before “court”."
+    }
+  ],
+  "setValidationSummary": "Supreme Court; food court; tennis court; contempt of court; the ball is in your court all support familiar names, compounds, and sayings completed by the word court, so the answer holds across every clue rather than only the opening pair.",
+  "categoryPrecisionNote": "one shared ending word after each clue, not a mixed category about law or sports"
+}

--- a/data/puzzles/pinpoint-answer-794.json
+++ b/data/puzzles/pinpoint-answer-794.json
@@ -1,0 +1,214 @@
+{
+  "puzzleNumber": 794,
+  "slug": "pinpoint-answer-794",
+  "publishDate": "2026-07-03",
+  "isoDate": "2026-07-03",
+  "detailState": "fallback_full",
+  "bodyMode": "standard",
+  "pageExperienceMode": "full-analysis",
+  "questionType": "category",
+  "difficultyBand": "hard",
+  "clues": [
+    "AA",
+    "AAA",
+    "9V",
+    "Alkaline",
+    "Lithium-ion (rechargeable)"
+  ],
+  "answer": "Terms used to describe batteries",
+  "category": "Terms used to describe batteries",
+  "wordHints": {
+    "AA": "AA is a common cylindrical battery size used in many portable household devices.",
+    "AAA": "AAA is a smaller cylindrical battery size often used in remotes and compact electronics.",
+    "9V": "9V names the familiar rectangular battery by its nominal voltage.",
+    "Alkaline": "Alkaline identifies a widely used battery chemistry found in disposable household cells.",
+    "Lithium-ion (rechargeable)": "Lithium-ion identifies a rechargeable battery chemistry used in phones, laptops, and many other devices."
+  },
+  "spoilerHints": {
+    "AA": "AA should be tested as part of terms used to describe batteries, not as a standalone reference.",
+    "AAA": "Keep AAA in mind, then see whether Lithium-ion (rechargeable) supports the same answer.",
+    "9V": "9V works best after the board narrows toward terms used to describe batteries.",
+    "Alkaline": "Alkaline should be tested as part of terms used to describe batteries, not as a standalone reference.",
+    "Lithium-ion (rechargeable)": "Lithium-ion (rechargeable) is the clue that makes terms used to describe batteries concrete enough to test across the full board."
+  },
+  "articleBlocks": [
+    "The opening pair, AA and AAA, leaves more than one reasonable route. Read without the rest of the board, they can suggest electrical measurements instead of the exact connection. At that stage, none of those first impressions explains 9V, Alkaline, and Lithium-ion (rechargeable) with the same precision. The useful move is to keep several readings open, wait for the clue that supplies a repeatable test, and then check every earlier clue against that same narrow rule.",
+    "electrical measurements is tempting because 9V looks like an electrical measurement, but AA and AAA are sizes rather than voltages. That idea remains incomplete once 9V is added and the clues need one repeatable explanation.",
+    "A second possibility is labels printed on electronics. All five can appear on product packaging, but each one specifically describes a battery by size, voltage, or chemistry. The board therefore needs a narrower rule that can account for every clue without changing direction halfway through.",
+    "Alkaline is the turning clue. Its clean reading as alkaline battery makes battery descriptions covering size, voltage, and chemical type concrete enough to test against the earlier entries.",
+    "AA battery, AAA battery, 9V battery, alkaline battery, rechargeable lithium-ion battery all survive the same check. That full-board agreement rules out the broader first impressions and keeps the solution at one level of specificity.",
+    "The answer is Terms used to describe batteries. More precisely, the puzzle resolves as recognized battery size, voltage, or chemistry terms rather than electrical labels broadly, which explains why every reveal belongs in the final set."
+  ],
+  "solutionNarrative": [
+    "I began with AA and AAA and tested electrical measurements. It was a fair first read because 9V looks like an electrical measurement, but AA and AAA are sizes rather than voltages. I kept it provisional rather than forcing the remaining clues into it.",
+    "When 9V appeared, I also considered labels printed on electronics. That alternative described part of the surface, but it still did not provide one exact rule for Alkaline and Lithium-ion (rechargeable).",
+    "The decisive step came from Alkaline. Reading it as alkaline battery gave me a precise test, so I went back through AA battery, AAA battery, 9V battery, alkaline battery and checked the same relationship each time.",
+    "After all five checks held, I could reject both early guesses. The answer was Terms used to describe batteries, with the important distinction that this is recognized battery size, voltage, or chemistry terms rather than electrical labels broadly."
+  ],
+  "lessons": [
+    {
+      "title": "Do not lock onto AA too early",
+      "body": "AA can support electrical measurements, so wait until another clue supplies a rule that repeats across the entire board."
+    },
+    {
+      "title": "Alkaline supplies the strongest test",
+      "body": "Once Alkaline reads as alkaline battery, apply that exact relationship to the earlier clues instead of relying on a broad topic match."
+    },
+    {
+      "title": "Pinpoint 794 needs five clean confirmations",
+      "body": "The solution is secure only when 9V battery, alkaline battery, rechargeable lithium-ion battery fit the same rule naturally and do not require separate exceptions."
+    }
+  ],
+  "display": {
+    "connectorSummary": "a category board focused on terms",
+    "fastStrategy": "AA can support electrical measurements, so wait until another clue supplies a rule that repeats across the entire board.",
+    "clueTableRows": [
+      {
+        "clue": "AA",
+        "examplePhrase": "AA battery",
+        "connectionExplained": "AA is a common cylindrical battery size used in many portable household devices."
+      },
+      {
+        "clue": "AAA",
+        "examplePhrase": "AAA battery",
+        "connectionExplained": "AAA is a smaller cylindrical battery size often used in remotes and compact electronics."
+      },
+      {
+        "clue": "9V",
+        "examplePhrase": "9V battery",
+        "connectionExplained": "9V names the familiar rectangular battery by its nominal voltage."
+      },
+      {
+        "clue": "Alkaline",
+        "examplePhrase": "alkaline battery",
+        "connectionExplained": "Alkaline identifies a widely used battery chemistry found in disposable household cells."
+      },
+      {
+        "clue": "Lithium-ion (rechargeable)",
+        "examplePhrase": "rechargeable lithium-ion battery",
+        "connectionExplained": "Lithium-ion identifies a rechargeable battery chemistry used in phones, laptops, and many other devices."
+      }
+    ]
+  },
+  "faqs": [
+    {
+      "question": "How does “AA” reveal the final category in LinkedIn Pinpoint #794?",
+      "answer": "The exact answer is Terms used to describe batteries. AA is a common cylindrical battery size used in many portable household devices. This reading also matches the connection used by the other four clues."
+    },
+    {
+      "question": "How do AA and AAA connect in Pinpoint #794?",
+      "answer": "AA resolves as AA battery, while AAA resolves as AAA battery. Both support the same final answer."
+    },
+    {
+      "question": "Why is Alkaline important in Pinpoint #794?",
+      "answer": "Alkaline is decisive because Alkaline identifies a widely used battery chemistry found in disposable household cells. That reading gives a precise check for the other four clues."
+    }
+  ],
+  "solvePath": {
+    "firstRead": "The opening pair, AA and AAA, leaves more than one reasonable route. Read without the rest of the board, they can suggest electrical measurements instead of the exact connection. At that stage, none of those first impressions explains 9V, Alkaline, and Lithium-ion (rechargeable) with the same precision. The useful move is to keep several readings open, wait for the clue that supplies a repeatable test, and then check every earlier clue against that same narrow rule.",
+    "falseStarts": [
+      "electrical measurements",
+      "labels printed on electronics"
+    ],
+    "whyFalseStartPlausible": [
+      "9V looks like an electrical measurement, but AA and AAA are sizes rather than voltages.",
+      "All five can appear on product packaging, but each one specifically describes a battery by size, voltage, or chemistry."
+    ],
+    "breakingClue": "Alkaline",
+    "pivot": "The decisive step came from Alkaline. Reading it as alkaline battery gave me a precise test, so I went back through AA battery, AAA battery, 9V battery, alkaline battery and checked the same relationship each time.",
+    "fullBoardConfirmation": "AA battery, AAA battery, 9V battery, alkaline battery, rechargeable lithium-ion battery all survive the same check. That full-board agreement rules out the broader first impressions and keeps the solution at one level of specificity."
+  },
+  "turningPoint": {
+    "clue": "Alkaline",
+    "whyDecisive": "Alkaline resolves cleanly as alkaline battery, making battery descriptions covering size, voltage, and chemical type specific enough to test across all five clues.",
+    "whatChangedAfterIt": "After Alkaline, the earlier clues could be checked through the same precise relationship instead of two broad surface guesses."
+  },
+  "clueRows": [
+    {
+      "clue": "AA",
+      "surfaceMisread": "electrical measurements",
+      "resolvedPhraseOrMember": "AA battery",
+      "nonObviousWhy": "AA is a common cylindrical battery size used in many portable household devices.",
+      "searchableContext": "AA battery"
+    },
+    {
+      "clue": "AAA",
+      "surfaceMisread": "labels printed on electronics",
+      "resolvedPhraseOrMember": "AAA battery",
+      "nonObviousWhy": "AAA is a smaller cylindrical battery size often used in remotes and compact electronics.",
+      "searchableContext": "AAA battery"
+    },
+    {
+      "clue": "9V",
+      "surfaceMisread": "electrical measurements",
+      "resolvedPhraseOrMember": "9V battery",
+      "nonObviousWhy": "9V names the familiar rectangular battery by its nominal voltage.",
+      "searchableContext": "9V battery"
+    },
+    {
+      "clue": "Alkaline",
+      "surfaceMisread": "labels printed on electronics",
+      "resolvedPhraseOrMember": "alkaline battery",
+      "nonObviousWhy": "Alkaline identifies a widely used battery chemistry found in disposable household cells.",
+      "searchableContext": "alkaline battery"
+    },
+    {
+      "clue": "Lithium-ion (rechargeable)",
+      "surfaceMisread": "electrical measurements",
+      "resolvedPhraseOrMember": "rechargeable lithium-ion battery",
+      "nonObviousWhy": "Lithium-ion identifies a rechargeable battery chemistry used in phones, laptops, and many other devices.",
+      "searchableContext": "rechargeable lithium-ion battery"
+    }
+  ],
+  "faqItems": [
+    {
+      "intentType": "solve_strategy",
+      "question": "How does “AA” reveal the final category in LinkedIn Pinpoint #794?",
+      "answer": "The exact answer is Terms used to describe batteries. AA is a common cylindrical battery size used in many portable household devices. This reading also matches the connection used by the other four clues.",
+      "tiedClue": "AA"
+    },
+    {
+      "intentType": "solve_strategy",
+      "question": "How do AA and AAA connect in Pinpoint #794?",
+      "answer": "AA resolves as AA battery, while AAA resolves as AAA battery. Both support the same final answer.",
+      "tiedClue": "AA"
+    },
+    {
+      "intentType": "clue_background",
+      "question": "Why is Alkaline important in Pinpoint #794?",
+      "answer": "Alkaline is decisive because Alkaline identifies a widely used battery chemistry found in disposable household cells. That reading gives a precise check for the other four clues.",
+      "tiedClue": "Alkaline"
+    }
+  ],
+  "uniquenessSignals": {
+    "angle": "battery descriptions covering size, voltage, and chemical type",
+    "relatedEntities": [
+      "AA battery",
+      "AAA battery",
+      "9V battery",
+      "alkaline battery",
+      "rechargeable lithium-ion battery"
+    ],
+    "doNotRepeatPatterns": [
+      "battery descriptions covering size, voltage, and chemical type",
+      "AA battery",
+      "AAA battery",
+      "9V battery",
+      "alkaline battery"
+    ]
+  },
+  "wrongGuessCandidates": [
+    {
+      "label": "electrical measurements",
+      "whyPlausible": "9V looks like an electrical measurement, but AA and AAA are sizes rather than voltages.",
+      "whyRejected": "Alkaline and the full five-clue check point more precisely to Terms used to describe batteries."
+    },
+    {
+      "label": "labels printed on electronics",
+      "whyPlausible": "All five can appear on product packaging, but each one specifically describes a battery by size, voltage, or chemistry.",
+      "whyRejected": "Alkaline and the full five-clue check point more precisely to Terms used to describe batteries."
+    }
+  ],
+  "setValidationSummary": "AA battery; AAA battery; 9V battery; alkaline battery; rechargeable lithium-ion battery all support battery descriptions covering size, voltage, and chemical type, so the answer holds across every clue rather than only the opening pair.",
+  "categoryPrecisionNote": "recognized battery size, voltage, or chemistry terms rather than electrical labels broadly"
+}

--- a/data/puzzles/pinpoint-answer-795.json
+++ b/data/puzzles/pinpoint-answer-795.json
@@ -1,0 +1,219 @@
+{
+  "puzzleNumber": 795,
+  "slug": "pinpoint-answer-795",
+  "publishDate": "2026-07-04",
+  "isoDate": "2026-07-04",
+  "detailState": "fallback_full",
+  "bodyMode": "standard",
+  "pageExperienceMode": "full-analysis",
+  "questionType": "phrase",
+  "difficultyBand": "hard",
+  "clues": [
+    "Front",
+    "Kingdom",
+    "Nations",
+    "States (🎆 Happy 250th! 🎇)",
+    "We stand, divided we fall"
+  ],
+  "answer": "Words that come after “united”",
+  "category": "Words that come after “united”",
+  "wordHints": {
+    "Front": "“United Front” describes a group presenting a shared position or acting together.",
+    "Kingdom": "“United Kingdom” is the country name formed by placing United before Kingdom.",
+    "Nations": "“United Nations” is the international organization whose official name uses the same opening word.",
+    "States (🎆 Happy 250th! 🎇)": "“United States” completes the country name highlighted by the 250th-anniversary note in the clue.",
+    "We stand, divided we fall": "“United we stand, divided we fall” is the well-known saying completed by the final clue text."
+  },
+  "spoilerHints": {
+    "Front": "Try reading Front as part of a familiar phrase in words that come after “united” instead of as a standalone word.",
+    "Kingdom": "Kingdom works better once you test a fixed phrase pattern rather than a broad topic.",
+    "Nations": "Look for a natural expression that absorbs Nations cleanly before locking the board.",
+    "States (🎆 Happy 250th! 🎇)": "States (🎆 Happy 250th! 🎇) is the clue that makes the phrase pattern in words that come after “united” concrete enough to test.",
+    "We stand, divided we fall": "We stand, divided we fall works better once you test a fixed phrase pattern rather than a broad topic."
+  },
+  "articleBlocks": [
+    "The opening pair, Front and Kingdom, leaves more than one reasonable route. Read without the rest of the board, they can suggest names of countries and organizations instead of the exact connection. At that stage, none of those first impressions explains Nations, States (🎆 Happy 250th! 🎇), and We stand, divided we fall with the same precision. The useful move is to keep several readings open, wait for the clue that supplies a repeatable test, and then check every earlier clue against that same narrow rule.",
+    "names of countries and organizations is tempting because Kingdom, Nations, and States suggest political names, but Front and the closing saying show a wider phrase family. That idea remains incomplete once Nations is added and the clues need one repeatable explanation.",
+    "A second possibility is things connected with national unity. The board invokes unity, yet the precise mechanism is that the same opening word precedes every clue. The board therefore needs a narrower rule that can account for every clue without changing direction halfway through.",
+    "We stand, divided we fall is the turning clue. Its clean reading as United we stand, divided we fall makes proper names and a saying that all begin with the word united concrete enough to test against the earlier entries.",
+    "United Front, United Kingdom, United Nations, United States, United we stand, divided we fall all survive the same check. That full-board agreement rules out the broader first impressions and keeps the solution at one level of specificity.",
+    "The answer is Words that come after “united”. More precisely, the puzzle resolves as one shared opening word before each clue, not a broad theme of patriotism or cooperation, which explains why every reveal belongs in the final set."
+  ],
+  "solutionNarrative": [
+    "I began with Front and Kingdom and tested names of countries and organizations. It was a fair first read because kingdom, Nations, and States suggest political names, but Front and the closing saying show a wider phrase family. I kept it provisional rather than forcing the remaining clues into it.",
+    "When Nations appeared, I also considered things connected with national unity. That alternative described part of the surface, but it still did not provide one exact rule for States (🎆 Happy 250th! 🎇) and We stand, divided we fall.",
+    "The decisive step came from We stand, divided we fall. Reading it as United we stand, divided we fall gave me a precise test, so I went back through United Front, United Kingdom, United Nations, United States and checked the same relationship each time.",
+    "After all five checks held, I could reject both early guesses. The answer was Words that come after “united”, with the important distinction that this is one shared opening word before each clue, not a broad theme of patriotism or cooperation."
+  ],
+  "lessons": [
+    {
+      "title": "Do not lock onto Front too early",
+      "body": "Front can support names of countries and organizations, so wait until another clue supplies a rule that repeats across the entire board."
+    },
+    {
+      "title": "We stand, divided we fall supplies the strongest test",
+      "body": "Once We stand, divided we fall reads as United we stand, divided we fall, apply that exact relationship to the earlier clues instead of relying on a broad topic match."
+    },
+    {
+      "title": "Pinpoint 795 needs five clean confirmations",
+      "body": "The solution is secure only when United Nations, United States, United we stand, divided we fall fit the same rule naturally and do not require separate exceptions."
+    }
+  ],
+  "display": {
+    "connectorSummary": "familiar phrases and everyday terms built with one shared opening word",
+    "fastStrategy": "Front can support names of countries and organizations, so wait until another clue supplies a rule that repeats across the entire board.",
+    "clueTableRows": [
+      {
+        "clue": "Front",
+        "examplePhrase": "United Front",
+        "connectionExplained": "“United Front” describes a group presenting a shared position or acting together."
+      },
+      {
+        "clue": "Kingdom",
+        "examplePhrase": "United Kingdom",
+        "connectionExplained": "“United Kingdom” is the country name formed by placing United before Kingdom."
+      },
+      {
+        "clue": "Nations",
+        "examplePhrase": "United Nations",
+        "connectionExplained": "“United Nations” is the international organization whose official name uses the same opening word."
+      },
+      {
+        "clue": "States (🎆 Happy 250th! 🎇)",
+        "examplePhrase": "United States",
+        "connectionExplained": "“United States” completes the country name highlighted by the 250th-anniversary note in the clue."
+      },
+      {
+        "clue": "We stand, divided we fall",
+        "examplePhrase": "United we stand, divided we fall",
+        "connectionExplained": "“United we stand, divided we fall” is the well-known saying completed by the final clue text."
+      }
+    ]
+  },
+  "faqs": [
+    {
+      "question": "How does “Front” reveal the final category in LinkedIn Pinpoint #795?",
+      "answer": "The exact answer is Words that come after “united”. “United Front” describes a group presenting a shared position or acting together. This reading also matches the connection used by the other four clues."
+    },
+    {
+      "question": "How do Front and Kingdom connect in Pinpoint #795?",
+      "answer": "Front resolves as United Front, while Kingdom resolves as United Kingdom. Both support the same final answer."
+    },
+    {
+      "question": "Why is We stand, divided we fall important in Pinpoint #795?",
+      "answer": "We stand, divided we fall is decisive because “United we stand, divided we fall” is the well-known saying completed by the final clue text. That reading gives a precise check for the other four clues."
+    }
+  ],
+  "solvePath": {
+    "firstRead": "The opening pair, Front and Kingdom, leaves more than one reasonable route. Read without the rest of the board, they can suggest names of countries and organizations instead of the exact connection. At that stage, none of those first impressions explains Nations, States (🎆 Happy 250th! 🎇), and We stand, divided we fall with the same precision. The useful move is to keep several readings open, wait for the clue that supplies a repeatable test, and then check every earlier clue against that same narrow rule.",
+    "falseStarts": [
+      "names of countries and organizations",
+      "things connected with national unity"
+    ],
+    "whyFalseStartPlausible": [
+      "Kingdom, Nations, and States suggest political names, but Front and the closing saying show a wider phrase family.",
+      "The board invokes unity, yet the precise mechanism is that the same opening word precedes every clue."
+    ],
+    "breakingClue": "We stand, divided we fall",
+    "pivot": "The decisive step came from We stand, divided we fall. Reading it as United we stand, divided we fall gave me a precise test, so I went back through United Front, United Kingdom, United Nations, United States and checked the same relationship each time.",
+    "fullBoardConfirmation": "United Front, United Kingdom, United Nations, United States, United we stand, divided we fall all survive the same check. That full-board agreement rules out the broader first impressions and keeps the solution at one level of specificity."
+  },
+  "turningPoint": {
+    "clue": "We stand, divided we fall",
+    "whyDecisive": "We stand, divided we fall resolves cleanly as United we stand, divided we fall, making proper names and a saying that all begin with the word united specific enough to test across all five clues.",
+    "whatChangedAfterIt": "After We stand, divided we fall, the earlier clues could be checked through the same precise relationship instead of two broad surface guesses."
+  },
+  "clueRows": [
+    {
+      "clue": "Front",
+      "surfaceMisread": "names of countries and organizations",
+      "resolvedPhraseOrMember": "United Front",
+      "nonObviousWhy": "“United Front” describes a group presenting a shared position or acting together.",
+      "searchableContext": "United Front",
+      "phraseExample": "United Front"
+    },
+    {
+      "clue": "Kingdom",
+      "surfaceMisread": "things connected with national unity",
+      "resolvedPhraseOrMember": "United Kingdom",
+      "nonObviousWhy": "“United Kingdom” is the country name formed by placing United before Kingdom.",
+      "searchableContext": "United Kingdom",
+      "phraseExample": "United Kingdom"
+    },
+    {
+      "clue": "Nations",
+      "surfaceMisread": "names of countries and organizations",
+      "resolvedPhraseOrMember": "United Nations",
+      "nonObviousWhy": "“United Nations” is the international organization whose official name uses the same opening word.",
+      "searchableContext": "United Nations",
+      "phraseExample": "United Nations"
+    },
+    {
+      "clue": "States (🎆 Happy 250th! 🎇)",
+      "surfaceMisread": "things connected with national unity",
+      "resolvedPhraseOrMember": "United States",
+      "nonObviousWhy": "“United States” completes the country name highlighted by the 250th-anniversary note in the clue.",
+      "searchableContext": "United States",
+      "phraseExample": "United States"
+    },
+    {
+      "clue": "We stand, divided we fall",
+      "surfaceMisread": "names of countries and organizations",
+      "resolvedPhraseOrMember": "United we stand, divided we fall",
+      "nonObviousWhy": "“United we stand, divided we fall” is the well-known saying completed by the final clue text.",
+      "searchableContext": "United we stand, divided we fall",
+      "phraseExample": "United we stand, divided we fall"
+    }
+  ],
+  "faqItems": [
+    {
+      "intentType": "solve_strategy",
+      "question": "How does “Front” reveal the final category in LinkedIn Pinpoint #795?",
+      "answer": "The exact answer is Words that come after “united”. “United Front” describes a group presenting a shared position or acting together. This reading also matches the connection used by the other four clues.",
+      "tiedClue": "Front"
+    },
+    {
+      "intentType": "solve_strategy",
+      "question": "How do Front and Kingdom connect in Pinpoint #795?",
+      "answer": "Front resolves as United Front, while Kingdom resolves as United Kingdom. Both support the same final answer.",
+      "tiedClue": "Front"
+    },
+    {
+      "intentType": "clue_background",
+      "question": "Why is We stand, divided we fall important in Pinpoint #795?",
+      "answer": "We stand, divided we fall is decisive because “United we stand, divided we fall” is the well-known saying completed by the final clue text. That reading gives a precise check for the other four clues.",
+      "tiedClue": "We stand, divided we fall"
+    }
+  ],
+  "uniquenessSignals": {
+    "angle": "proper names and a saying that all begin with the word united",
+    "relatedEntities": [
+      "United Front",
+      "United Kingdom",
+      "United Nations",
+      "United States",
+      "United we stand, divided we fall"
+    ],
+    "doNotRepeatPatterns": [
+      "proper names and a saying that all begin with the word united",
+      "United Front",
+      "United Kingdom",
+      "United Nations",
+      "United States"
+    ]
+  },
+  "wrongGuessCandidates": [
+    {
+      "label": "names of countries and organizations",
+      "whyPlausible": "Kingdom, Nations, and States suggest political names, but Front and the closing saying show a wider phrase family.",
+      "whyRejected": "We stand, divided we fall and the full five-clue check point more precisely to Words that come after “united”."
+    },
+    {
+      "label": "things connected with national unity",
+      "whyPlausible": "The board invokes unity, yet the precise mechanism is that the same opening word precedes every clue.",
+      "whyRejected": "We stand, divided we fall and the full five-clue check point more precisely to Words that come after “united”."
+    }
+  ],
+  "setValidationSummary": "United Front; United Kingdom; United Nations; United States; United we stand, divided we fall all support proper names and a saying that all begin with the word united, so the answer holds across every clue rather than only the opening pair.",
+  "categoryPrecisionNote": "one shared opening word before each clue, not a broad theme of patriotism or cooperation"
+}

--- a/data/puzzles/pinpoint-answer-796.json
+++ b/data/puzzles/pinpoint-answer-796.json
@@ -1,0 +1,214 @@
+{
+  "puzzleNumber": 796,
+  "slug": "pinpoint-answer-796",
+  "publishDate": "2026-07-05",
+  "isoDate": "2026-07-05",
+  "detailState": "fallback_full",
+  "bodyMode": "standard",
+  "pageExperienceMode": "full-analysis",
+  "questionType": "hybrid",
+  "difficultyBand": "hard",
+  "clues": [
+    "A rapid pace",
+    "Hit at an angle",
+    "Small metal fastener for paper",
+    "Cut with scissors",
+    "Short segment of a film"
+  ],
+  "answer": "Different meanings of “clip”",
+  "category": "Different meanings of “clip”",
+  "wordHints": {
+    "A rapid pace": "Moving “at a fast clip” uses clip to mean a rapid rate or pace.",
+    "Hit at an angle": "To clip something can mean striking it lightly or at an angle rather than hitting it squarely.",
+    "Small metal fastener for paper": "A paper clip is the small bent-metal fastener used to hold sheets of paper together.",
+    "Cut with scissors": "To clip with scissors means trimming or cutting a small amount from something.",
+    "Short segment of a film": "A film clip is a short extracted segment from a longer movie or recording."
+  },
+  "spoilerHints": {
+    "A rapid pace": "A rapid pace should be tested as part of different meanings of “clip”, not as a standalone reference.",
+    "Hit at an angle": "Keep Hit at an angle in mind, then see whether Small metal fastener for paper supports the same answer.",
+    "Small metal fastener for paper": "Small metal fastener for paper is the clue that makes different meanings of “clip” concrete enough to test across the full board.",
+    "Cut with scissors": "Cut with scissors should be tested as part of different meanings of “clip”, not as a standalone reference.",
+    "Short segment of a film": "Keep Short segment of a film in mind, then see whether Small metal fastener for paper supports the same answer."
+  },
+  "articleBlocks": [
+    "The opening pair, A rapid pace and Hit at an angle, leaves more than one reasonable route. Read without the rest of the board, they can suggest editing and cutting tools instead of the exact connection. At that stage, none of those first impressions explains Small metal fastener for paper, Cut with scissors, and Short segment of a film with the same precision. The useful move is to keep several readings open, wait for the clue that supplies a repeatable test, and then check every earlier clue against that same narrow rule.",
+    "editing and cutting tools is tempting because Scissors and a film segment suggest editing, but the pace and impact clues require other dictionary senses. That idea remains incomplete once Small metal fastener for paper is added and the clues need one repeatable explanation.",
+    "A second possibility is quick movements and impacts. A rapid pace and a glancing hit sound active, yet the paper fastener shows that the shared word also functions as a noun. The board therefore needs a narrower rule that can account for every clue without changing direction halfway through.",
+    "Small metal fastener for paper is the turning clue. Its clean reading as paper clip makes five distinct noun and verb senses of the word clip concrete enough to test against the earlier entries.",
+    "move at a fast clip, clip something with a glancing hit, paper clip, clip with scissors, film clip all survive the same check. That full-board agreement rules out the broader first impressions and keeps the solution at one level of specificity.",
+    "The answer is Different meanings of “clip”. More precisely, the puzzle resolves as separate established meanings of one word rather than items connected only by cutting, which explains why every reveal belongs in the final set."
+  ],
+  "solutionNarrative": [
+    "I began with A rapid pace and Hit at an angle and tested editing and cutting tools. It was a fair first read because scissors and a film segment suggest editing, but the pace and impact clues require other dictionary senses. I kept it provisional rather than forcing the remaining clues into it.",
+    "When Small metal fastener for paper appeared, I also considered quick movements and impacts. That alternative described part of the surface, but it still did not provide one exact rule for Cut with scissors and Short segment of a film.",
+    "The decisive step came from Small metal fastener for paper. Reading it as paper clip gave me a precise test, so I went back through move at a fast clip, clip something with a glancing hit, paper clip, clip with scissors and checked the same relationship each time.",
+    "After all five checks held, I could reject both early guesses. The answer was Different meanings of “clip”, with the important distinction that this is separate established meanings of one word rather than items connected only by cutting."
+  ],
+  "lessons": [
+    {
+      "title": "Do not lock onto A rapid pace too early",
+      "body": "A rapid pace can support editing and cutting tools, so wait until another clue supplies a rule that repeats across the entire board."
+    },
+    {
+      "title": "Small metal fastener for paper supplies the strongest test",
+      "body": "Once Small metal fastener for paper reads as paper clip, apply that exact relationship to the earlier clues instead of relying on a broad topic match."
+    },
+    {
+      "title": "Pinpoint 796 needs five clean confirmations",
+      "body": "The solution is secure only when paper clip, clip with scissors, film clip fit the same rule naturally and do not require separate exceptions."
+    }
+  ],
+  "display": {
+    "connectorSummary": "a category board focused on different",
+    "fastStrategy": "A rapid pace can support editing and cutting tools, so wait until another clue supplies a rule that repeats across the entire board.",
+    "clueTableRows": [
+      {
+        "clue": "A rapid pace",
+        "examplePhrase": "move at a fast clip",
+        "connectionExplained": "Moving “at a fast clip” uses clip to mean a rapid rate or pace."
+      },
+      {
+        "clue": "Hit at an angle",
+        "examplePhrase": "clip something with a glancing hit",
+        "connectionExplained": "To clip something can mean striking it lightly or at an angle rather than hitting it squarely."
+      },
+      {
+        "clue": "Small metal fastener for paper",
+        "examplePhrase": "paper clip",
+        "connectionExplained": "A paper clip is the small bent-metal fastener used to hold sheets of paper together."
+      },
+      {
+        "clue": "Cut with scissors",
+        "examplePhrase": "clip with scissors",
+        "connectionExplained": "To clip with scissors means trimming or cutting a small amount from something."
+      },
+      {
+        "clue": "Short segment of a film",
+        "examplePhrase": "film clip",
+        "connectionExplained": "A film clip is a short extracted segment from a longer movie or recording."
+      }
+    ]
+  },
+  "faqs": [
+    {
+      "question": "How does “A rapid pace” reveal the final category in LinkedIn Pinpoint #796?",
+      "answer": "The exact answer is Different meanings of “clip”. Moving “at a fast clip” uses clip to mean a rapid rate or pace. This reading also matches the connection used by the other four clues."
+    },
+    {
+      "question": "How do A rapid pace and Hit at an angle connect in Pinpoint #796?",
+      "answer": "A rapid pace resolves as move at a fast clip, while Hit at an angle resolves as clip something with a glancing hit. Both support the same final answer."
+    },
+    {
+      "question": "Why is Small metal fastener for paper important in Pinpoint #796?",
+      "answer": "Small metal fastener for paper is decisive because A paper clip is the small bent-metal fastener used to hold sheets of paper together. That reading gives a precise check for the other four clues."
+    }
+  ],
+  "solvePath": {
+    "firstRead": "The opening pair, A rapid pace and Hit at an angle, leaves more than one reasonable route. Read without the rest of the board, they can suggest editing and cutting tools instead of the exact connection. At that stage, none of those first impressions explains Small metal fastener for paper, Cut with scissors, and Short segment of a film with the same precision. The useful move is to keep several readings open, wait for the clue that supplies a repeatable test, and then check every earlier clue against that same narrow rule.",
+    "falseStarts": [
+      "editing and cutting tools",
+      "quick movements and impacts"
+    ],
+    "whyFalseStartPlausible": [
+      "Scissors and a film segment suggest editing, but the pace and impact clues require other dictionary senses.",
+      "A rapid pace and a glancing hit sound active, yet the paper fastener shows that the shared word also functions as a noun."
+    ],
+    "breakingClue": "Small metal fastener for paper",
+    "pivot": "The decisive step came from Small metal fastener for paper. Reading it as paper clip gave me a precise test, so I went back through move at a fast clip, clip something with a glancing hit, paper clip, clip with scissors and checked the same relationship each time.",
+    "fullBoardConfirmation": "move at a fast clip, clip something with a glancing hit, paper clip, clip with scissors, film clip all survive the same check. That full-board agreement rules out the broader first impressions and keeps the solution at one level of specificity."
+  },
+  "turningPoint": {
+    "clue": "Small metal fastener for paper",
+    "whyDecisive": "Small metal fastener for paper resolves cleanly as paper clip, making five distinct noun and verb senses of the word clip specific enough to test across all five clues.",
+    "whatChangedAfterIt": "After Small metal fastener for paper, the earlier clues could be checked through the same precise relationship instead of two broad surface guesses."
+  },
+  "clueRows": [
+    {
+      "clue": "A rapid pace",
+      "surfaceMisread": "editing and cutting tools",
+      "resolvedPhraseOrMember": "move at a fast clip",
+      "nonObviousWhy": "Moving “at a fast clip” uses clip to mean a rapid rate or pace.",
+      "searchableContext": "move at a fast clip"
+    },
+    {
+      "clue": "Hit at an angle",
+      "surfaceMisread": "quick movements and impacts",
+      "resolvedPhraseOrMember": "clip something with a glancing hit",
+      "nonObviousWhy": "To clip something can mean striking it lightly or at an angle rather than hitting it squarely.",
+      "searchableContext": "clip something with a glancing hit"
+    },
+    {
+      "clue": "Small metal fastener for paper",
+      "surfaceMisread": "editing and cutting tools",
+      "resolvedPhraseOrMember": "paper clip",
+      "nonObviousWhy": "A paper clip is the small bent-metal fastener used to hold sheets of paper together.",
+      "searchableContext": "paper clip"
+    },
+    {
+      "clue": "Cut with scissors",
+      "surfaceMisread": "quick movements and impacts",
+      "resolvedPhraseOrMember": "clip with scissors",
+      "nonObviousWhy": "To clip with scissors means trimming or cutting a small amount from something.",
+      "searchableContext": "clip with scissors"
+    },
+    {
+      "clue": "Short segment of a film",
+      "surfaceMisread": "editing and cutting tools",
+      "resolvedPhraseOrMember": "film clip",
+      "nonObviousWhy": "A film clip is a short extracted segment from a longer movie or recording.",
+      "searchableContext": "film clip"
+    }
+  ],
+  "faqItems": [
+    {
+      "intentType": "solve_strategy",
+      "question": "How does “A rapid pace” reveal the final category in LinkedIn Pinpoint #796?",
+      "answer": "The exact answer is Different meanings of “clip”. Moving “at a fast clip” uses clip to mean a rapid rate or pace. This reading also matches the connection used by the other four clues.",
+      "tiedClue": "A rapid pace"
+    },
+    {
+      "intentType": "solve_strategy",
+      "question": "How do A rapid pace and Hit at an angle connect in Pinpoint #796?",
+      "answer": "A rapid pace resolves as move at a fast clip, while Hit at an angle resolves as clip something with a glancing hit. Both support the same final answer.",
+      "tiedClue": "A rapid pace"
+    },
+    {
+      "intentType": "clue_background",
+      "question": "Why is Small metal fastener for paper important in Pinpoint #796?",
+      "answer": "Small metal fastener for paper is decisive because A paper clip is the small bent-metal fastener used to hold sheets of paper together. That reading gives a precise check for the other four clues.",
+      "tiedClue": "Small metal fastener for paper"
+    }
+  ],
+  "uniquenessSignals": {
+    "angle": "five distinct noun and verb senses of the word clip",
+    "relatedEntities": [
+      "move at a fast clip",
+      "clip something with a glancing hit",
+      "paper clip",
+      "clip with scissors",
+      "film clip"
+    ],
+    "doNotRepeatPatterns": [
+      "five distinct noun and verb senses of the word clip",
+      "move at a fast clip",
+      "clip something with a glancing hit",
+      "paper clip",
+      "clip with scissors"
+    ]
+  },
+  "wrongGuessCandidates": [
+    {
+      "label": "editing and cutting tools",
+      "whyPlausible": "Scissors and a film segment suggest editing, but the pace and impact clues require other dictionary senses.",
+      "whyRejected": "Small metal fastener for paper and the full five-clue check point more precisely to Different meanings of “clip”."
+    },
+    {
+      "label": "quick movements and impacts",
+      "whyPlausible": "A rapid pace and a glancing hit sound active, yet the paper fastener shows that the shared word also functions as a noun.",
+      "whyRejected": "Small metal fastener for paper and the full five-clue check point more precisely to Different meanings of “clip”."
+    }
+  ],
+  "setValidationSummary": "move at a fast clip; clip something with a glancing hit; paper clip; clip with scissors; film clip all support five distinct noun and verb senses of the word clip, so the answer holds across every clue rather than only the opening pair.",
+  "categoryPrecisionNote": "separate established meanings of one word rather than items connected only by cutting"
+}

--- a/data/puzzles/pinpoint-answer-797.json
+++ b/data/puzzles/pinpoint-answer-797.json
@@ -1,0 +1,214 @@
+{
+  "puzzleNumber": 797,
+  "slug": "pinpoint-answer-797",
+  "publishDate": "2026-07-06",
+  "isoDate": "2026-07-06",
+  "detailState": "fallback_full",
+  "bodyMode": "standard",
+  "pageExperienceMode": "full-analysis",
+  "questionType": "category",
+  "difficultyBand": "hard",
+  "clues": [
+    "Avianca",
+    "El Al",
+    "Qantas",
+    "Lufthansa",
+    "Aeroméxico"
+  ],
+  "answer": "National airlines (flag carriers)",
+  "category": "National airlines (flag carriers)",
+  "wordHints": {
+    "Avianca": "Avianca is the flag carrier associated with Colombia.",
+    "El Al": "El Al is the national flag carrier airline of Israel.",
+    "Qantas": "Qantas is Australia’s flag carrier and its best-known international airline brand.",
+    "Lufthansa": "Lufthansa is the flag carrier airline associated with Germany.",
+    "Aeroméxico": "Aeroméxico is the flag carrier airline associated with Mexico."
+  },
+  "spoilerHints": {
+    "Avianca": "Avianca should be tested as part of national airlines (flag carriers), not as a standalone reference.",
+    "El Al": "Keep El Al in mind, then see whether Aeroméxico supports the same answer.",
+    "Qantas": "Qantas works best after the board narrows toward national airlines (flag carriers).",
+    "Lufthansa": "Lufthansa should be tested as part of national airlines (flag carriers), not as a standalone reference.",
+    "Aeroméxico": "Aeroméxico is the clue that makes national airlines (flag carriers) concrete enough to test across the full board."
+  },
+  "articleBlocks": [
+    "The opening pair, Avianca and El Al, leaves more than one reasonable route. Read without the rest of the board, they can suggest large international airlines instead of the exact connection. At that stage, none of those first impressions explains Qantas, Lufthansa, and Aeroméxico with the same precision. The useful move is to keep several readings open, wait for the clue that supplies a repeatable test, and then check every earlier clue against that same narrow rule.",
+    "large international airlines is tempting because All five operate international routes, but many international airlines are not national flag carriers. That idea remains incomplete once Qantas is added and the clues need one repeatable explanation.",
+    "A second possibility is companies seen at major airports. Airport visibility explains where the names appear, not the more exact role each airline holds for its country. The board therefore needs a narrower rule that can account for every clue without changing direction halfway through.",
+    "Qantas is the turning clue. Its clean reading as Qantas of Australia makes airlines recognized as flag carriers for their respective countries concrete enough to test against the earlier entries.",
+    "Avianca of Colombia, El Al of Israel, Qantas of Australia, Lufthansa of Germany, Aeroméxico of Mexico all survive the same check. That full-board agreement rules out the broader first impressions and keeps the solution at one level of specificity.",
+    "The answer is National airlines (flag carriers). More precisely, the puzzle resolves as national flag carrier airlines rather than international airlines of any kind, which explains why every reveal belongs in the final set."
+  ],
+  "solutionNarrative": [
+    "I began with Avianca and El Al and tested large international airlines. It was a fair first read because all five operate international routes, but many international airlines are not national flag carriers. I kept it provisional rather than forcing the remaining clues into it.",
+    "When Qantas appeared, I also considered companies seen at major airports. That alternative described part of the surface, but it still did not provide one exact rule for Lufthansa and Aeroméxico.",
+    "The decisive step came from Qantas. Reading it as Qantas of Australia gave me a precise test, so I went back through Avianca of Colombia, El Al of Israel, Qantas of Australia, Lufthansa of Germany and checked the same relationship each time.",
+    "After all five checks held, I could reject both early guesses. The answer was National airlines (flag carriers), with the important distinction that this is national flag carrier airlines rather than international airlines of any kind."
+  ],
+  "lessons": [
+    {
+      "title": "Do not lock onto Avianca too early",
+      "body": "Avianca can support large international airlines, so wait until another clue supplies a rule that repeats across the entire board."
+    },
+    {
+      "title": "Qantas supplies the strongest test",
+      "body": "Once Qantas reads as Qantas of Australia, apply that exact relationship to the earlier clues instead of relying on a broad topic match."
+    },
+    {
+      "title": "Pinpoint 797 needs five clean confirmations",
+      "body": "The solution is secure only when Qantas of Australia, Lufthansa of Germany, Aeroméxico of Mexico fit the same rule naturally and do not require separate exceptions."
+    }
+  ],
+  "display": {
+    "connectorSummary": "a category board focused on national",
+    "fastStrategy": "Avianca can support large international airlines, so wait until another clue supplies a rule that repeats across the entire board.",
+    "clueTableRows": [
+      {
+        "clue": "Avianca",
+        "examplePhrase": "Avianca of Colombia",
+        "connectionExplained": "Avianca is the flag carrier associated with Colombia."
+      },
+      {
+        "clue": "El Al",
+        "examplePhrase": "El Al of Israel",
+        "connectionExplained": "El Al is the national flag carrier airline of Israel."
+      },
+      {
+        "clue": "Qantas",
+        "examplePhrase": "Qantas of Australia",
+        "connectionExplained": "Qantas is Australia’s flag carrier and its best-known international airline brand."
+      },
+      {
+        "clue": "Lufthansa",
+        "examplePhrase": "Lufthansa of Germany",
+        "connectionExplained": "Lufthansa is the flag carrier airline associated with Germany."
+      },
+      {
+        "clue": "Aeroméxico",
+        "examplePhrase": "Aeroméxico of Mexico",
+        "connectionExplained": "Aeroméxico is the flag carrier airline associated with Mexico."
+      }
+    ]
+  },
+  "faqs": [
+    {
+      "question": "How does “Avianca” reveal the final category in LinkedIn Pinpoint #797?",
+      "answer": "The exact answer is National airlines (flag carriers). Avianca is the flag carrier associated with Colombia. This reading also matches the connection used by the other four clues."
+    },
+    {
+      "question": "How do Avianca and El Al connect in Pinpoint #797?",
+      "answer": "Avianca resolves as Avianca of Colombia, while El Al resolves as El Al of Israel. Both support the same final answer."
+    },
+    {
+      "question": "Why is Qantas important in Pinpoint #797?",
+      "answer": "Qantas is decisive because Qantas is Australia’s flag carrier and its best-known international airline brand. That reading gives a precise check for the other four clues."
+    }
+  ],
+  "solvePath": {
+    "firstRead": "The opening pair, Avianca and El Al, leaves more than one reasonable route. Read without the rest of the board, they can suggest large international airlines instead of the exact connection. At that stage, none of those first impressions explains Qantas, Lufthansa, and Aeroméxico with the same precision. The useful move is to keep several readings open, wait for the clue that supplies a repeatable test, and then check every earlier clue against that same narrow rule.",
+    "falseStarts": [
+      "large international airlines",
+      "companies seen at major airports"
+    ],
+    "whyFalseStartPlausible": [
+      "All five operate international routes, but many international airlines are not national flag carriers.",
+      "Airport visibility explains where the names appear, not the more exact role each airline holds for its country."
+    ],
+    "breakingClue": "Qantas",
+    "pivot": "The decisive step came from Qantas. Reading it as Qantas of Australia gave me a precise test, so I went back through Avianca of Colombia, El Al of Israel, Qantas of Australia, Lufthansa of Germany and checked the same relationship each time.",
+    "fullBoardConfirmation": "Avianca of Colombia, El Al of Israel, Qantas of Australia, Lufthansa of Germany, Aeroméxico of Mexico all survive the same check. That full-board agreement rules out the broader first impressions and keeps the solution at one level of specificity."
+  },
+  "turningPoint": {
+    "clue": "Qantas",
+    "whyDecisive": "Qantas resolves cleanly as Qantas of Australia, making airlines recognized as flag carriers for their respective countries specific enough to test across all five clues.",
+    "whatChangedAfterIt": "After Qantas, the earlier clues could be checked through the same precise relationship instead of two broad surface guesses."
+  },
+  "clueRows": [
+    {
+      "clue": "Avianca",
+      "surfaceMisread": "large international airlines",
+      "resolvedPhraseOrMember": "Avianca of Colombia",
+      "nonObviousWhy": "Avianca is the flag carrier associated with Colombia.",
+      "searchableContext": "Avianca of Colombia"
+    },
+    {
+      "clue": "El Al",
+      "surfaceMisread": "companies seen at major airports",
+      "resolvedPhraseOrMember": "El Al of Israel",
+      "nonObviousWhy": "El Al is the national flag carrier airline of Israel.",
+      "searchableContext": "El Al of Israel"
+    },
+    {
+      "clue": "Qantas",
+      "surfaceMisread": "large international airlines",
+      "resolvedPhraseOrMember": "Qantas of Australia",
+      "nonObviousWhy": "Qantas is Australia’s flag carrier and its best-known international airline brand.",
+      "searchableContext": "Qantas of Australia"
+    },
+    {
+      "clue": "Lufthansa",
+      "surfaceMisread": "companies seen at major airports",
+      "resolvedPhraseOrMember": "Lufthansa of Germany",
+      "nonObviousWhy": "Lufthansa is the flag carrier airline associated with Germany.",
+      "searchableContext": "Lufthansa of Germany"
+    },
+    {
+      "clue": "Aeroméxico",
+      "surfaceMisread": "large international airlines",
+      "resolvedPhraseOrMember": "Aeroméxico of Mexico",
+      "nonObviousWhy": "Aeroméxico is the flag carrier airline associated with Mexico.",
+      "searchableContext": "Aeroméxico of Mexico"
+    }
+  ],
+  "faqItems": [
+    {
+      "intentType": "solve_strategy",
+      "question": "How does “Avianca” reveal the final category in LinkedIn Pinpoint #797?",
+      "answer": "The exact answer is National airlines (flag carriers). Avianca is the flag carrier associated with Colombia. This reading also matches the connection used by the other four clues.",
+      "tiedClue": "Avianca"
+    },
+    {
+      "intentType": "solve_strategy",
+      "question": "How do Avianca and El Al connect in Pinpoint #797?",
+      "answer": "Avianca resolves as Avianca of Colombia, while El Al resolves as El Al of Israel. Both support the same final answer.",
+      "tiedClue": "Avianca"
+    },
+    {
+      "intentType": "clue_background",
+      "question": "Why is Qantas important in Pinpoint #797?",
+      "answer": "Qantas is decisive because Qantas is Australia’s flag carrier and its best-known international airline brand. That reading gives a precise check for the other four clues.",
+      "tiedClue": "Qantas"
+    }
+  ],
+  "uniquenessSignals": {
+    "angle": "airlines recognized as flag carriers for their respective countries",
+    "relatedEntities": [
+      "Avianca of Colombia",
+      "El Al of Israel",
+      "Qantas of Australia",
+      "Lufthansa of Germany",
+      "Aeroméxico of Mexico"
+    ],
+    "doNotRepeatPatterns": [
+      "airlines recognized as flag carriers for their respective countries",
+      "Avianca of Colombia",
+      "El Al of Israel",
+      "Qantas of Australia",
+      "Lufthansa of Germany"
+    ]
+  },
+  "wrongGuessCandidates": [
+    {
+      "label": "large international airlines",
+      "whyPlausible": "All five operate international routes, but many international airlines are not national flag carriers.",
+      "whyRejected": "Qantas and the full five-clue check point more precisely to National airlines (flag carriers)."
+    },
+    {
+      "label": "companies seen at major airports",
+      "whyPlausible": "Airport visibility explains where the names appear, not the more exact role each airline holds for its country.",
+      "whyRejected": "Qantas and the full five-clue check point more precisely to National airlines (flag carriers)."
+    }
+  ],
+  "setValidationSummary": "Avianca of Colombia; El Al of Israel; Qantas of Australia; Lufthansa of Germany; Aeroméxico of Mexico all support airlines recognized as flag carriers for their respective countries, so the answer holds across every clue rather than only the opening pair.",
+  "categoryPrecisionNote": "national flag carrier airlines rather than international airlines of any kind"
+}

--- a/data/puzzles/pinpoint-answer-798.json
+++ b/data/puzzles/pinpoint-answer-798.json
@@ -1,0 +1,214 @@
+{
+  "puzzleNumber": 798,
+  "slug": "pinpoint-answer-798",
+  "publishDate": "2026-07-07",
+  "isoDate": "2026-07-07",
+  "detailState": "fallback_full",
+  "bodyMode": "standard",
+  "pageExperienceMode": "full-analysis",
+  "questionType": "category",
+  "difficultyBand": "hard",
+  "clues": [
+    "Library",
+    "Auditorium",
+    "Playground",
+    "Science lab",
+    "Classroom"
+  ],
+  "answer": "Places at a school",
+  "category": "Places at a school",
+  "wordHints": {
+    "Library": "A school library provides books, study space, and research materials for students.",
+    "Auditorium": "A school auditorium is used for assemblies, performances, presentations, and large group events.",
+    "Playground": "A playground is the outdoor area where younger students can play during breaks.",
+    "Science lab": "A science lab is the specialist room where students conduct experiments and practical lessons.",
+    "Classroom": "A classroom is the standard room where teachers and students meet for lessons."
+  },
+  "spoilerHints": {
+    "Library": "Library should be tested as part of places at a school, not as a standalone reference.",
+    "Auditorium": "Keep Auditorium in mind, then see whether Science lab supports the same answer.",
+    "Playground": "Playground works best after the board narrows toward places at a school.",
+    "Science lab": "Science lab is the clue that makes places at a school concrete enough to test across the full board.",
+    "Classroom": "Keep Classroom in mind, then see whether Science lab supports the same answer."
+  },
+  "articleBlocks": [
+    "The opening pair, Library and Auditorium, leaves more than one reasonable route. Read without the rest of the board, they can suggest rooms in a public building instead of the exact connection. At that stage, none of those first impressions explains Playground, Science lab, and Classroom with the same precision. The useful move is to keep several readings open, wait for the clue that supplies a repeatable test, and then check every earlier clue against that same narrow rule.",
+    "rooms in a public building is tempting because Libraries and auditoriums appear in many public buildings, but playground and classroom narrow the setting to a school. That idea remains incomplete once Playground is added and the clues need one repeatable explanation.",
+    "A second possibility is places used by children. Children use several of these places, yet science labs and auditoriums are defined here by their role inside a school campus. The board therefore needs a narrower rule that can account for every clue without changing direction halfway through.",
+    "Science lab is the turning clue. Its clean reading as school science laboratory makes indoor and outdoor spaces normally found on a school campus concrete enough to test against the earlier entries.",
+    "school library, school auditorium, school playground, school science laboratory, school classroom all survive the same check. That full-board agreement rules out the broader first impressions and keeps the solution at one level of specificity.",
+    "The answer is Places at a school. More precisely, the puzzle resolves as specific school locations rather than public rooms or places for children generally, which explains why every reveal belongs in the final set."
+  ],
+  "solutionNarrative": [
+    "I began with Library and Auditorium and tested rooms in a public building. It was a fair first read because libraries and auditoriums appear in many public buildings, but playground and classroom narrow the setting to a school. I kept it provisional rather than forcing the remaining clues into it.",
+    "When Playground appeared, I also considered places used by children. That alternative described part of the surface, but it still did not provide one exact rule for Science lab and Classroom.",
+    "The decisive step came from Science lab. Reading it as school science laboratory gave me a precise test, so I went back through school library, school auditorium, school playground, school science laboratory and checked the same relationship each time.",
+    "After all five checks held, I could reject both early guesses. The answer was Places at a school, with the important distinction that this is specific school locations rather than public rooms or places for children generally."
+  ],
+  "lessons": [
+    {
+      "title": "Do not lock onto Library too early",
+      "body": "Library can support rooms in a public building, so wait until another clue supplies a rule that repeats across the entire board."
+    },
+    {
+      "title": "Science lab supplies the strongest test",
+      "body": "Once Science lab reads as school science laboratory, apply that exact relationship to the earlier clues instead of relying on a broad topic match."
+    },
+    {
+      "title": "Pinpoint 798 needs five clean confirmations",
+      "body": "The solution is secure only when school playground, school science laboratory, school classroom fit the same rule naturally and do not require separate exceptions."
+    }
+  ],
+  "display": {
+    "connectorSummary": "a category board focused on places",
+    "fastStrategy": "Library can support rooms in a public building, so wait until another clue supplies a rule that repeats across the entire board.",
+    "clueTableRows": [
+      {
+        "clue": "Library",
+        "examplePhrase": "school library",
+        "connectionExplained": "A school library provides books, study space, and research materials for students."
+      },
+      {
+        "clue": "Auditorium",
+        "examplePhrase": "school auditorium",
+        "connectionExplained": "A school auditorium is used for assemblies, performances, presentations, and large group events."
+      },
+      {
+        "clue": "Playground",
+        "examplePhrase": "school playground",
+        "connectionExplained": "A playground is the outdoor area where younger students can play during breaks."
+      },
+      {
+        "clue": "Science lab",
+        "examplePhrase": "school science laboratory",
+        "connectionExplained": "A science lab is the specialist room where students conduct experiments and practical lessons."
+      },
+      {
+        "clue": "Classroom",
+        "examplePhrase": "school classroom",
+        "connectionExplained": "A classroom is the standard room where teachers and students meet for lessons."
+      }
+    ]
+  },
+  "faqs": [
+    {
+      "question": "How does “Library” reveal the final category in LinkedIn Pinpoint #798?",
+      "answer": "The exact answer is Places at a school. A school library provides books, study space, and research materials for students. This reading also matches the connection used by the other four clues."
+    },
+    {
+      "question": "How do Library and Auditorium connect in Pinpoint #798?",
+      "answer": "Library resolves as school library, while Auditorium resolves as school auditorium. Both support the same final answer."
+    },
+    {
+      "question": "Why is Science lab important in Pinpoint #798?",
+      "answer": "Science lab is decisive because A science lab is the specialist room where students conduct experiments and practical lessons. That reading gives a precise check for the other four clues."
+    }
+  ],
+  "solvePath": {
+    "firstRead": "The opening pair, Library and Auditorium, leaves more than one reasonable route. Read without the rest of the board, they can suggest rooms in a public building instead of the exact connection. At that stage, none of those first impressions explains Playground, Science lab, and Classroom with the same precision. The useful move is to keep several readings open, wait for the clue that supplies a repeatable test, and then check every earlier clue against that same narrow rule.",
+    "falseStarts": [
+      "rooms in a public building",
+      "places used by children"
+    ],
+    "whyFalseStartPlausible": [
+      "Libraries and auditoriums appear in many public buildings, but playground and classroom narrow the setting to a school.",
+      "Children use several of these places, yet science labs and auditoriums are defined here by their role inside a school campus."
+    ],
+    "breakingClue": "Science lab",
+    "pivot": "The decisive step came from Science lab. Reading it as school science laboratory gave me a precise test, so I went back through school library, school auditorium, school playground, school science laboratory and checked the same relationship each time.",
+    "fullBoardConfirmation": "school library, school auditorium, school playground, school science laboratory, school classroom all survive the same check. That full-board agreement rules out the broader first impressions and keeps the solution at one level of specificity."
+  },
+  "turningPoint": {
+    "clue": "Science lab",
+    "whyDecisive": "Science lab resolves cleanly as school science laboratory, making indoor and outdoor spaces normally found on a school campus specific enough to test across all five clues.",
+    "whatChangedAfterIt": "After Science lab, the earlier clues could be checked through the same precise relationship instead of two broad surface guesses."
+  },
+  "clueRows": [
+    {
+      "clue": "Library",
+      "surfaceMisread": "rooms in a public building",
+      "resolvedPhraseOrMember": "school library",
+      "nonObviousWhy": "A school library provides books, study space, and research materials for students.",
+      "searchableContext": "school library"
+    },
+    {
+      "clue": "Auditorium",
+      "surfaceMisread": "places used by children",
+      "resolvedPhraseOrMember": "school auditorium",
+      "nonObviousWhy": "A school auditorium is used for assemblies, performances, presentations, and large group events.",
+      "searchableContext": "school auditorium"
+    },
+    {
+      "clue": "Playground",
+      "surfaceMisread": "rooms in a public building",
+      "resolvedPhraseOrMember": "school playground",
+      "nonObviousWhy": "A playground is the outdoor area where younger students can play during breaks.",
+      "searchableContext": "school playground"
+    },
+    {
+      "clue": "Science lab",
+      "surfaceMisread": "places used by children",
+      "resolvedPhraseOrMember": "school science laboratory",
+      "nonObviousWhy": "A science lab is the specialist room where students conduct experiments and practical lessons.",
+      "searchableContext": "school science laboratory"
+    },
+    {
+      "clue": "Classroom",
+      "surfaceMisread": "rooms in a public building",
+      "resolvedPhraseOrMember": "school classroom",
+      "nonObviousWhy": "A classroom is the standard room where teachers and students meet for lessons.",
+      "searchableContext": "school classroom"
+    }
+  ],
+  "faqItems": [
+    {
+      "intentType": "solve_strategy",
+      "question": "How does “Library” reveal the final category in LinkedIn Pinpoint #798?",
+      "answer": "The exact answer is Places at a school. A school library provides books, study space, and research materials for students. This reading also matches the connection used by the other four clues.",
+      "tiedClue": "Library"
+    },
+    {
+      "intentType": "solve_strategy",
+      "question": "How do Library and Auditorium connect in Pinpoint #798?",
+      "answer": "Library resolves as school library, while Auditorium resolves as school auditorium. Both support the same final answer.",
+      "tiedClue": "Library"
+    },
+    {
+      "intentType": "clue_background",
+      "question": "Why is Science lab important in Pinpoint #798?",
+      "answer": "Science lab is decisive because A science lab is the specialist room where students conduct experiments and practical lessons. That reading gives a precise check for the other four clues.",
+      "tiedClue": "Science lab"
+    }
+  ],
+  "uniquenessSignals": {
+    "angle": "indoor and outdoor spaces normally found on a school campus",
+    "relatedEntities": [
+      "school library",
+      "school auditorium",
+      "school playground",
+      "school science laboratory",
+      "school classroom"
+    ],
+    "doNotRepeatPatterns": [
+      "indoor and outdoor spaces normally found on a school campus",
+      "school library",
+      "school auditorium",
+      "school playground",
+      "school science laboratory"
+    ]
+  },
+  "wrongGuessCandidates": [
+    {
+      "label": "rooms in a public building",
+      "whyPlausible": "Libraries and auditoriums appear in many public buildings, but playground and classroom narrow the setting to a school.",
+      "whyRejected": "Science lab and the full five-clue check point more precisely to Places at a school."
+    },
+    {
+      "label": "places used by children",
+      "whyPlausible": "Children use several of these places, yet science labs and auditoriums are defined here by their role inside a school campus.",
+      "whyRejected": "Science lab and the full five-clue check point more precisely to Places at a school."
+    }
+  ],
+  "setValidationSummary": "school library; school auditorium; school playground; school science laboratory; school classroom all support indoor and outdoor spaces normally found on a school campus, so the answer holds across every clue rather than only the opening pair.",
+  "categoryPrecisionNote": "specific school locations rather than public rooms or places for children generally"
+}

--- a/data/puzzles/pinpoint-answer-799.json
+++ b/data/puzzles/pinpoint-answer-799.json
@@ -1,0 +1,219 @@
+{
+  "puzzleNumber": 799,
+  "slug": "pinpoint-answer-799",
+  "publishDate": "2026-07-08",
+  "isoDate": "2026-07-08",
+  "detailState": "fallback_full",
+  "bodyMode": "standard",
+  "pageExperienceMode": "full-analysis",
+  "questionType": "phrase",
+  "difficultyBand": "hard",
+  "clues": [
+    "Ice",
+    "Cold",
+    "Whipped",
+    "Shaving",
+    "Cookies and"
+  ],
+  "answer": "Words that come before “cream”",
+  "category": "Words that come before “cream”",
+  "wordHints": {
+    "Ice": "“Ice cream” is the frozen dessert made from a sweetened dairy or dairy-like mixture.",
+    "Cold": "“Cold cream” is the traditional moisturizing and cleansing cosmetic preparation.",
+    "Whipped": "“Whipped cream” is cream beaten until it becomes light and holds air.",
+    "Shaving": "“Shaving cream” is the product applied to skin before shaving.",
+    "Cookies and": "“Cookies and cream” is the familiar flavor combining cream with pieces of chocolate sandwich cookies."
+  },
+  "spoilerHints": {
+    "Ice": "Try reading Ice as part of a familiar phrase in words that come before “cream” instead of as a standalone word.",
+    "Cold": "Cold works better once you test a fixed phrase pattern rather than a broad topic.",
+    "Whipped": "Look for a natural expression that absorbs Whipped cleanly before locking the board.",
+    "Shaving": "Try reading Shaving as part of a familiar phrase in words that come before “cream” instead of as a standalone word.",
+    "Cookies and": "Cookies and is the clue that makes the phrase pattern in words that come before “cream” concrete enough to test."
+  },
+  "articleBlocks": [
+    "The opening pair, Ice and Cold, leaves more than one reasonable route. Read without the rest of the board, they can suggest cold desserts and toppings instead of the exact connection. At that stage, none of those first impressions explains Whipped, Shaving, and Cookies and with the same precision. The useful move is to keep several readings open, wait for the clue that supplies a repeatable test, and then check every earlier clue against that same narrow rule.",
+    "cold desserts and toppings is tempting because Ice, whipped, and cookies and point toward dessert, but cold and shaving introduce non-food compounds. That idea remains incomplete once Whipped is added and the clues need one repeatable explanation.",
+    "A second possibility is soft white products. Several answers can look pale or soft, yet the exact repeated feature is the shared ending word in five standard phrases. The board therefore needs a narrower rule that can account for every clue without changing direction halfway through.",
+    "Shaving is the turning clue. Its clean reading as shaving cream makes familiar compounds and a flavor name completed by the word cream concrete enough to test against the earlier entries.",
+    "ice cream, cold cream, whipped cream, shaving cream, cookies and cream all survive the same check. That full-board agreement rules out the broader first impressions and keeps the solution at one level of specificity.",
+    "The answer is Words that come before “cream”. More precisely, the puzzle resolves as one shared ending word after each clue, not a category limited to food or cosmetics, which explains why every reveal belongs in the final set."
+  ],
+  "solutionNarrative": [
+    "I began with Ice and Cold and tested cold desserts and toppings. It was a fair first read because ice, whipped, and cookies and point toward dessert, but cold and shaving introduce non-food compounds. I kept it provisional rather than forcing the remaining clues into it.",
+    "When Whipped appeared, I also considered soft white products. That alternative described part of the surface, but it still did not provide one exact rule for Shaving and Cookies and.",
+    "The decisive step came from Shaving. Reading it as shaving cream gave me a precise test, so I went back through ice cream, cold cream, whipped cream, shaving cream and checked the same relationship each time.",
+    "After all five checks held, I could reject both early guesses. The answer was Words that come before “cream”, with the important distinction that this is one shared ending word after each clue, not a category limited to food or cosmetics."
+  ],
+  "lessons": [
+    {
+      "title": "Do not lock onto Ice too early",
+      "body": "Ice can support cold desserts and toppings, so wait until another clue supplies a rule that repeats across the entire board."
+    },
+    {
+      "title": "Shaving supplies the strongest test",
+      "body": "Once Shaving reads as shaving cream, apply that exact relationship to the earlier clues instead of relying on a broad topic match."
+    },
+    {
+      "title": "Pinpoint 799 needs five clean confirmations",
+      "body": "The solution is secure only when whipped cream, shaving cream, cookies and cream fit the same rule naturally and do not require separate exceptions."
+    }
+  ],
+  "display": {
+    "connectorSummary": "familiar phrases completed by one shared ending word",
+    "fastStrategy": "Ice can support cold desserts and toppings, so wait until another clue supplies a rule that repeats across the entire board.",
+    "clueTableRows": [
+      {
+        "clue": "Ice",
+        "examplePhrase": "ice cream",
+        "connectionExplained": "“Ice cream” is the frozen dessert made from a sweetened dairy or dairy-like mixture."
+      },
+      {
+        "clue": "Cold",
+        "examplePhrase": "cold cream",
+        "connectionExplained": "“Cold cream” is the traditional moisturizing and cleansing cosmetic preparation."
+      },
+      {
+        "clue": "Whipped",
+        "examplePhrase": "whipped cream",
+        "connectionExplained": "“Whipped cream” is cream beaten until it becomes light and holds air."
+      },
+      {
+        "clue": "Shaving",
+        "examplePhrase": "shaving cream",
+        "connectionExplained": "“Shaving cream” is the product applied to skin before shaving."
+      },
+      {
+        "clue": "Cookies and",
+        "examplePhrase": "cookies and cream",
+        "connectionExplained": "“Cookies and cream” is the familiar flavor combining cream with pieces of chocolate sandwich cookies."
+      }
+    ]
+  },
+  "faqs": [
+    {
+      "question": "How does “Ice” reveal the final category in LinkedIn Pinpoint #799?",
+      "answer": "The exact answer is Words that come before “cream”. “Ice cream” is the frozen dessert made from a sweetened dairy or dairy-like mixture. This reading also matches the connection used by the other four clues."
+    },
+    {
+      "question": "How do Ice and Cold connect in Pinpoint #799?",
+      "answer": "Ice resolves as ice cream, while Cold resolves as cold cream. Both support the same final answer."
+    },
+    {
+      "question": "Why is Shaving important in Pinpoint #799?",
+      "answer": "Shaving is decisive because “Shaving cream” is the product applied to skin before shaving. That reading gives a precise check for the other four clues."
+    }
+  ],
+  "solvePath": {
+    "firstRead": "The opening pair, Ice and Cold, leaves more than one reasonable route. Read without the rest of the board, they can suggest cold desserts and toppings instead of the exact connection. At that stage, none of those first impressions explains Whipped, Shaving, and Cookies and with the same precision. The useful move is to keep several readings open, wait for the clue that supplies a repeatable test, and then check every earlier clue against that same narrow rule.",
+    "falseStarts": [
+      "cold desserts and toppings",
+      "soft white products"
+    ],
+    "whyFalseStartPlausible": [
+      "Ice, whipped, and cookies and point toward dessert, but cold and shaving introduce non-food compounds.",
+      "Several answers can look pale or soft, yet the exact repeated feature is the shared ending word in five standard phrases."
+    ],
+    "breakingClue": "Shaving",
+    "pivot": "The decisive step came from Shaving. Reading it as shaving cream gave me a precise test, so I went back through ice cream, cold cream, whipped cream, shaving cream and checked the same relationship each time.",
+    "fullBoardConfirmation": "ice cream, cold cream, whipped cream, shaving cream, cookies and cream all survive the same check. That full-board agreement rules out the broader first impressions and keeps the solution at one level of specificity."
+  },
+  "turningPoint": {
+    "clue": "Shaving",
+    "whyDecisive": "Shaving resolves cleanly as shaving cream, making familiar compounds and a flavor name completed by the word cream specific enough to test across all five clues.",
+    "whatChangedAfterIt": "After Shaving, the earlier clues could be checked through the same precise relationship instead of two broad surface guesses."
+  },
+  "clueRows": [
+    {
+      "clue": "Ice",
+      "surfaceMisread": "cold desserts and toppings",
+      "resolvedPhraseOrMember": "ice cream",
+      "nonObviousWhy": "“Ice cream” is the frozen dessert made from a sweetened dairy or dairy-like mixture.",
+      "searchableContext": "ice cream",
+      "phraseExample": "ice cream"
+    },
+    {
+      "clue": "Cold",
+      "surfaceMisread": "soft white products",
+      "resolvedPhraseOrMember": "cold cream",
+      "nonObviousWhy": "“Cold cream” is the traditional moisturizing and cleansing cosmetic preparation.",
+      "searchableContext": "cold cream",
+      "phraseExample": "cold cream"
+    },
+    {
+      "clue": "Whipped",
+      "surfaceMisread": "cold desserts and toppings",
+      "resolvedPhraseOrMember": "whipped cream",
+      "nonObviousWhy": "“Whipped cream” is cream beaten until it becomes light and holds air.",
+      "searchableContext": "whipped cream",
+      "phraseExample": "whipped cream"
+    },
+    {
+      "clue": "Shaving",
+      "surfaceMisread": "soft white products",
+      "resolvedPhraseOrMember": "shaving cream",
+      "nonObviousWhy": "“Shaving cream” is the product applied to skin before shaving.",
+      "searchableContext": "shaving cream",
+      "phraseExample": "shaving cream"
+    },
+    {
+      "clue": "Cookies and",
+      "surfaceMisread": "cold desserts and toppings",
+      "resolvedPhraseOrMember": "cookies and cream",
+      "nonObviousWhy": "“Cookies and cream” is the familiar flavor combining cream with pieces of chocolate sandwich cookies.",
+      "searchableContext": "cookies and cream",
+      "phraseExample": "cookies and cream"
+    }
+  ],
+  "faqItems": [
+    {
+      "intentType": "solve_strategy",
+      "question": "How does “Ice” reveal the final category in LinkedIn Pinpoint #799?",
+      "answer": "The exact answer is Words that come before “cream”. “Ice cream” is the frozen dessert made from a sweetened dairy or dairy-like mixture. This reading also matches the connection used by the other four clues.",
+      "tiedClue": "Ice"
+    },
+    {
+      "intentType": "solve_strategy",
+      "question": "How do Ice and Cold connect in Pinpoint #799?",
+      "answer": "Ice resolves as ice cream, while Cold resolves as cold cream. Both support the same final answer.",
+      "tiedClue": "Ice"
+    },
+    {
+      "intentType": "clue_background",
+      "question": "Why is Shaving important in Pinpoint #799?",
+      "answer": "Shaving is decisive because “Shaving cream” is the product applied to skin before shaving. That reading gives a precise check for the other four clues.",
+      "tiedClue": "Shaving"
+    }
+  ],
+  "uniquenessSignals": {
+    "angle": "familiar compounds and a flavor name completed by the word cream",
+    "relatedEntities": [
+      "ice cream",
+      "cold cream",
+      "whipped cream",
+      "shaving cream",
+      "cookies and cream"
+    ],
+    "doNotRepeatPatterns": [
+      "familiar compounds and a flavor name completed by the word cream",
+      "ice cream",
+      "cold cream",
+      "whipped cream",
+      "shaving cream"
+    ]
+  },
+  "wrongGuessCandidates": [
+    {
+      "label": "cold desserts and toppings",
+      "whyPlausible": "Ice, whipped, and cookies and point toward dessert, but cold and shaving introduce non-food compounds.",
+      "whyRejected": "Shaving and the full five-clue check point more precisely to Words that come before “cream”."
+    },
+    {
+      "label": "soft white products",
+      "whyPlausible": "Several answers can look pale or soft, yet the exact repeated feature is the shared ending word in five standard phrases.",
+      "whyRejected": "Shaving and the full five-clue check point more precisely to Words that come before “cream”."
+    }
+  ],
+  "setValidationSummary": "ice cream; cold cream; whipped cream; shaving cream; cookies and cream all support familiar compounds and a flavor name completed by the word cream, so the answer holds across every clue rather than only the opening pair.",
+  "categoryPrecisionNote": "one shared ending word after each clue, not a category limited to food or cosmetics"
+}

--- a/data/puzzles/pinpoint-answer-800.json
+++ b/data/puzzles/pinpoint-answer-800.json
@@ -1,0 +1,219 @@
+{
+  "puzzleNumber": 800,
+  "slug": "pinpoint-answer-800",
+  "publishDate": "2026-07-09",
+  "isoDate": "2026-07-09",
+  "detailState": "fallback_full",
+  "bodyMode": "standard",
+  "pageExperienceMode": "full-analysis",
+  "questionType": "phrase",
+  "difficultyBand": "hard",
+  "clues": [
+    "Spray",
+    "Style",
+    "Dryer",
+    "Raising",
+    "Follicle"
+  ],
+  "answer": "Words that come after “hair”",
+  "category": "Words that come after “hair”",
+  "wordHints": {
+    "Spray": "“Hair spray” is the styling product used to help a hairstyle hold its shape.",
+    "Style": "“Hairstyle” is the standard compound for the way a person’s hair is arranged.",
+    "Dryer": "A “hair dryer” is the electric appliance used to dry and shape hair with blown air.",
+    "Raising": "“Hair-raising” is the familiar adjective for something frightening or thrilling.",
+    "Follicle": "A “hair follicle” is the small skin structure from which a hair grows."
+  },
+  "spoilerHints": {
+    "Spray": "Try reading Spray as part of a familiar phrase in words that come after “hair” instead of as a standalone word.",
+    "Style": "Style works better once you test a fixed phrase pattern rather than a broad topic.",
+    "Dryer": "Look for a natural expression that absorbs Dryer cleanly before locking the board.",
+    "Raising": "Try reading Raising as part of a familiar phrase in words that come after “hair” instead of as a standalone word.",
+    "Follicle": "Follicle is the clue that makes the phrase pattern in words that come after “hair” concrete enough to test."
+  },
+  "articleBlocks": [
+    "The opening pair, Spray and Style, leaves more than one reasonable route. Read without the rest of the board, they can suggest salon products and tools instead of the exact connection. At that stage, none of those first impressions explains Dryer, Raising, and Follicle with the same precision. The useful move is to keep several readings open, wait for the clue that supplies a repeatable test, and then check every earlier clue against that same narrow rule.",
+    "salon products and tools is tempting because Spray, style, and dryer fit a salon, but raising is an adjective and follicle is anatomy rather than grooming equipment. That idea remains incomplete once Dryer is added and the clues need one repeatable explanation.",
+    "A second possibility is parts of personal grooming. Most clues touch hair care, yet the exact construction places hair before every clue to make a known word or phrase. The board therefore needs a narrower rule that can account for every clue without changing direction halfway through.",
+    "Raising is the turning clue. Its clean reading as hair-raising makes compounds and an adjective formed by putting hair before each clue concrete enough to test against the earlier entries.",
+    "hair spray, hairstyle, hair dryer, hair-raising, hair follicle all survive the same check. That full-board agreement rules out the broader first impressions and keeps the solution at one level of specificity.",
+    "The answer is Words that come after “hair”. More precisely, the puzzle resolves as one shared opening word before all five clues, not a list of salon items, which explains why every reveal belongs in the final set."
+  ],
+  "solutionNarrative": [
+    "I began with Spray and Style and tested salon products and tools. It was a fair first read because spray, style, and dryer fit a salon, but raising is an adjective and follicle is anatomy rather than grooming equipment. I kept it provisional rather than forcing the remaining clues into it.",
+    "When Dryer appeared, I also considered parts of personal grooming. That alternative described part of the surface, but it still did not provide one exact rule for Raising and Follicle.",
+    "The decisive step came from Raising. Reading it as hair-raising gave me a precise test, so I went back through hair spray, hairstyle, hair dryer, hair-raising and checked the same relationship each time.",
+    "After all five checks held, I could reject both early guesses. The answer was Words that come after “hair”, with the important distinction that this is one shared opening word before all five clues, not a list of salon items."
+  ],
+  "lessons": [
+    {
+      "title": "Do not lock onto Spray too early",
+      "body": "Spray can support salon products and tools, so wait until another clue supplies a rule that repeats across the entire board."
+    },
+    {
+      "title": "Raising supplies the strongest test",
+      "body": "Once Raising reads as hair-raising, apply that exact relationship to the earlier clues instead of relying on a broad topic match."
+    },
+    {
+      "title": "Pinpoint 800 needs five clean confirmations",
+      "body": "The solution is secure only when hair dryer, hair-raising, hair follicle fit the same rule naturally and do not require separate exceptions."
+    }
+  ],
+  "display": {
+    "connectorSummary": "familiar phrases and everyday terms built with one shared opening word",
+    "fastStrategy": "Spray can support salon products and tools, so wait until another clue supplies a rule that repeats across the entire board.",
+    "clueTableRows": [
+      {
+        "clue": "Spray",
+        "examplePhrase": "hair spray",
+        "connectionExplained": "“Hair spray” is the styling product used to help a hairstyle hold its shape."
+      },
+      {
+        "clue": "Style",
+        "examplePhrase": "hairstyle",
+        "connectionExplained": "“Hairstyle” is the standard compound for the way a person’s hair is arranged."
+      },
+      {
+        "clue": "Dryer",
+        "examplePhrase": "hair dryer",
+        "connectionExplained": "A “hair dryer” is the electric appliance used to dry and shape hair with blown air."
+      },
+      {
+        "clue": "Raising",
+        "examplePhrase": "hair-raising",
+        "connectionExplained": "“Hair-raising” is the familiar adjective for something frightening or thrilling."
+      },
+      {
+        "clue": "Follicle",
+        "examplePhrase": "hair follicle",
+        "connectionExplained": "A “hair follicle” is the small skin structure from which a hair grows."
+      }
+    ]
+  },
+  "faqs": [
+    {
+      "question": "How does “Spray” reveal the final category in LinkedIn Pinpoint #800?",
+      "answer": "The exact answer is Words that come after “hair”. “Hair spray” is the styling product used to help a hairstyle hold its shape. This reading also matches the connection used by the other four clues."
+    },
+    {
+      "question": "How do Spray and Style connect in Pinpoint #800?",
+      "answer": "Spray resolves as hair spray, while Style resolves as hairstyle. Both support the same final answer."
+    },
+    {
+      "question": "Why is Raising important in Pinpoint #800?",
+      "answer": "Raising is decisive because “Hair-raising” is the familiar adjective for something frightening or thrilling. That reading gives a precise check for the other four clues."
+    }
+  ],
+  "solvePath": {
+    "firstRead": "The opening pair, Spray and Style, leaves more than one reasonable route. Read without the rest of the board, they can suggest salon products and tools instead of the exact connection. At that stage, none of those first impressions explains Dryer, Raising, and Follicle with the same precision. The useful move is to keep several readings open, wait for the clue that supplies a repeatable test, and then check every earlier clue against that same narrow rule.",
+    "falseStarts": [
+      "salon products and tools",
+      "parts of personal grooming"
+    ],
+    "whyFalseStartPlausible": [
+      "Spray, style, and dryer fit a salon, but raising is an adjective and follicle is anatomy rather than grooming equipment.",
+      "Most clues touch hair care, yet the exact construction places hair before every clue to make a known word or phrase."
+    ],
+    "breakingClue": "Raising",
+    "pivot": "The decisive step came from Raising. Reading it as hair-raising gave me a precise test, so I went back through hair spray, hairstyle, hair dryer, hair-raising and checked the same relationship each time.",
+    "fullBoardConfirmation": "hair spray, hairstyle, hair dryer, hair-raising, hair follicle all survive the same check. That full-board agreement rules out the broader first impressions and keeps the solution at one level of specificity."
+  },
+  "turningPoint": {
+    "clue": "Raising",
+    "whyDecisive": "Raising resolves cleanly as hair-raising, making compounds and an adjective formed by putting hair before each clue specific enough to test across all five clues.",
+    "whatChangedAfterIt": "After Raising, the earlier clues could be checked through the same precise relationship instead of two broad surface guesses."
+  },
+  "clueRows": [
+    {
+      "clue": "Spray",
+      "surfaceMisread": "salon products and tools",
+      "resolvedPhraseOrMember": "hair spray",
+      "nonObviousWhy": "“Hair spray” is the styling product used to help a hairstyle hold its shape.",
+      "searchableContext": "hair spray",
+      "phraseExample": "hair spray"
+    },
+    {
+      "clue": "Style",
+      "surfaceMisread": "parts of personal grooming",
+      "resolvedPhraseOrMember": "hairstyle",
+      "nonObviousWhy": "“Hairstyle” is the standard compound for the way a person’s hair is arranged.",
+      "searchableContext": "hairstyle",
+      "phraseExample": "hairstyle"
+    },
+    {
+      "clue": "Dryer",
+      "surfaceMisread": "salon products and tools",
+      "resolvedPhraseOrMember": "hair dryer",
+      "nonObviousWhy": "A “hair dryer” is the electric appliance used to dry and shape hair with blown air.",
+      "searchableContext": "hair dryer",
+      "phraseExample": "hair dryer"
+    },
+    {
+      "clue": "Raising",
+      "surfaceMisread": "parts of personal grooming",
+      "resolvedPhraseOrMember": "hair-raising",
+      "nonObviousWhy": "“Hair-raising” is the familiar adjective for something frightening or thrilling.",
+      "searchableContext": "hair-raising",
+      "phraseExample": "hair-raising"
+    },
+    {
+      "clue": "Follicle",
+      "surfaceMisread": "salon products and tools",
+      "resolvedPhraseOrMember": "hair follicle",
+      "nonObviousWhy": "A “hair follicle” is the small skin structure from which a hair grows.",
+      "searchableContext": "hair follicle",
+      "phraseExample": "hair follicle"
+    }
+  ],
+  "faqItems": [
+    {
+      "intentType": "solve_strategy",
+      "question": "How does “Spray” reveal the final category in LinkedIn Pinpoint #800?",
+      "answer": "The exact answer is Words that come after “hair”. “Hair spray” is the styling product used to help a hairstyle hold its shape. This reading also matches the connection used by the other four clues.",
+      "tiedClue": "Spray"
+    },
+    {
+      "intentType": "solve_strategy",
+      "question": "How do Spray and Style connect in Pinpoint #800?",
+      "answer": "Spray resolves as hair spray, while Style resolves as hairstyle. Both support the same final answer.",
+      "tiedClue": "Spray"
+    },
+    {
+      "intentType": "clue_background",
+      "question": "Why is Raising important in Pinpoint #800?",
+      "answer": "Raising is decisive because “Hair-raising” is the familiar adjective for something frightening or thrilling. That reading gives a precise check for the other four clues.",
+      "tiedClue": "Raising"
+    }
+  ],
+  "uniquenessSignals": {
+    "angle": "compounds and an adjective formed by putting hair before each clue",
+    "relatedEntities": [
+      "hair spray",
+      "hairstyle",
+      "hair dryer",
+      "hair-raising",
+      "hair follicle"
+    ],
+    "doNotRepeatPatterns": [
+      "compounds and an adjective formed by putting hair before each clue",
+      "hair spray",
+      "hairstyle",
+      "hair dryer",
+      "hair-raising"
+    ]
+  },
+  "wrongGuessCandidates": [
+    {
+      "label": "salon products and tools",
+      "whyPlausible": "Spray, style, and dryer fit a salon, but raising is an adjective and follicle is anatomy rather than grooming equipment.",
+      "whyRejected": "Raising and the full five-clue check point more precisely to Words that come after “hair”."
+    },
+    {
+      "label": "parts of personal grooming",
+      "whyPlausible": "Most clues touch hair care, yet the exact construction places hair before every clue to make a known word or phrase.",
+      "whyRejected": "Raising and the full five-clue check point more precisely to Words that come after “hair”."
+    }
+  ],
+  "setValidationSummary": "hair spray; hairstyle; hair dryer; hair-raising; hair follicle all support compounds and an adjective formed by putting hair before each clue, so the answer holds across every clue rather than only the opening pair.",
+  "categoryPrecisionNote": "one shared opening word before all five clues, not a list of salon items"
+}

--- a/data/puzzles/pinpoint-answer-801.json
+++ b/data/puzzles/pinpoint-answer-801.json
@@ -1,0 +1,214 @@
+{
+  "puzzleNumber": 801,
+  "slug": "pinpoint-answer-801",
+  "publishDate": "2026-07-10",
+  "isoDate": "2026-07-10",
+  "detailState": "fallback_full",
+  "bodyMode": "standard",
+  "pageExperienceMode": "full-analysis",
+  "questionType": "category",
+  "difficultyBand": "hard",
+  "clues": [
+    "Header",
+    "Gutter",
+    "Bleed",
+    "Column",
+    "Margin"
+  ],
+  "answer": "Terms used in graphic design for page layout",
+  "category": "Terms used in graphic design for page layout",
+  "wordHints": {
+    "Header": "A header is the repeated or prominent area placed at the top of a page or section.",
+    "Gutter": "A gutter is the space between columns or the inner space near a bound page’s fold.",
+    "Bleed": "Bleed is artwork extended beyond the trim edge so printing reaches the finished edge cleanly.",
+    "Column": "A column is a vertical block used to organize text or other page content.",
+    "Margin": "A margin is the planned blank space between page content and the outer edge."
+  },
+  "spoilerHints": {
+    "Header": "Header should be tested as part of terms used in graphic design for page layout, not as a standalone reference.",
+    "Gutter": "Keep Gutter in mind, then see whether Margin supports the same answer.",
+    "Bleed": "Bleed works best after the board narrows toward terms used in graphic design for page layout.",
+    "Column": "Column should be tested as part of terms used in graphic design for page layout, not as a standalone reference.",
+    "Margin": "Margin is the clue that makes terms used in graphic design for page layout concrete enough to test across the full board."
+  },
+  "articleBlocks": [
+    "The opening pair, Header and Gutter, leaves more than one reasonable route. Read without the rest of the board, they can suggest parts of a document instead of the exact connection. At that stage, none of those first impressions explains Bleed, Column, and Margin with the same precision. The useful move is to keep several readings open, wait for the clue that supplies a repeatable test, and then check every earlier clue against that same narrow rule.",
+    "parts of a document is tempting because Every clue can describe a document, but bleed and gutter point specifically to how the page is designed and laid out. That idea remains incomplete once Bleed is added and the clues need one repeatable explanation.",
+    "A second possibility is printing and publishing vocabulary. The terms are common in publishing, yet their shared job is arranging page space rather than covering the whole production process. The board therefore needs a narrower rule that can account for every clue without changing direction halfway through.",
+    "Bleed is the turning clue. Its clean reading as print bleed makes layout vocabulary controlling the structure and printable area of a designed page concrete enough to test against the earlier entries.",
+    "page header, layout gutter, print bleed, text column, page margin all survive the same check. That full-board agreement rules out the broader first impressions and keeps the solution at one level of specificity.",
+    "The answer is Terms used in graphic design for page layout. More precisely, the puzzle resolves as graphic-design page-layout terms rather than document parts or publishing terms broadly, which explains why every reveal belongs in the final set."
+  ],
+  "solutionNarrative": [
+    "I began with Header and Gutter and tested parts of a document. It was a fair first read because every clue can describe a document, but bleed and gutter point specifically to how the page is designed and laid out. I kept it provisional rather than forcing the remaining clues into it.",
+    "When Bleed appeared, I also considered printing and publishing vocabulary. That alternative described part of the surface, but it still did not provide one exact rule for Column and Margin.",
+    "The decisive step came from Bleed. Reading it as print bleed gave me a precise test, so I went back through page header, layout gutter, print bleed, text column and checked the same relationship each time.",
+    "After all five checks held, I could reject both early guesses. The answer was Terms used in graphic design for page layout, with the important distinction that this is graphic-design page-layout terms rather than document parts or publishing terms broadly."
+  ],
+  "lessons": [
+    {
+      "title": "Do not lock onto Header too early",
+      "body": "Header can support parts of a document, so wait until another clue supplies a rule that repeats across the entire board."
+    },
+    {
+      "title": "Bleed supplies the strongest test",
+      "body": "Once Bleed reads as print bleed, apply that exact relationship to the earlier clues instead of relying on a broad topic match."
+    },
+    {
+      "title": "Pinpoint 801 needs five clean confirmations",
+      "body": "The solution is secure only when print bleed, text column, page margin fit the same rule naturally and do not require separate exceptions."
+    }
+  ],
+  "display": {
+    "connectorSummary": "a category board focused on terms",
+    "fastStrategy": "Header can support parts of a document, so wait until another clue supplies a rule that repeats across the entire board.",
+    "clueTableRows": [
+      {
+        "clue": "Header",
+        "examplePhrase": "page header",
+        "connectionExplained": "A header is the repeated or prominent area placed at the top of a page or section."
+      },
+      {
+        "clue": "Gutter",
+        "examplePhrase": "layout gutter",
+        "connectionExplained": "A gutter is the space between columns or the inner space near a bound page’s fold."
+      },
+      {
+        "clue": "Bleed",
+        "examplePhrase": "print bleed",
+        "connectionExplained": "Bleed is artwork extended beyond the trim edge so printing reaches the finished edge cleanly."
+      },
+      {
+        "clue": "Column",
+        "examplePhrase": "text column",
+        "connectionExplained": "A column is a vertical block used to organize text or other page content."
+      },
+      {
+        "clue": "Margin",
+        "examplePhrase": "page margin",
+        "connectionExplained": "A margin is the planned blank space between page content and the outer edge."
+      }
+    ]
+  },
+  "faqs": [
+    {
+      "question": "How does “Header” reveal the final category in LinkedIn Pinpoint #801?",
+      "answer": "The exact answer is Terms used in graphic design for page layout. A header is the repeated or prominent area placed at the top of a page or section. This reading also matches the connection used by the other four clues."
+    },
+    {
+      "question": "How do Header and Gutter connect in Pinpoint #801?",
+      "answer": "Header resolves as page header, while Gutter resolves as layout gutter. Both support the same final answer."
+    },
+    {
+      "question": "Why is Bleed important in Pinpoint #801?",
+      "answer": "Bleed is decisive because Bleed is artwork extended beyond the trim edge so printing reaches the finished edge cleanly. That reading gives a precise check for the other four clues."
+    }
+  ],
+  "solvePath": {
+    "firstRead": "The opening pair, Header and Gutter, leaves more than one reasonable route. Read without the rest of the board, they can suggest parts of a document instead of the exact connection. At that stage, none of those first impressions explains Bleed, Column, and Margin with the same precision. The useful move is to keep several readings open, wait for the clue that supplies a repeatable test, and then check every earlier clue against that same narrow rule.",
+    "falseStarts": [
+      "parts of a document",
+      "printing and publishing vocabulary"
+    ],
+    "whyFalseStartPlausible": [
+      "Every clue can describe a document, but bleed and gutter point specifically to how the page is designed and laid out.",
+      "The terms are common in publishing, yet their shared job is arranging page space rather than covering the whole production process."
+    ],
+    "breakingClue": "Bleed",
+    "pivot": "The decisive step came from Bleed. Reading it as print bleed gave me a precise test, so I went back through page header, layout gutter, print bleed, text column and checked the same relationship each time.",
+    "fullBoardConfirmation": "page header, layout gutter, print bleed, text column, page margin all survive the same check. That full-board agreement rules out the broader first impressions and keeps the solution at one level of specificity."
+  },
+  "turningPoint": {
+    "clue": "Bleed",
+    "whyDecisive": "Bleed resolves cleanly as print bleed, making layout vocabulary controlling the structure and printable area of a designed page specific enough to test across all five clues.",
+    "whatChangedAfterIt": "After Bleed, the earlier clues could be checked through the same precise relationship instead of two broad surface guesses."
+  },
+  "clueRows": [
+    {
+      "clue": "Header",
+      "surfaceMisread": "parts of a document",
+      "resolvedPhraseOrMember": "page header",
+      "nonObviousWhy": "A header is the repeated or prominent area placed at the top of a page or section.",
+      "searchableContext": "page header"
+    },
+    {
+      "clue": "Gutter",
+      "surfaceMisread": "printing and publishing vocabulary",
+      "resolvedPhraseOrMember": "layout gutter",
+      "nonObviousWhy": "A gutter is the space between columns or the inner space near a bound page’s fold.",
+      "searchableContext": "layout gutter"
+    },
+    {
+      "clue": "Bleed",
+      "surfaceMisread": "parts of a document",
+      "resolvedPhraseOrMember": "print bleed",
+      "nonObviousWhy": "Bleed is artwork extended beyond the trim edge so printing reaches the finished edge cleanly.",
+      "searchableContext": "print bleed"
+    },
+    {
+      "clue": "Column",
+      "surfaceMisread": "printing and publishing vocabulary",
+      "resolvedPhraseOrMember": "text column",
+      "nonObviousWhy": "A column is a vertical block used to organize text or other page content.",
+      "searchableContext": "text column"
+    },
+    {
+      "clue": "Margin",
+      "surfaceMisread": "parts of a document",
+      "resolvedPhraseOrMember": "page margin",
+      "nonObviousWhy": "A margin is the planned blank space between page content and the outer edge.",
+      "searchableContext": "page margin"
+    }
+  ],
+  "faqItems": [
+    {
+      "intentType": "solve_strategy",
+      "question": "How does “Header” reveal the final category in LinkedIn Pinpoint #801?",
+      "answer": "The exact answer is Terms used in graphic design for page layout. A header is the repeated or prominent area placed at the top of a page or section. This reading also matches the connection used by the other four clues.",
+      "tiedClue": "Header"
+    },
+    {
+      "intentType": "solve_strategy",
+      "question": "How do Header and Gutter connect in Pinpoint #801?",
+      "answer": "Header resolves as page header, while Gutter resolves as layout gutter. Both support the same final answer.",
+      "tiedClue": "Header"
+    },
+    {
+      "intentType": "clue_background",
+      "question": "Why is Bleed important in Pinpoint #801?",
+      "answer": "Bleed is decisive because Bleed is artwork extended beyond the trim edge so printing reaches the finished edge cleanly. That reading gives a precise check for the other four clues.",
+      "tiedClue": "Bleed"
+    }
+  ],
+  "uniquenessSignals": {
+    "angle": "layout vocabulary controlling the structure and printable area of a designed page",
+    "relatedEntities": [
+      "page header",
+      "layout gutter",
+      "print bleed",
+      "text column",
+      "page margin"
+    ],
+    "doNotRepeatPatterns": [
+      "layout vocabulary controlling the structure and printable area of a designed page",
+      "page header",
+      "layout gutter",
+      "print bleed",
+      "text column"
+    ]
+  },
+  "wrongGuessCandidates": [
+    {
+      "label": "parts of a document",
+      "whyPlausible": "Every clue can describe a document, but bleed and gutter point specifically to how the page is designed and laid out.",
+      "whyRejected": "Bleed and the full five-clue check point more precisely to Terms used in graphic design for page layout."
+    },
+    {
+      "label": "printing and publishing vocabulary",
+      "whyPlausible": "The terms are common in publishing, yet their shared job is arranging page space rather than covering the whole production process.",
+      "whyRejected": "Bleed and the full five-clue check point more precisely to Terms used in graphic design for page layout."
+    }
+  ],
+  "setValidationSummary": "page header; layout gutter; print bleed; text column; page margin all support layout vocabulary controlling the structure and printable area of a designed page, so the answer holds across every clue rather than only the opening pair.",
+  "categoryPrecisionNote": "graphic-design page-layout terms rather than document parts or publishing terms broadly"
+}

--- a/data/puzzles/pinpoint-answer-802.json
+++ b/data/puzzles/pinpoint-answer-802.json
@@ -1,0 +1,214 @@
+{
+  "puzzleNumber": 802,
+  "slug": "pinpoint-answer-802",
+  "publishDate": "2026-07-11",
+  "isoDate": "2026-07-11",
+  "detailState": "fallback_full",
+  "bodyMode": "standard",
+  "pageExperienceMode": "full-analysis",
+  "questionType": "category",
+  "difficultyBand": "hard",
+  "clues": [
+    "Grave",
+    "Presto",
+    "Adagio",
+    "Andante",
+    "Allegro (120+ beats per minute)"
+  ],
+  "answer": "Musical tempos",
+  "category": "Musical tempos",
+  "wordHints": {
+    "Grave": "Grave is a musical tempo marking for a very slow and solemn manner.",
+    "Presto": "Presto is a tempo marking directing music to be played very fast.",
+    "Adagio": "Adagio indicates a slow tempo and a relaxed, measured pace.",
+    "Andante": "Andante indicates a moderate walking pace in musical performance.",
+    "Allegro (120+ beats per minute)": "Allegro is a fast, lively tempo, and the clue’s beat-rate note makes the speed meaning explicit."
+  },
+  "spoilerHints": {
+    "Grave": "Grave should be tested as part of musical tempos, not as a standalone reference.",
+    "Presto": "Keep Presto in mind, then see whether Allegro (120+ beats per minute) supports the same answer.",
+    "Adagio": "Adagio works best after the board narrows toward musical tempos.",
+    "Andante": "Andante should be tested as part of musical tempos, not as a standalone reference.",
+    "Allegro (120+ beats per minute)": "Allegro (120+ beats per minute) is the clue that makes musical tempos concrete enough to test across the full board."
+  },
+  "articleBlocks": [
+    "The opening pair, Grave and Presto, leaves more than one reasonable route. Read without the rest of the board, they can suggest Italian words used in music instead of the exact connection. At that stage, none of those first impressions explains Adagio, Andante, and Allegro (120+ beats per minute) with the same precision. The useful move is to keep several readings open, wait for the clue that supplies a repeatable test, and then check every earlier clue against that same narrow rule.",
+    "Italian words used in music is tempting because The terms are Italian and appear in music, but the exact relationship is that each one specifies performance speed. That idea remains incomplete once Adagio is added and the clues need one repeatable explanation.",
+    "A second possibility is labels for different performance moods. Some markings also suggest character or mood, yet all five are standard tempo names arranged by pace. The board therefore needs a narrower rule that can account for every clue without changing direction halfway through.",
+    "Allegro (120+ beats per minute) is the turning clue. Its clean reading as allegro tempo makes standard music markings telling performers how fast a passage should be played concrete enough to test against the earlier entries.",
+    "grave tempo, presto tempo, adagio tempo, andante tempo, allegro tempo all survive the same check. That full-board agreement rules out the broader first impressions and keeps the solution at one level of specificity.",
+    "The answer is Musical tempos. More precisely, the puzzle resolves as named musical tempo markings rather than Italian music vocabulary generally, which explains why every reveal belongs in the final set."
+  ],
+  "solutionNarrative": [
+    "I began with Grave and Presto and tested Italian words used in music. It was a fair first read because the terms are Italian and appear in music, but the exact relationship is that each one specifies performance speed. I kept it provisional rather than forcing the remaining clues into it.",
+    "When Adagio appeared, I also considered labels for different performance moods. That alternative described part of the surface, but it still did not provide one exact rule for Andante and Allegro (120+ beats per minute).",
+    "The decisive step came from Allegro (120+ beats per minute). Reading it as allegro tempo gave me a precise test, so I went back through grave tempo, presto tempo, adagio tempo, andante tempo and checked the same relationship each time.",
+    "After all five checks held, I could reject both early guesses. The answer was Musical tempos, with the important distinction that this is named musical tempo markings rather than Italian music vocabulary generally."
+  ],
+  "lessons": [
+    {
+      "title": "Do not lock onto Grave too early",
+      "body": "Grave can support Italian words used in music, so wait until another clue supplies a rule that repeats across the entire board."
+    },
+    {
+      "title": "Allegro (120+ beats per minute) supplies the strongest test",
+      "body": "Once Allegro (120+ beats per minute) reads as allegro tempo, apply that exact relationship to the earlier clues instead of relying on a broad topic match."
+    },
+    {
+      "title": "Pinpoint 802 needs five clean confirmations",
+      "body": "The solution is secure only when adagio tempo, andante tempo, allegro tempo fit the same rule naturally and do not require separate exceptions."
+    }
+  ],
+  "display": {
+    "connectorSummary": "a category board focused on musical",
+    "fastStrategy": "Grave can support Italian words used in music, so wait until another clue supplies a rule that repeats across the entire board.",
+    "clueTableRows": [
+      {
+        "clue": "Grave",
+        "examplePhrase": "grave tempo",
+        "connectionExplained": "Grave is a musical tempo marking for a very slow and solemn manner."
+      },
+      {
+        "clue": "Presto",
+        "examplePhrase": "presto tempo",
+        "connectionExplained": "Presto is a tempo marking directing music to be played very fast."
+      },
+      {
+        "clue": "Adagio",
+        "examplePhrase": "adagio tempo",
+        "connectionExplained": "Adagio indicates a slow tempo and a relaxed, measured pace."
+      },
+      {
+        "clue": "Andante",
+        "examplePhrase": "andante tempo",
+        "connectionExplained": "Andante indicates a moderate walking pace in musical performance."
+      },
+      {
+        "clue": "Allegro (120+ beats per minute)",
+        "examplePhrase": "allegro tempo",
+        "connectionExplained": "Allegro is a fast, lively tempo, and the clue’s beat-rate note makes the speed meaning explicit."
+      }
+    ]
+  },
+  "faqs": [
+    {
+      "question": "How does “Grave” reveal the final category in LinkedIn Pinpoint #802?",
+      "answer": "The exact answer is Musical tempos. Grave is a musical tempo marking for a very slow and solemn manner. This reading also matches the connection used by the other four clues."
+    },
+    {
+      "question": "How do Grave and Presto connect in Pinpoint #802?",
+      "answer": "Grave resolves as grave tempo, while Presto resolves as presto tempo. Both support the same final answer."
+    },
+    {
+      "question": "Why is Allegro (120+ beats per minute) important in Pinpoint #802?",
+      "answer": "Allegro (120+ beats per minute) is decisive because Allegro is a fast, lively tempo, and the clue’s beat-rate note makes the speed meaning explicit. That reading gives a precise check for the other four clues."
+    }
+  ],
+  "solvePath": {
+    "firstRead": "The opening pair, Grave and Presto, leaves more than one reasonable route. Read without the rest of the board, they can suggest Italian words used in music instead of the exact connection. At that stage, none of those first impressions explains Adagio, Andante, and Allegro (120+ beats per minute) with the same precision. The useful move is to keep several readings open, wait for the clue that supplies a repeatable test, and then check every earlier clue against that same narrow rule.",
+    "falseStarts": [
+      "Italian words used in music",
+      "labels for different performance moods"
+    ],
+    "whyFalseStartPlausible": [
+      "The terms are Italian and appear in music, but the exact relationship is that each one specifies performance speed.",
+      "Some markings also suggest character or mood, yet all five are standard tempo names arranged by pace."
+    ],
+    "breakingClue": "Allegro (120+ beats per minute)",
+    "pivot": "The decisive step came from Allegro (120+ beats per minute). Reading it as allegro tempo gave me a precise test, so I went back through grave tempo, presto tempo, adagio tempo, andante tempo and checked the same relationship each time.",
+    "fullBoardConfirmation": "grave tempo, presto tempo, adagio tempo, andante tempo, allegro tempo all survive the same check. That full-board agreement rules out the broader first impressions and keeps the solution at one level of specificity."
+  },
+  "turningPoint": {
+    "clue": "Allegro (120+ beats per minute)",
+    "whyDecisive": "Allegro (120+ beats per minute) resolves cleanly as allegro tempo, making standard music markings telling performers how fast a passage should be played specific enough to test across all five clues.",
+    "whatChangedAfterIt": "After Allegro (120+ beats per minute), the earlier clues could be checked through the same precise relationship instead of two broad surface guesses."
+  },
+  "clueRows": [
+    {
+      "clue": "Grave",
+      "surfaceMisread": "Italian words used in music",
+      "resolvedPhraseOrMember": "grave tempo",
+      "nonObviousWhy": "Grave is a musical tempo marking for a very slow and solemn manner.",
+      "searchableContext": "grave tempo"
+    },
+    {
+      "clue": "Presto",
+      "surfaceMisread": "labels for different performance moods",
+      "resolvedPhraseOrMember": "presto tempo",
+      "nonObviousWhy": "Presto is a tempo marking directing music to be played very fast.",
+      "searchableContext": "presto tempo"
+    },
+    {
+      "clue": "Adagio",
+      "surfaceMisread": "Italian words used in music",
+      "resolvedPhraseOrMember": "adagio tempo",
+      "nonObviousWhy": "Adagio indicates a slow tempo and a relaxed, measured pace.",
+      "searchableContext": "adagio tempo"
+    },
+    {
+      "clue": "Andante",
+      "surfaceMisread": "labels for different performance moods",
+      "resolvedPhraseOrMember": "andante tempo",
+      "nonObviousWhy": "Andante indicates a moderate walking pace in musical performance.",
+      "searchableContext": "andante tempo"
+    },
+    {
+      "clue": "Allegro (120+ beats per minute)",
+      "surfaceMisread": "Italian words used in music",
+      "resolvedPhraseOrMember": "allegro tempo",
+      "nonObviousWhy": "Allegro is a fast, lively tempo, and the clue’s beat-rate note makes the speed meaning explicit.",
+      "searchableContext": "allegro tempo"
+    }
+  ],
+  "faqItems": [
+    {
+      "intentType": "solve_strategy",
+      "question": "How does “Grave” reveal the final category in LinkedIn Pinpoint #802?",
+      "answer": "The exact answer is Musical tempos. Grave is a musical tempo marking for a very slow and solemn manner. This reading also matches the connection used by the other four clues.",
+      "tiedClue": "Grave"
+    },
+    {
+      "intentType": "solve_strategy",
+      "question": "How do Grave and Presto connect in Pinpoint #802?",
+      "answer": "Grave resolves as grave tempo, while Presto resolves as presto tempo. Both support the same final answer.",
+      "tiedClue": "Grave"
+    },
+    {
+      "intentType": "clue_background",
+      "question": "Why is Allegro (120+ beats per minute) important in Pinpoint #802?",
+      "answer": "Allegro (120+ beats per minute) is decisive because Allegro is a fast, lively tempo, and the clue’s beat-rate note makes the speed meaning explicit. That reading gives a precise check for the other four clues.",
+      "tiedClue": "Allegro (120+ beats per minute)"
+    }
+  ],
+  "uniquenessSignals": {
+    "angle": "standard music markings telling performers how fast a passage should be played",
+    "relatedEntities": [
+      "grave tempo",
+      "presto tempo",
+      "adagio tempo",
+      "andante tempo",
+      "allegro tempo"
+    ],
+    "doNotRepeatPatterns": [
+      "standard music markings telling performers how fast a passage should be played",
+      "grave tempo",
+      "presto tempo",
+      "adagio tempo",
+      "andante tempo"
+    ]
+  },
+  "wrongGuessCandidates": [
+    {
+      "label": "Italian words used in music",
+      "whyPlausible": "The terms are Italian and appear in music, but the exact relationship is that each one specifies performance speed.",
+      "whyRejected": "Allegro (120+ beats per minute) and the full five-clue check point more precisely to Musical tempos."
+    },
+    {
+      "label": "labels for different performance moods",
+      "whyPlausible": "Some markings also suggest character or mood, yet all five are standard tempo names arranged by pace.",
+      "whyRejected": "Allegro (120+ beats per minute) and the full five-clue check point more precisely to Musical tempos."
+    }
+  ],
+  "setValidationSummary": "grave tempo; presto tempo; adagio tempo; andante tempo; allegro tempo all support standard music markings telling performers how fast a passage should be played, so the answer holds across every clue rather than only the opening pair.",
+  "categoryPrecisionNote": "named musical tempo markings rather than Italian music vocabulary generally"
+}

--- a/data/puzzles/registry.json
+++ b/data/puzzles/registry.json
@@ -1,9 +1,294 @@
 [
   {
+    "puzzleNumber": 802,
+    "slug": "pinpoint-answer-802",
+    "publishDate": "2026-07-11",
+    "status": "live",
+    "detailState": "fallback_full",
+    "clues": [
+      "Grave",
+      "Presto",
+      "Adagio",
+      "Andante",
+      "Allegro (120+ beats per minute)"
+    ],
+    "mainAnswer": "Musical tempos",
+    "category": "Musical tempos",
+    "difficultyLevel": "Moderate",
+    "shortSummary": "LinkedIn Pinpoint #802: Grave, Presto, Adagio, Andante, Allegro (120+ beats per minute). Spoiler-safe hints and the full walkthrough are inside.",
+    "updatedAt": "2026-07-11T08:56:55.561Z"
+  },
+  {
+    "puzzleNumber": 801,
+    "slug": "pinpoint-answer-801",
+    "publishDate": "2026-07-10",
+    "status": "archived",
+    "detailState": "fallback_full",
+    "clues": [
+      "Header",
+      "Gutter",
+      "Bleed",
+      "Column",
+      "Margin"
+    ],
+    "mainAnswer": "Terms used in graphic design for page layout",
+    "category": "Terms used in graphic design for page layout",
+    "difficultyLevel": "Moderate",
+    "shortSummary": "LinkedIn Pinpoint #801: Header, Gutter, Bleed, Column, Margin. Spoiler-safe hints and the full walkthrough are inside.",
+    "updatedAt": "2026-07-11T08:56:55.561Z"
+  },
+  {
+    "puzzleNumber": 800,
+    "slug": "pinpoint-answer-800",
+    "publishDate": "2026-07-09",
+    "status": "archived",
+    "detailState": "fallback_full",
+    "clues": [
+      "Spray",
+      "Style",
+      "Dryer",
+      "Raising",
+      "Follicle"
+    ],
+    "mainAnswer": "Words that come after “hair”",
+    "category": "Words that come after “hair”",
+    "difficultyLevel": "Moderate",
+    "shortSummary": "LinkedIn Pinpoint #800: Spray, Style, Dryer, Raising, Follicle. Spoiler-safe hints and the full walkthrough are inside.",
+    "updatedAt": "2026-07-11T08:56:55.561Z"
+  },
+  {
+    "puzzleNumber": 799,
+    "slug": "pinpoint-answer-799",
+    "publishDate": "2026-07-08",
+    "status": "archived",
+    "detailState": "fallback_full",
+    "clues": [
+      "Ice",
+      "Cold",
+      "Whipped",
+      "Shaving",
+      "Cookies and"
+    ],
+    "mainAnswer": "Words that come before “cream”",
+    "category": "Words that come before “cream”",
+    "difficultyLevel": "Moderate",
+    "shortSummary": "LinkedIn Pinpoint #799: Ice, Cold, Whipped, Shaving, Cookies and. Spoiler-safe hints and the full walkthrough are inside.",
+    "updatedAt": "2026-07-11T08:56:55.561Z"
+  },
+  {
+    "puzzleNumber": 798,
+    "slug": "pinpoint-answer-798",
+    "publishDate": "2026-07-07",
+    "status": "archived",
+    "detailState": "fallback_full",
+    "clues": [
+      "Library",
+      "Auditorium",
+      "Playground",
+      "Science lab",
+      "Classroom"
+    ],
+    "mainAnswer": "Places at a school",
+    "category": "Places at a school",
+    "difficultyLevel": "Moderate",
+    "shortSummary": "LinkedIn Pinpoint #798: Library, Auditorium, Playground, Science lab, Classroom. Spoiler-safe hints and the full walkthrough are inside.",
+    "updatedAt": "2026-07-11T08:56:55.561Z"
+  },
+  {
+    "puzzleNumber": 797,
+    "slug": "pinpoint-answer-797",
+    "publishDate": "2026-07-06",
+    "status": "archived",
+    "detailState": "fallback_full",
+    "clues": [
+      "Avianca",
+      "El Al",
+      "Qantas",
+      "Lufthansa",
+      "Aeroméxico"
+    ],
+    "mainAnswer": "National airlines (flag carriers)",
+    "category": "National airlines (flag carriers)",
+    "difficultyLevel": "Moderate",
+    "shortSummary": "LinkedIn Pinpoint #797: Avianca, El Al, Qantas, Lufthansa, Aeroméxico. Spoiler-safe hints and the full walkthrough are inside.",
+    "updatedAt": "2026-07-11T08:56:55.561Z"
+  },
+  {
+    "puzzleNumber": 796,
+    "slug": "pinpoint-answer-796",
+    "publishDate": "2026-07-05",
+    "status": "archived",
+    "detailState": "fallback_full",
+    "clues": [
+      "A rapid pace",
+      "Hit at an angle",
+      "Small metal fastener for paper",
+      "Cut with scissors",
+      "Short segment of a film"
+    ],
+    "mainAnswer": "Different meanings of “clip”",
+    "category": "Different meanings of “clip”",
+    "difficultyLevel": "Moderate",
+    "shortSummary": "LinkedIn Pinpoint #796: A rapid pace, Hit at an angle, Small metal fastener for paper, Cut with scissors, Short segment of a film. Spoiler-safe hints and the full walkthrough are inside.",
+    "updatedAt": "2026-07-11T08:56:55.561Z"
+  },
+  {
+    "puzzleNumber": 795,
+    "slug": "pinpoint-answer-795",
+    "publishDate": "2026-07-04",
+    "status": "archived",
+    "detailState": "fallback_full",
+    "clues": [
+      "Front",
+      "Kingdom",
+      "Nations",
+      "States (🎆 Happy 250th! 🎇)",
+      "We stand, divided we fall"
+    ],
+    "mainAnswer": "Words that come after “united”",
+    "category": "Words that come after “united”",
+    "difficultyLevel": "Moderate",
+    "shortSummary": "LinkedIn Pinpoint #795: Front, Kingdom, Nations, States (🎆 Happy 250th! 🎇), We stand, divided we fall. Spoiler-safe hints and the full walkthrough are inside.",
+    "updatedAt": "2026-07-11T08:56:55.561Z"
+  },
+  {
+    "puzzleNumber": 794,
+    "slug": "pinpoint-answer-794",
+    "publishDate": "2026-07-03",
+    "status": "archived",
+    "detailState": "fallback_full",
+    "clues": [
+      "AA",
+      "AAA",
+      "9V",
+      "Alkaline",
+      "Lithium-ion (rechargeable)"
+    ],
+    "mainAnswer": "Terms used to describe batteries",
+    "category": "Terms used to describe batteries",
+    "difficultyLevel": "Moderate",
+    "shortSummary": "LinkedIn Pinpoint #794: AA, AAA, 9V, Alkaline, Lithium-ion (rechargeable). Spoiler-safe hints and the full walkthrough are inside.",
+    "updatedAt": "2026-07-11T08:56:55.561Z"
+  },
+  {
+    "puzzleNumber": 793,
+    "slug": "pinpoint-answer-793",
+    "publishDate": "2026-07-02",
+    "status": "archived",
+    "detailState": "fallback_full",
+    "clues": [
+      "Supreme",
+      "Food",
+      "Tennis",
+      "Contempt of",
+      "The ball is in your"
+    ],
+    "mainAnswer": "Words that come before “court”",
+    "category": "Words that come before “court”",
+    "difficultyLevel": "Moderate",
+    "shortSummary": "LinkedIn Pinpoint #793: Supreme, Food, Tennis, Contempt of, The ball is in your. Spoiler-safe hints and the full walkthrough are inside.",
+    "updatedAt": "2026-07-11T08:56:55.561Z"
+  },
+  {
+    "puzzleNumber": 792,
+    "slug": "pinpoint-answer-792",
+    "publishDate": "2026-07-01",
+    "status": "archived",
+    "detailState": "fallback_full",
+    "clues": [
+      "Pronunciation",
+      "Etymology",
+      "Part of speech",
+      "Example sentence",
+      "Definition"
+    ],
+    "mainAnswer": "Parts of a dictionary entry",
+    "category": "Parts of a dictionary entry",
+    "difficultyLevel": "Moderate",
+    "shortSummary": "LinkedIn Pinpoint #792: Pronunciation, Etymology, Part of speech, Example sentence, Definition. Spoiler-safe hints and the full walkthrough are inside.",
+    "updatedAt": "2026-07-11T08:56:55.561Z"
+  },
+  {
+    "puzzleNumber": 791,
+    "slug": "pinpoint-answer-791",
+    "publishDate": "2026-06-30",
+    "status": "archived",
+    "detailState": "fallback_full",
+    "clues": [
+      "Lantern",
+      "Sleeping bag",
+      "Portable stove",
+      "Water filter",
+      "Tent"
+    ],
+    "mainAnswer": "Things brought on a camping trip",
+    "category": "Things brought on a camping trip",
+    "difficultyLevel": "Moderate",
+    "shortSummary": "LinkedIn Pinpoint #791: Lantern, Sleeping bag, Portable stove, Water filter, Tent. Spoiler-safe hints and the full walkthrough are inside.",
+    "updatedAt": "2026-07-11T08:56:55.561Z"
+  },
+  {
+    "puzzleNumber": 790,
+    "slug": "pinpoint-answer-790",
+    "publishDate": "2026-06-29",
+    "status": "archived",
+    "detailState": "fallback_full",
+    "clues": [
+      "Sink",
+      "Pan",
+      "Whisk",
+      "Fridge",
+      "Oven"
+    ],
+    "mainAnswer": "Things found in a kitchen",
+    "category": "Things found in a kitchen",
+    "difficultyLevel": "Moderate",
+    "shortSummary": "LinkedIn Pinpoint #790: Sink, Pan, Whisk, Fridge, Oven. Spoiler-safe hints and the full walkthrough are inside.",
+    "updatedAt": "2026-07-11T08:56:55.561Z"
+  },
+  {
+    "puzzleNumber": 789,
+    "slug": "pinpoint-answer-789",
+    "publishDate": "2026-06-28",
+    "status": "archived",
+    "detailState": "fallback_full",
+    "clues": [
+      "Face",
+      "Your breath",
+      "The day",
+      "Someone's skin",
+      "For a rainy day"
+    ],
+    "mainAnswer": "Words that come after “save”",
+    "category": "Words that come after “save”",
+    "difficultyLevel": "Moderate",
+    "shortSummary": "LinkedIn Pinpoint #789: Face, Your breath, The day, Someone's skin, For a rainy day. Spoiler-safe hints and the full walkthrough are inside.",
+    "updatedAt": "2026-07-11T08:56:55.561Z"
+  },
+  {
+    "puzzleNumber": 788,
+    "slug": "pinpoint-answer-788",
+    "publishDate": "2026-06-27",
+    "status": "archived",
+    "detailState": "fallback_full",
+    "clues": [
+      "Go (🇯🇵)",
+      "Lima (🇵🇭)",
+      "Fünf (🇩🇪)",
+      "Cinq (🇫🇷)",
+      "Cinco (this one's Spanish: 🇪🇸)"
+    ],
+    "mainAnswer": "The number “five” in different languages (Japanese, Tagalog, German, French, Spanish)",
+    "category": "The number “five” in different languages (Japanese, Tagalog, German, French, Spanish)",
+    "difficultyLevel": "Moderate",
+    "shortSummary": "LinkedIn Pinpoint #788: Go (🇯🇵), Lima (🇵🇭), Fünf (🇩🇪), Cinq (🇫🇷), Cinco (this one's Spanish: 🇪🇸). Spoiler-safe hints and the full walkthrough are inside.",
+    "updatedAt": "2026-07-11T08:56:55.561Z"
+  },
+  {
     "puzzleNumber": 787,
     "slug": "pinpoint-answer-787",
     "publishDate": "2026-06-26",
-    "status": "live",
+    "status": "archived",
     "detailState": "fallback_full",
     "clues": [
       "Wheat",


### PR DESCRIPTION
## What changed

- add verified puzzle detail data for Pinpoint #788 through #802
- update the registry so #788-#801 are archived and #802 is live
- restore continuous daily coverage from 2026-06-27 through 2026-07-11

## Why

Auto-publish remained paused after the #787 post-publish audit, leaving production stuck on 2026-06-26. This data-only backfill closes the missing range before auto-publish is resumed.

## Validation

- `npm run validate:data` (345 records)
- `npm run test:pinpoint-guardrails`
- `npm run typecheck`
- `npm run build` (370 static pages)
- verified #788-#802 HTML output and sitemap entries

No homepage SEO metadata, routes, sitemap rules, Worker code, or unrelated files are changed.
