### PR TITLE
Fix Pinpoint final publish retry for #826

### DIFF
--- a/docs/ITERATION.md
+++ b/docs/ITERATION.md
@@ -280,3 +280,14 @@
 未做：没有启用任何 `serp-v2` 页面；没有用当天 GSC 数据判断流量效果；阶段 4.5、4.6 和阶段 5 尚未开始。
 复查日期：阶段 3 获得完整日期样本后，再决定未来 canary slug。
 下一步：继续阶段 3 的 14 天发布与 GSC 基线；数据够之前不启动去答案实验。
+
+## 2026-08-04 #826 最终发布门槛重试与保底全文修复记录
+
+问题：Worker 已抓到 #826 真实题目，但 AI 草稿或保底内容在最终发布检查中被降成轻量页；正式发布又禁止轻量页，导致候选分支没有创建，自动流程重复失败。
+证据：生产诊断显示 `publishMode.inferredLegacy`、`publishMode.answerFirstDisabled`、`publishMode.bodyModeMismatch`、`publishMode.pageExperienceMismatch` 和 `publishMode.expectedFullAnalysis`；本地复现进一步定位到保底 `clueRows[0] phrase repeats the clue`。
+本轮边界：只修 Worker 最终发布检查、重新生成和保底全文结构，并补守卫测试；不改首页 SEO、题目数据、URL、canonical、sitemap 或页面正文模板。
+修改：AI 草稿通过前置校验后，再用最终公开发布规则检查；不合格时把最终错误送入下一次重写；两次仍失败才切换保底全文。保底全文现在先通过同一最终规则，通不过就明确停止。为 `Things that come in groups of ...` 生成真实的成员组例子，避免原样重复线索并被降成轻量页。
+验证：#826 真实线索回归样本保持 `bodyMode=standard`、`pageExperienceMode=full-analysis`，最终发布资格检查通过；四条线索的无效保底样本明确报错，没有进入 GitHub 写入流程；根目录与 Worker 类型检查、lint、Pinpoint 守卫、368 条真实数据校验和 393 页完整构建全部通过。
+未做：尚未提交、推送、部署 Worker，也未手动补发 #826；没有碰原工作区的未提交改动。
+复查日期：代码部署并补发 #826 后立即复查。
+下一步：获得生产授权后提交并推送修复、部署 Worker，再从真实 Worker 历史补发 #826，并验证 candidate、CI、Production、summary、详情页和 sitemap。

--- a/docs/ITERATION.md
+++ b/docs/ITERATION.md
@@ -291,3 +291,15 @@
 未做：尚未提交、推送、部署 Worker，也未手动补发 #826；没有碰原工作区的未提交改动。
 复查日期：代码部署并补发 #826 后立即复查。
 下一步：获得生产授权后提交并推送修复、部署 Worker，再从真实 Worker 历史补发 #826，并验证 candidate、CI、Production、summary、详情页和 sitemap。
