### PR TITLE
Trigger Production for stage 2 closeout

### DIFF
--- a/.vercel-production-trigger.json
+++ b/.vercel-production-trigger.json
@@ -1,0 +1,7 @@
+{
+  "version": 1,
+  "candidateBranch": "codex/pinpoint-traffic-recovery-stage2-closeout",
+  "candidateSha": "aaa54bef5c3d276e7a88ab26fffdf092fec53f6a",
+  "previousProductionSha": "ae9e6355dba28d3fa246a963354b3ff6479d7d99",
+  "requestedAt": "2026-08-02T08:56:17Z"
+}


### PR DESCRIPTION
## Summary

- add the repository production retry marker for the documentation-only closeout SHA
- force Vercel to create an exact-SHA Production deployment
- prevent release queue from remaining unknown after the docs-only merge

No application or puzzle data changes.