### PR TITLE
Prevent false unpublished diagnosis

### DIFF
--- a/docs/ITERATION.md
+++ b/docs/ITERATION.md
@@ -202,8 +202,8 @@
 问题：`#806` 已在 15:10 写入候选分支并在 15:12 进入 `main`，但 Vercel 只创建 Preview，没有创建 Production；旧脚本只看同一提交上的 `Vercel=success`，把 Preview 成功误当成正式部署成功。
 证据：截至 15:54，正式站 summary 仍是 `#805`，`#806` 返回 `404` 且不在 sitemap；GitHub deployment 只有 `environment=Preview`，最新 Vercel Production 仍是 7 月 14 日。
 本轮边界：只修候选分支到 Production 的最后闭环和 Worker 部署状态判断，不改首页 SEO、题目内容、Cookie、AI 模型和 URL 规则。
-修改：候选提升改为生成唯一的 `main` 提交；部署验证改查 exact SHA 的 GitHub Deployment，并要求 `environment=Production`；Preview 成功不再算正式部署；Production 三分钟内完全没出现时，只允许提交一次构建触发标记；正式页审计通过后才删除候选分支；Worker 和只读诊断命令同步改用 Production deployment 判断。
-验证：`validate:data`（349 条）、Pinpoint 守卫、根目录和 Worker 类型检查、lint、完整构建已通过；GitHub Actions、Vercel Production 和线上首页/详情页/sitemap 待本次合并后复查。
+修改：候选提升改为生成唯一的 `main` 提交；部署验证改查 exact SHA 的 GitHub Deployment，并要求 `environment=Production`；Preview 成功不再算正式部署；Production 三分钟内完全没出现时，只允许提交一次构建触发标记；正式页审计通过后才删除候选分支；Worker 和只读诊断命令同步改用 Production deployment 判断；正式站 summary 已是当天时，不再被 Cron 接口的临时读取失败误报成未发布。
+验证：`validate:data`（349 条）、Pinpoint 守卫、根目录和 Worker 类型检查、lint、完整构建、PR #132 GitHub Actions 已通过。`main` 提交 `11aad7f` 的 GitHub Deployment 是 `Production` 且状态为 `success`；正式站 summary 已是 `#806`，详情页 HTTP 200，sitemap 包含 `#806`，公开审计结果为 `published_and_audit_passed`。生产 Worker 版本 `34eb2f8e-0fda-49d6-bc45-0a5909dc72c4` 已部署，并返回 `productionDeploymentFound=true`、`deploymentState=ready`；候选分支数已回到 0。
 未做：未处理 AI 在 15:01、15:05 的超时；未恢复不依赖 AI 的快速发布路径。
 复查日期：本次合并部署后立即复查，下一次 15:00 发布窗口再复查一次。
-下一步：先证明 `#806` 对应的 Production 部署和线上页面真实恢复，再单独处理 AI 超时造成的前九分钟延迟。
+下一步：在下一次 15:00 发布窗口复查这套闭环，再单独处理 AI 超时造成的前九分钟延迟。

--- a/scripts/check-pinpoint-guardrails.ts
+++ b/scripts/check-pinpoint-guardrails.ts
@@ -3217,6 +3217,11 @@ async function checkReleaseQueueObservationOpsScript() {
   const packageJson = JSON.parse(await readFile(resolve(ROOT, "package.json"), "utf8")) as {
     scripts?: Record<string, string>;
   };
+  const diagnosisStart = opsSource.indexOf("function buildPublishWindowDiagnosis");
+  const diagnosisEnd = opsSource.indexOf("function getReleaseQueueDryRunScenarios", diagnosisStart);
+  const diagnosisSource = diagnosisStart >= 0 && diagnosisEnd > diagnosisStart
+    ? opsSource.slice(diagnosisStart, diagnosisEnd)
+    : "";
   const observeStart = opsSource.indexOf('cmd === "release-queue-observe"');
   const diagnoseStart = opsSource.indexOf('cmd === "publish-window-diagnose"');
   const observeEnd = Math.min(
@@ -3279,6 +3284,12 @@ async function checkReleaseQueueObservationOpsScript() {
       !diagnoseBlock.includes('method: "POST"') &&
       !diagnoseBlock.includes("refresh-cookie"),
     "publish-window diagnosis must stay read-only and avoid publish, pause writes, or cookie refresh",
+  );
+  assert.ok(
+    diagnosisSource.indexOf("report.siteSummary.ok && latestSummaryMatchesDate") >= 0 &&
+      diagnosisSource.indexOf("report.siteSummary.ok && latestSummaryMatchesDate") <
+        diagnosisSource.indexOf("const heartbeat = report.cronStatus"),
+    "publish-window diagnosis must trust a current public summary before reporting an auxiliary cron read failure",
   );
 
   console.log("ok: worker ops exposes production release queue observation");

--- a/scripts/worker-ops.mjs
+++ b/scripts/worker-ops.mjs
@@ -277,6 +277,15 @@ async function readDiagnosticJson(label, url, options = {}) {
 }
 
 function buildPublishWindowDiagnosis(report) {
+  if (report.siteSummary.ok && latestSummaryMatchesDate(report.siteSummary.json, report.date)) {
+    const latest = report.siteSummary.json?.latest || {};
+    return {
+      stage: "已发布",
+      conclusion: `已发布：正式站 summary 已是 #${latest.puzzleNumber || "未知"}，日期是 ${report.date}。`,
+      nextStep: "不用处理发布。其他诊断接口即使临时读不到，也不能把已上线误报成未发布。",
+    };
+  }
+
   const pauseStatus = report.pauseStatus.json?.status || {};
   if (pauseStatus.paused === true) {
     return {
@@ -377,11 +386,7 @@ function buildPublishWindowDiagnosis(report) {
     };
   }
 
-  return {
-    stage: "已发布",
-    conclusion: "已发布：Worker、GitHub、Vercel、正式站 summary 都是今天。",
-    nextStep: "不用处理。继续观察明天 15:00 窗口。",
-  };
+  throw new Error("Publish window diagnosis reached an unexpected state.");
 }
 
 function getReleaseQueueDryRunScenarios(nowIso) {


### PR DESCRIPTION
## What changed
- treat a current live summary as published before checking auxiliary Cron diagnostics
- keep Cron and deployment failures useful only when the public summary is still stale
- record the verified #806 Production, detail, sitemap, Worker, and candidate-branch results

## Verification
- npm run test:pinpoint-guardrails
- worker:publish-window-diagnose reports 已发布 for #806
- pre-push validate:data passed (349 records)