+
+## 2026-08-04 #826 Worker 部署与补发收口记录
+
+问题：#826 修复已在本地通过，但还缺少代码留痕、生产 Worker 部署、真实题目补发和正式站验收。
+证据：修复提交为 `1524773`，生产 Worker 版本为 `43782a4a-5c9e-4118-b769-49e5694799fd`；补发内容来自生产 Worker 历史接口，抓取时间为 `2026-08-04T08:47:28.877Z`，校验哈希为 `sha256:3663d727768190843c98d463f104ae8a2df966491fa60eadd4bc4a17af7a76b7`。
+本轮边界：只部署已验证的 Worker 修复并补发 #826；不改首页固定 SEO 文案、URL、canonical、sitemap 规则或原工作区的未提交内容。
+修改：修复分支已推送到 `origin/codex/pinpoint-publish-retry`；生产 Worker 已部署；#826 候选提交 `cca69cc` 经 GitHub Actions 自动提升到 `main` 提交 `f7d4c4d2157f345dca681abd5d94af3d25ea1304`；两次断开的手动长请求留下的同日过期运行标记已按精确键删除，没有伪造完成状态。
+验证：GitHub Actions `30893893971` 的数据、lint、类型、守卫、构建、提升和 Production 核验全部通过；准确 main SHA 的 Vercel Production 状态为 `ready`；正式站 summary 为 #826，详情页返回 HTTP 200，sitemap 包含 #826，候选分支数为 0；发布窗口诊断结论为“已发布”。
+剩余问题：详情页结构和发布状态检查通过，但关键词审计仍把标题没有完整短语 `LinkedIn Pinpoint 826 Answer` 以及数个线索组合词排名不足标为 P1。本轮没有为了通过词频检查改正文，也没有自动回滚已经正常上线的页面。
+未做：没有把修复分支合并进 `main`；后续重新部署 Worker 前，仍需先合并该修复，避免生产代码被旧版覆盖。
+复查日期：本次部署和补发后已立即复查；下一次 Worker 发布前复查修复是否已进入 `main`。
+下一步：单独审阅并合并 `codex/pinpoint-publish-retry`；关键词审计问题另开一轮判断规则是否合理，不和本次发布恢复混改。

--- a/scripts/check-pinpoint-guardrails.ts
+++ b/scripts/check-pinpoint-guardrails.ts
@@ -3795,6 +3795,139 @@ async function checkCandidateBranchWatchdogClosesStuckBranches() {
   console.log("ok: candidate branch watchdog closes or escalates stuck candidates");
 }
 
+async function checkWorkerFinalGuardRegeneratesAndUsesValidatedFallback() {
+  const workerModulePath = "../worker/src/index.ts";
+  const workerModule = (await import(workerModulePath)) as {
+    buildTemplateFallbackDetailRecord: (
+      siteBaseUrl: string,
+      puzzleDate: string,
+      doc: Record<string, unknown>,
+      puzzleNumber: number,
+      words: string[],
+    ) => {
+      bodyMode: string;
+      pageExperienceMode: string;
+      clueRows: Array<{ clue: string; phraseExample?: string }>;
+    };
+    buildValidatedTemplateFallbackPayload: (
+      siteBaseUrl: string,
+      puzzleDate: string,
+      doc: Record<string, unknown>,
+      puzzleNumber: number,
+      words: string[],
+    ) => Record<string, unknown>;
+    resolvePublicDetailExperienceDecision: (input: {
+      incoming: Record<string, unknown>;
+      existingBranchSummary: null;
+      primaryBranchSummary: null;
+    }) => { action: string; record?: Record<string, unknown>; reason?: string };
+    validateWorkerPublishEligibility: (input: {
+      slug: string;
+      detail: Record<string, unknown>;
+      registryEntry: Record<string, unknown>;
+      expectedMode: "full-analysis";
+      answerFirstPublicEnabled: boolean;
+    }) => { ok: boolean; issues: Array<{ code: string; level: string }> };
+  };
+
+  const words = [
+    "Ghosts in Pac-Man",
+    "Grand Slams in tennis",
+    "Bases in DNA",
+    "Nations in the United Kingdom",
+    "Train spaces in Monopoly (1/side)",
+  ];
+  const doc = {
+    version: 1,
+    puzzleDate: "2026-08-04",
+    answers: words.map((word, index) => ({ rank: index + 1, word })),
+    source: "fallback-local",
+    fetchedAt: "2026-08-04T07:25:33.210Z",
+    checksum: "sha256:worker-backed-826-regression-fixture",
+    theme: "Things that come in groups of four",
+    mainAnswer: "Things that come in groups of four",
+  };
+  const detail = workerModule.buildTemplateFallbackDetailRecord(
+    "https://pinpointanswertoday.app",
+    "2026-08-04",
+    doc,
+    826,
+    words,
+  );
+  const decision = workerModule.resolvePublicDetailExperienceDecision({
+    incoming: detail,
+    existingBranchSummary: null,
+    primaryBranchSummary: null,
+  });
+
+  assert.equal(
+    decision.action,
+    "use-full-analysis",
+    "#826 fallback must stay full-analysis instead of being downgraded to a blocked light explainer",
+  );
+  assert.equal(detail.bodyMode, "standard", "#826 fallback must keep a non-short body mode");
+  assert.equal(
+    detail.pageExperienceMode,
+    "full-analysis",
+    "#826 fallback must keep the full-analysis page experience",
+  );
+  assert.ok(
+    detail.clueRows.every((row) => {
+      const clue = row.clue.toLowerCase().replace(/[^a-z0-9]+/g, " ").trim();
+      const phrase = String(row.phraseExample || "").toLowerCase().replace(/[^a-z0-9]+/g, " ").trim();
+      return phrase && phrase !== clue;
+    }),
+    "#826 fallback clue rows must add a real category example instead of repeating each clue",
+  );
+
+  const payload = workerModule.buildValidatedTemplateFallbackPayload(
+    "https://pinpointanswertoday.app",
+    "2026-08-04",
+    doc,
+    826,
+    words,
+  );
+  assert.equal(payload.detailState, "fallback_full", "validated fallback must stay explicitly fallback_full");
+  const eligibility = workerModule.validateWorkerPublishEligibility({
+    slug: "pinpoint-answer-826",
+    detail: decision.record ?? detail,
+    registryEntry: {
+      puzzleNumber: 826,
+      slug: "pinpoint-answer-826",
+      publishDate: "2026-08-04",
+      status: "live",
+      detailState: "fallback_full",
+      clues: words,
+      mainAnswer: doc.mainAnswer,
+    },
+    expectedMode: "full-analysis",
+    answerFirstPublicEnabled: false,
+  });
+  assert.equal(eligibility.ok, true, "#826 validated fallback must pass the final shared publish gate");
+
+  assert.throws(
+    () => workerModule.buildValidatedTemplateFallbackPayload(
+      "https://pinpointanswertoday.app",
+      "2026-08-04",
+      doc,
+      826,
+      words.slice(0, 4),
+    ),
+    /template fallback failed final full-analysis guard/,
+    "an invalid fallback must fail closed instead of reaching GitHub",
+  );
+
+  const workerSource = await readFile(resolve(ROOT, "worker/src/index.ts"), "utf8");
+  assert.ok(
+    workerSource.includes("final full-analysis guard blocked; regenerating (Vercel)") &&
+      workerSource.includes("final full-analysis guard; regenerating (Worker LLM)") &&
+      workerSource.includes("buildValidatedTemplateFallbackPayload"),
+    "both draft paths must retry final-guard failures and only use a fallback that passes the same final guard",
+  );
+
+  console.log("ok: Worker retries final publish guards and validates #826 fallback before GitHub");
+}
+
 async function checkPublicVerificationCopyMatchesRecordedProcess() {
   const publicCopyFiles = [
     "components/detail/PuzzleDetail.tsx",
@@ -4383,6 +4516,7 @@ async function main() {
   await checkWorkerBlocksOverusedAnswersBeforeGithubWrite();
   await checkMainFailureContentRecoveryCreatesAutoPromotedCandidate();
   await checkCandidateBranchWatchdogClosesStuckBranches();
+  await checkWorkerFinalGuardRegeneratesAndUsesValidatedFallback();
   await checkPublicVerificationCopyMatchesRecordedProcess();
   await checkLiveWorkerCoreDataFailsClosed();
   await checkClueEvidenceTableStaysHidden();

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1518,7 +1518,12 @@ function buildWorkerFallbackPhrase(clue: string, answer: string): string {
       return `${normalizedBase} as ${article} ${singularLabel}`.trim();
     }
 
-    return normalizedBase;
+    const groupedThings = pattern.label.match(/^Things that come in groups of\s+(.+)$/i);
+    if (groupedThings?.[1]) {
+      return `${groupedThings[1].trim().toLowerCase()}-member set: ${normalizedBase}`;
+    }
+
+    return `Category example: ${normalizedBase}`;
   }
   return normalizedBase;
 }
@@ -4140,6 +4145,80 @@ function isSuccessfulEnrichResult(
   );
 }
 
+function buildEnrichedPayloadFromDraft({
+  siteBaseUrl,
+  puzzleDate,
+  doc,
+  puzzleNumber,
+  words,
+  draftData,
+  detailState,
+}: {
+  siteBaseUrl: string;
+  puzzleDate: string;
+  doc: Doc;
+  puzzleNumber: number;
+  words: string[];
+  draftData: JsonRecord;
+  detailState: PublicDetailState;
+}): JsonRecord {
+  const draftSections = asRecord(draftData.sections);
+  const draftAnalysis = asRecord(draftData.analysis);
+  const draftSlots = asRecord(draftData.slots);
+  const draftMetadata = asRecord(draftData.metadata);
+  const draftEvidence = extractProvidedEvidenceFields(draftData);
+  const fallbackPayload = createQuickPayload(siteBaseUrl, puzzleDate, doc, puzzleNumber, words);
+
+  return {
+    ...fallbackPayload,
+    analysis: {
+      ...fallbackPayload.analysis,
+      detailedBreakdown: String(draftAnalysis?.detailedBreakdown || fallbackPayload.analysis.detailedBreakdown),
+      dailyDebrief: String(draftAnalysis?.dailyDebrief || fallbackPayload.analysis.dailyDebrief),
+    },
+    summary: String(draftAnalysis?.heroSummary || draftData.summary || fallbackPayload.summary),
+    detailState,
+    ...draftEvidence,
+    seoDescription: typeof draftAnalysis?.seoDescription === "string" ? draftAnalysis.seoDescription : undefined,
+    seo: typeof draftAnalysis?.seoTitle === "string" ? { title: draftAnalysis.seoTitle } : undefined,
+    sections: buildEnrichedSections(draftSections, asRecord(fallbackPayload.sections)),
+    ...(draftSlots ? { slots: draftSlots } : {}),
+    metadata: {
+      publishedAtSource:
+        typeof draftMetadata?.publishedAtSource === "string"
+          ? String(draftMetadata.publishedAtSource)
+          : `${siteBaseUrl}/api/admin/generate-draft`,
+      publishedAtConfidence:
+        typeof draftMetadata?.publishedAtConfidence === "number"
+          ? Number(draftMetadata.publishedAtConfidence)
+          : 1,
+    },
+  };
+}
+
+export function buildValidatedTemplateFallbackPayload(
+  siteBaseUrl: string,
+  puzzleDate: string,
+  doc: Doc,
+  puzzleNumber: number,
+  words: string[],
+): JsonRecord {
+  const payload: JsonRecord = {
+    ...buildTemplateFallbackPayload(siteBaseUrl, puzzleDate, doc, puzzleNumber, words),
+    detailState: "fallback_full",
+  };
+  const blockReason = getPublicFullAnalysisPayloadBlockReason({
+    puzzleDate,
+    doc,
+    enrichedPayload: payload,
+    puzzleNumber,
+  });
+  if (blockReason) {
+    throw new Error(`[new-site] template fallback failed final full-analysis guard: ${blockReason}`);
+  }
+  return payload;
+}
+
 async function publishToNewSiteGitHub(
   env: Env,
   puzzleDate: string,
@@ -5333,24 +5412,49 @@ async function enrichPublishToSite(
           }
 
           if (validateResp.valid) {
-            draftResp = { success: true, data: candidateData };
-            break;
+            const candidatePayload = buildEnrichedPayloadFromDraft({
+              siteBaseUrl,
+              puzzleDate,
+              doc,
+              puzzleNumber,
+              words,
+              draftData: asRecord(candidateData) ?? {},
+              detailState: "published",
+            });
+            const finalGuardReason = getPublicFullAnalysisPayloadBlockReason({
+              puzzleDate,
+              doc,
+              enrichedPayload: candidatePayload,
+              puzzleNumber,
+            });
+            if (!finalGuardReason) {
+              draftResp = { success: true, data: candidateData };
+              break;
+            }
+            qualityGateSummary = `final full-analysis guard: ${finalGuardReason}`;
+            lastValidationIssues = [{ message: qualityGateSummary }];
+          } else {
+            const issues = Array.isArray(validateResp.issues) ? validateResp.issues : [];
+            const errorIssues = issues.filter(
+              (i: Record<string, unknown>) => i?.level === "error",
+            );
+            lastValidationIssues = errorIssues
+              .map((i: Record<string, unknown>) => ({ message: String(i?.message || "") }))
+              .filter((issue) => issue.message);
+            qualityGateSummary = errorIssues
+              .map((i: Record<string, unknown>) => String(i?.message || ""))
+              .join(" | ");
           }
-
-          const issues = Array.isArray(validateResp.issues) ? validateResp.issues : [];
-          const errorIssues = issues.filter(
-            (i: Record<string, unknown>) => i?.level === "error",
-          );
-          lastValidationIssues = errorIssues
-            .map((i: Record<string, unknown>) => ({ message: String(i?.message || "") }))
-            .filter((issue) => issue.message);
-          qualityGateSummary = errorIssues
-            .map((i: Record<string, unknown>) => String(i?.message || ""))
-            .join(" | ");
 
           if (attempt >= draftAttempts) {
             publishDetailState = "fallback_full";
-            const fallbackPayload = buildTemplateFallbackPayload(siteBaseUrl, puzzleDate, doc, puzzleNumber, words);
+            const fallbackPayload = buildValidatedTemplateFallbackPayload(
+              siteBaseUrl,
+              puzzleDate,
+              doc,
+              puzzleNumber,
+              words,
+            );
             const reason = `quality gate blocked after ${draftAttempts} attempt(s): ${qualityGateSummary}; used fallback_full`;
             await notifyCron(env, "⚠️ Worker 草稿质量未过线，已切换为保底全文页", [
               `日期: ${puzzleDate}`,
@@ -5372,7 +5476,7 @@ async function enrichPublishToSite(
             break;
           }
 
-          console.warn("[enrich] draft blocked by quality gates; regenerating (Worker LLM)", {
+          console.warn("[enrich] draft blocked by quality gates or final full-analysis guard; regenerating (Worker LLM)", {
             puzzleDate,
             puzzleNumber,
             attempt,
@@ -5386,7 +5490,13 @@ async function enrichPublishToSite(
           if (isRetryableSitePostError(error)) {
             if (shouldUseTemplateFallbackAfterRetryableDraftFailure(error, attempt, draftAttempts)) {
               publishDetailState = "fallback_full";
-              const fallbackPayload = buildTemplateFallbackPayload(siteBaseUrl, puzzleDate, doc, puzzleNumber, words);
+              const fallbackPayload = buildValidatedTemplateFallbackPayload(
+                siteBaseUrl,
+                puzzleDate,
+                doc,
+                puzzleNumber,
+                words,
+              );
               await notifyCron(env, "⚠️ Worker 草稿请求超时，已切换为保底全文页", [
                 `日期: ${puzzleDate}`,
                 `谜题: #${puzzleNumber}`,
@@ -5423,7 +5533,7 @@ async function enrichPublishToSite(
       for (let attempt = 1; attempt <= draftAttempts; attempt += 1) {
         const draftModel = attempt === 1 ? enrichModel : retryModel;
         try {
-          draftResp = await postSiteJson(
+          const candidateResp = await postSiteJson(
             `${siteBaseUrl}/api/admin/generate-draft`,
             token,
             {
@@ -5435,7 +5545,66 @@ async function enrichPublishToSite(
             },
             timeoutMs,
           );
-          break;
+          const candidateData = asRecord(candidateResp.data);
+          if (!candidateResp.success || !candidateData) {
+            throw new Error(
+              typeof candidateResp.message === "string"
+                ? candidateResp.message
+                : "draft generation failed",
+            );
+          }
+          const candidatePayload = buildEnrichedPayloadFromDraft({
+            siteBaseUrl,
+            puzzleDate,
+            doc,
+            puzzleNumber,
+            words,
+            draftData: candidateData,
+            detailState: "published",
+          });
+          const finalGuardReason = getPublicFullAnalysisPayloadBlockReason({
+            puzzleDate,
+            doc,
+            enrichedPayload: candidatePayload,
+            puzzleNumber,
+          });
+          if (!finalGuardReason) {
+            draftResp = candidateResp;
+            break;
+          }
+
+          qualityGateSummary = `final full-analysis guard: ${finalGuardReason}`;
+          if (attempt >= draftAttempts) {
+            publishDetailState = "fallback_full";
+            const fallbackPayload = buildValidatedTemplateFallbackPayload(
+              siteBaseUrl,
+              puzzleDate,
+              doc,
+              puzzleNumber,
+              words,
+            );
+            draftResp = { success: true, data: fallbackPayload };
+            lastDraftError = null;
+            console.warn("[enrich] final full-analysis guard exhausted; switched to fallback_full", {
+              puzzleDate,
+              puzzleNumber,
+              attempt,
+              draftAttempts,
+              reason: qualityGateSummary,
+            });
+            break;
+          }
+
+          console.warn("[enrich] final full-analysis guard blocked; regenerating (Vercel)", {
+            puzzleDate,
+            puzzleNumber,
+            attempt,
+            draftAttempts,
+            model: draftModel,
+            nextModel: retryModel,
+            reason: qualityGateSummary,
+          });
+          await sleep(800 * attempt);
         } catch (error) {
           lastDraftError = error;
           const qualityGateError = isDraftQualityGateError(error);
@@ -5448,7 +5617,13 @@ async function enrichPublishToSite(
             : error instanceof Error ? error.message : String(error);
           if (attempt >= draftAttempts) {
             publishDetailState = "fallback_full";
-            const fallbackPayload = buildTemplateFallbackPayload(siteBaseUrl, puzzleDate, doc, puzzleNumber, words);
+            const fallbackPayload = buildValidatedTemplateFallbackPayload(
+              siteBaseUrl,
+              puzzleDate,
+              doc,
+              puzzleNumber,
+              words,
+            );
             const reason = `${qualityGateError ? "quality gate blocked" : "retryable draft request failed"} after ${draftAttempts} attempt(s): ${qualityGateSummary}; used fallback_full`;
             await notifyCron(env, qualityGateError
               ? "⚠️ Worker 草稿质量未过线，已切换为保底全文页"
@@ -5500,38 +5675,18 @@ async function enrichPublishToSite(
     }
 
     const draftData = asRecord(draftResp.data);
-    const draftSections = asRecord(draftData?.sections);
-    const draftAnalysis = asRecord(draftData?.analysis);
-    const draftSlots = asRecord(draftData?.slots);
-    const draftMetadata = asRecord(draftData?.metadata);
-    const draftEvidence = extractProvidedEvidenceFields(draftData ?? {});
-
-    const fallbackPayload = createQuickPayload(siteBaseUrl, puzzleDate, doc, puzzleNumber, words);
-    const enrichedPayload: JsonRecord = {
-      ...fallbackPayload,
-      analysis: {
-        ...fallbackPayload.analysis,
-        detailedBreakdown: String(draftAnalysis?.detailedBreakdown || fallbackPayload.analysis.detailedBreakdown),
-        dailyDebrief: String(draftAnalysis?.dailyDebrief || fallbackPayload.analysis.dailyDebrief),
-      },
-      summary: String(draftAnalysis?.heroSummary || draftData?.summary || fallbackPayload.summary),
+    if (!draftData) {
+      throw new Error("draft generation returned invalid data");
+    }
+    const enrichedPayload = buildEnrichedPayloadFromDraft({
+      siteBaseUrl,
+      puzzleDate,
+      doc,
+      puzzleNumber,
+      words,
+      draftData,
       detailState: publishDetailState,
-      ...draftEvidence,
-      seoDescription: typeof draftAnalysis?.seoDescription === "string" ? draftAnalysis.seoDescription : undefined,
-      seo: typeof draftAnalysis?.seoTitle === "string" ? { title: draftAnalysis.seoTitle } : undefined,
-      sections: buildEnrichedSections(draftSections, asRecord(fallbackPayload.sections)),
-      ...(draftSlots ? { slots: draftSlots } : {}),
-      metadata: {
-        publishedAtSource:
-          typeof draftMetadata?.publishedAtSource === "string"
-            ? String(draftMetadata.publishedAtSource)
-            : `${siteBaseUrl}/api/admin/generate-draft`,
-        publishedAtConfidence:
-          typeof draftMetadata?.publishedAtConfidence === "number"
-            ? Number(draftMetadata.publishedAtConfidence)
-            : 1,
-      },
-    };
+    });
 
     if (publishDetailState === "published") {
       await options.onDetailStateChange?.("validated");
@@ -5546,10 +5701,13 @@ async function enrichPublishToSite(
     });
     if (publishBlockReason) {
       publishDetailState = "fallback_full";
-      publishedPayload = {
-        ...buildTemplateFallbackPayload(siteBaseUrl, puzzleDate, doc, puzzleNumber, words),
-        detailState: publishDetailState,
-      };
+      publishedPayload = buildValidatedTemplateFallbackPayload(
+        siteBaseUrl,
+        puzzleDate,
+        doc,
+        puzzleNumber,
+        words,
+      );
       console.warn("[enrich] switched to fallback_full before GitHub publish", {
         puzzleDate,
         puzzleNumber,
@@ -7367,10 +7525,13 @@ export default {
         theme: answer,
         mainAnswer: answer,
       };
-      const payload = {
-        ...buildTemplateFallbackPayload(getPublicSiteBaseUrl(env), puzzleDate, doc, puzzleNumber, rawWords),
-        detailState: "fallback_full",
-      };
+      const payload = buildValidatedTemplateFallbackPayload(
+        getPublicSiteBaseUrl(env),
+        puzzleDate,
+        doc,
+        puzzleNumber,
+        rawWords,
+      );
       const candidateBranch = buildPinpointCandidateBranchName(env, puzzleDate, slug);
 
       await publishToNewSiteGitHub(env, puzzleDate, doc, payload, puzzleNumber);


### PR DESCRIPTION
## 这次修什么

- 把最终公开发布检查放进 AI 重试循环，不合格时重新生成
- 保底全文也必须通过同一最终检查，否则直接停止
- 修复 #826 这类 groups-of-four 线索在 clueRows 中重复原句的问题
- 增加 #826 回归和失败关闭测试
- 记录 Worker 部署与 #826 正式站收口结果

## 已验证

- `npm run validate:data`
- `npm run typecheck`
- `npm run lint`
- `npm run test:pinpoint-guardrails`
- `npm run build`
- Worker `npm run typecheck`
- Worker dry run 与生产部署
- #826 GitHub CI、Vercel Production、summary、详情页、sitemap、candidate=0

## 生产状态

- Worker version: `43782a4a-5c9e-4118-b769-49e5694799fd`
- #826 main SHA: `f7d4c4d2157f345dca681abd5d94af3d25ea1304`
- #826 已正式上线

## 不在本 PR 处理

详情页发布检查中的关键词排名 P1 另行审阅，不为通过词频检查改正文。