### PR TITLE
Fix Pinpoint #836-#852 publishing backlog

### DIFF
--- a/data/puzzles/pinpoint-answer-836.json
+++ b/data/puzzles/pinpoint-answer-836.json
@@ -1,0 +1,233 @@
+{
+  "puzzleNumber": 836,
+  "slug": "pinpoint-answer-836",
+  "publishDate": "2026-08-14",
+  "isoDate": "2026-08-14",
+  "detailState": "published",
+  "bodyMode": "standard",
+  "pageExperienceMode": "full-analysis",
+  "questionType": "category",
+  "difficultyBand": "hard",
+  "clues": [
+    "Odyssey",
+    "Galaxy",
+    "Kart",
+    "64",
+    "Bros. 3"
+  ],
+  "answer": "Terms that come after “Super Mario” in video game titles",
+  "category": "Terms that come after “Super Mario” in video game titles",
+  "wordHints": {
+    "64": "It fits because '64' follows 'Super Mario' in the title of a classic 3D platformer.",
+    "Odyssey": "It fits because 'Odyssey' is a title that follows 'Super Mario' in a well-known video game.",
+    "Galaxy": "It fits because 'Galaxy' is another title that follows 'Super Mario', indicating a pattern.",
+    "Kart": "It fits because 'Kart' follows 'Super Mario' in a series of racing games.",
+    "Bros. 3": "It fits because 'Bros. 3' follows 'Super Mario' in the title of a popular platformer game."
+  },
+  "spoilerHints": {
+    "64": "64 should be tested as part of terms that come after “super mario” in video game titles, not as a standalone reference.",
+    "Odyssey": "Odyssey should be tested as part of terms that come after “super mario” in video game titles, not as a standalone reference.",
+    "Galaxy": "Keep Galaxy in mind, then see whether Bros. 3 supports the same answer.",
+    "Kart": "Kart works best after the board narrows toward terms that come after “super mario” in video game titles.",
+    "Bros. 3": "Bros. 3 is the clue that makes terms that come after “super mario” in video game titles concrete enough to test across the full board."
+  },
+  "articleBlocks": [
+    "The puzzle started with 'Odyssey', which seemed like it could be about epic journeys.",
+    "But then 'Galaxy' appeared, and it seemed like maybe it was about space or types of environments.",
+    "The introduction of 'Kart' made me think about types of vehicles or sports.",
+    "However, when '64' was added, it made me reconsider because it's clearly a reference to a specific game console.",
+    "The clue 'Bros. 3' further clarified that we're dealing with parts of game titles, specifically those following 'Super Mario'.",
+    "At first, I thought it might be about game genres or console names, but these didn't fit consistently across all clues.",
+    "The turning point was realizing that 'Odyssey' wasn't just a type of journey, but a specific game title that follows 'Super Mario'.",
+    "This made me look at all the clues as parts of 'Super Mario' game titles, leading to the conclusion that the answer is terms that come after 'Super Mario' in video game titles.",
+    "In hindsight, the clues were always pointing to a specific pattern in how 'Super Mario' games are titled, making the solution clearer than it initially seemed.",
+    "The key takeaway is to pay attention to the structure of titles and how parts of them can form patterns or categories."
+  ],
+  "solutionNarrative": [
+    "Odyssey and Galaxy first pulled me toward game genres, so that was the first path I tested. It held together for a moment, but odyssey never really fit it. The more I pushed that first read, the more the board sounded stitched together instead of naturally solved.",
+    "The solve turned when I stopped treating odyssey as just another clue and asked what kind of thing each clue could really be describing. I was no longer trying to rescue game genres; I was checking whether Odyssey and Galaxy could survive the same tighter read.",
+    "Then I used Kart, 64, and Bros. 3 as the confirmation round. Kart, 64, and Bros. 3 stayed inside the real category, so the answer felt earned instead of guessed. The answer was Terms that come after Super Mario in video game titles."
+  ],
+  "lessons": [
+    {
+      "title": "\"Odyssey\" and \"Galaxy\" can look like they belong to different categories at first",
+      "body": "\"Odyssey\" and \"Galaxy\" both fit several loose themes, so it is often better to wait for a more specific word before locking in a category."
+    },
+    {
+      "title": "\"Odyssey\" anchors a shared category board with one concrete theme",
+      "body": "Odyssey organizes this board. Once one clue produces a precise natural reading, re-check the earlier clues under that same frame."
+    },
+    {
+      "title": "Use \"Odyssey\" to re-check \"Odyssey\" under a shared category board with one concrete theme",
+      "body": "Look for patterns in how titles are structured, not just the words themselves."
+    }
+  ],
+  "display": {
+    "connectorSummary": "a category board focused on terms",
+    "fastStrategy": "\"Odyssey\" and \"Galaxy\" both fit several loose themes, so it is often better to wait for a more specific word before locking in a category.",
+    "clueTableRows": [
+      {
+        "clue": "Odyssey",
+        "examplePhrase": "Super Mario Odyssey",
+        "connectionExplained": "It fits because 'Odyssey' is a title that follows 'Super Mario' in a well-known video game."
+      },
+      {
+        "clue": "Galaxy",
+        "examplePhrase": "Super Mario Galaxy",
+        "connectionExplained": "It fits because 'Galaxy' is another title that follows 'Super Mario', indicating a pattern."
+      },
+      {
+        "clue": "Kart",
+        "examplePhrase": "Super Mario Kart",
+        "connectionExplained": "It fits because 'Kart' follows 'Super Mario' in a series of racing games."
+      },
+      {
+        "clue": "64",
+        "examplePhrase": "Super Mario 64",
+        "connectionExplained": "It fits because '64' follows 'Super Mario' in the title of a classic 3D platformer."
+      },
+      {
+        "clue": "Bros. 3",
+        "examplePhrase": "Super Mario Bros. 3",
+        "connectionExplained": "It fits because 'Bros. 3' follows 'Super Mario' in the title of a popular platformer game."
+      }
+    ]
+  },
+  "faqs": [
+    {
+      "question": "What final category connects \"Odyssey\" and \"Galaxy\" in LinkedIn Pinpoint #836?",
+      "answer": "The answer is \"Terms that come after Super Mario in video game titles\" because that reading explains the full set cleanly, including the final clue."
+    },
+    {
+      "question": "How do \"Odyssey\" and \"Galaxy\" connect in LinkedIn Pinpoint #836?",
+      "answer": "The connection is that all 5 clues point back to one specific category instead of a loose umbrella theme. Odyssey is what keeps the category reading precise instead of broad."
+    },
+    {
+      "question": "Why is \"Odyssey\" the key clue in LinkedIn Pinpoint #836?",
+      "answer": "Odyssey is the turning clue because \"Super Mario Odyssey\" makes the shared category frame explicit. It also makes Galaxy read cleanly as \"Super Mario Galaxy\". The puzzle feels tricky because the clues are all recognizable game titles, but the connection is not about the games themselves, but about how they're titled."
+    },
+    {
+      "question": "How does \"Galaxy\" fit the same category as \"Odyssey\" in LinkedIn Pinpoint #836?",
+      "answer": "\"Galaxy\" reads as \"Super Mario Galaxy\" under the same answer, so it supports the category instead of pulling toward a broader guess."
+    }
+  ],
+  "solvePath": {
+    "firstRead": "Odyssey, Galaxy, and Kart do not immediately look like the same kind of thing, so the first read can wander in the wrong direction. That is why a first read like \"game series\" can feel plausible before one clue makes the answer feel concrete. Odyssey is the clue that finally breaks that first read and makes the real category feel concrete.",
+    "falseStarts": [
+      "game series",
+      "platform names"
+    ],
+    "whyFalseStartPlausible": [
+      "The guess breaks because the clues don't align with distinct game genres but rather with parts of specific game titles.",
+      "game series feels plausible early on, but it falls apart once odyssey demands a more exact reading."
+    ],
+    "breakingClue": "Odyssey",
+    "pivot": "The solve turned when I stopped treating odyssey as just another clue and asked what kind of thing each clue could really be describing. I was no longer trying to rescue game genres; I was checking whether Odyssey and Galaxy could survive the same tighter read.",
+    "fullBoardConfirmation": "From there, reading them through one specific category frame explains the board much more cleanly. Entries like Odyssey, Galaxy, and Kart stop feeling disconnected and start looking like they belong together. Once odyssey is read the right way, the earlier clues stop pulling in different directions and start behaving like parts of the same answer. The puzzle feels tricky because the clues are all recognizable game titles, but the connection is not about the games themselves, but about how they're titled."
+  },
+  "turningPoint": {
+    "clue": "Odyssey",
+    "whyDecisive": "The clue 'Odyssey' forced a reevaluation of the category because it is a well-known game title that follows the pattern.",
+    "whatChangedAfterIt": "Once Odyssey landed, the earlier clues stopped pulling in different directions and started reinforcing the same answer."
+  },
+  "clueRows": [
+    {
+      "clue": "Odyssey",
+      "surfaceMisread": "game genres",
+      "resolvedPhraseOrMember": "Super Mario Odyssey",
+      "nonObviousWhy": "It fits because 'Odyssey' is a title that follows 'Super Mario' in a well-known video game.",
+      "searchableContext": "From the idea of an epic journey, now used in a game title.",
+      "phraseExample": "From the idea of an epic journey, now used in a game title."
+    },
+    {
+      "clue": "Galaxy",
+      "surfaceMisread": "game genres",
+      "resolvedPhraseOrMember": "Super Mario Galaxy",
+      "nonObviousWhy": "It fits because 'Galaxy' is another title that follows 'Super Mario', indicating a pattern.",
+      "searchableContext": "From the astronomical term, now used in a game title.",
+      "phraseExample": "From the astronomical term, now used in a game title."
+    },
+    {
+      "clue": "Kart",
+      "surfaceMisread": "game genres",
+      "resolvedPhraseOrMember": "Super Mario Kart",
+      "nonObviousWhy": "It fits because 'Kart' follows 'Super Mario' in a series of racing games.",
+      "searchableContext": "From the word for a small vehicle, now part of a game title.",
+      "phraseExample": "From the word for a small vehicle, now part of a game title."
+    },
+    {
+      "clue": "64",
+      "surfaceMisread": "game genres",
+      "resolvedPhraseOrMember": "Super Mario 64",
+      "nonObviousWhy": "It fits because '64' follows 'Super Mario' in the title of a classic 3D platformer.",
+      "searchableContext": "Referring to the 64-bit console it was released on.",
+      "phraseExample": "Referring to the 64-bit console it was released on."
+    },
+    {
+      "clue": "Bros. 3",
+      "surfaceMisread": "game genres",
+      "resolvedPhraseOrMember": "Super Mario Bros. 3",
+      "nonObviousWhy": "It fits because 'Bros. 3' follows 'Super Mario' in the title of a popular platformer game.",
+      "searchableContext": "From the idea of brotherly characters, with '3' indicating the third game in the series.",
+      "phraseExample": "From the idea of brotherly characters, with '3' indicating the third game in the series."
+    }
+  ],
+  "faqItems": [
+    {
+      "intentType": "solve_strategy",
+      "question": "What final category connects \"Odyssey\" and \"Galaxy\" in LinkedIn Pinpoint #836?",
+      "answer": "The answer is \"Terms that come after Super Mario in video game titles\" because that reading explains the full set cleanly, including the final clue.",
+      "tiedClue": "Odyssey"
+    },
+    {
+      "intentType": "solve_strategy",
+      "question": "How do \"Odyssey\" and \"Galaxy\" connect in LinkedIn Pinpoint #836?",
+      "answer": "The connection is that all 5 clues point back to one specific category instead of a loose umbrella theme. Odyssey is what keeps the category reading precise instead of broad.",
+      "tiedClue": "Odyssey"
+    },
+    {
+      "intentType": "clue_background",
+      "question": "Why is \"Odyssey\" the key clue in LinkedIn Pinpoint #836?",
+      "answer": "Odyssey is the turning clue because \"Super Mario Odyssey\" makes the shared category frame explicit. It also makes Galaxy read cleanly as \"Super Mario Galaxy\". The puzzle feels tricky because the clues are all recognizable game titles, but the connection is not about the games themselves, but about how they're titled.",
+      "tiedClue": "Odyssey"
+    },
+    {
+      "intentType": "solve_strategy",
+      "question": "How does \"Galaxy\" fit the same category as \"Odyssey\" in LinkedIn Pinpoint #836?",
+      "answer": "\"Galaxy\" reads as \"Super Mario Galaxy\" under the same answer, so it supports the category instead of pulling toward a broader guess.",
+      "tiedClue": "Galaxy"
+    }
+  ],
+  "uniquenessSignals": {
+    "angle": "a shared category board with one concrete theme",
+    "relatedEntities": [
+      "Super Mario Odyssey",
+      "Super Mario Galaxy",
+      "Super Mario Kart",
+      "Super Mario 64",
+      "Super Mario Bros. 3"
+    ],
+    "doNotRepeatPatterns": [
+      "a shared category board with one concrete theme",
+      "\"Odyssey\" and \"Galaxy\" can look like they belong to different categories at first",
+      "\"Odyssey\" anchors a shared category board with one concrete theme",
+      "Use \"Odyssey\" to re-check \"Odyssey\" under a shared category board with one concrete theme",
+      "From the idea of an epic journey, now used in a game title.",
+      "From the astronomical term, now used in a game title."
+    ]
+  },
+  "wrongGuessCandidates": [
+    {
+      "label": "game genres",
+      "whyPlausible": "The guess breaks because the clues don't align with distinct game genres but rather with parts of specific game titles.",
+      "whyRejected": "Once Odyssey lands, the final answer explains the board more cleanly than game genres."
+    },
+    {
+      "label": "game series",
+      "whyPlausible": "game series feels plausible early on, but it falls apart once odyssey demands a more exact reading.",
+      "whyRejected": "Once Odyssey lands, the final answer explains the board more cleanly than game series."
+    }
+  ],
+  "setValidationSummary": "Kart, 64, Bros. 3 keep confirming the same answer, so the board reads like one exact set instead of a broad bucket.",
+  "categoryPrecisionNote": "one concrete category with members that stay at the same level of specificity as Terms that come after Super Mario in video game titles"
+}

--- a/data/puzzles/pinpoint-answer-837.json
+++ b/data/puzzles/pinpoint-answer-837.json
@@ -1,0 +1,218 @@
+{
+  "puzzleNumber": 837,
+  "slug": "pinpoint-answer-837",
+  "publishDate": "2026-08-15",
+  "isoDate": "2026-08-15",
+  "detailState": "fallback_full",
+  "bodyMode": "standard",
+  "pageExperienceMode": "full-analysis",
+  "questionType": "category",
+  "difficultyBand": "hard",
+  "clues": [
+    "A speech",
+    "The daily newspaper",
+    "The mail",
+    "A knockout blow",
+    "Restaurant food brought to you"
+  ],
+  "answer": "Things that are delivered",
+  "category": "Things that are delivered",
+  "wordHints": {
+    "A speech": "\"delivered a speech\" fits more cleanly once the board is tested under the same answer as the other clues.",
+    "The daily newspaper": "\"delivered the daily newspaper\" helps confirm the same answer instead of pulling the board back toward a looser guess.",
+    "The mail": "\"delivered the mail\" belongs in the same set as the rest of the board, which is why the answer sharpens once this pattern becomes visible.",
+    "A knockout blow": "\"delivered a knockout blow\" fits more cleanly once the board is tested under the same answer as the other clues.",
+    "Restaurant food brought to you": "\"Restaurant food brought to you\" is the clue that makes the shared answer concrete enough to test across the full board."
+  },
+  "spoilerHints": {
+    "A speech": "A speech should be tested as part of things that are delivered, not as a standalone reference.",
+    "The daily newspaper": "Keep The daily newspaper in mind, then see whether Restaurant food brought to you supports the same answer.",
+    "The mail": "The mail works best after the board narrows toward things that are delivered.",
+    "A knockout blow": "A knockout blow should be tested as part of things that are delivered, not as a standalone reference.",
+    "Restaurant food brought to you": "Restaurant food brought to you is the clue that makes things that are delivered concrete enough to test across the full board."
+  },
+  "articleBlocks": [
+    "At first, A speech and The daily newspaper pointed in a few different directions, so the board still felt wider than one exact category. One tempting read was \"a broader umbrella topic\". A speech, The daily newspaper can point toward several nearby themes before one clue makes the exact category level visible. Restaurant food brought to you is the clue that narrows the board into one category with clearer boundaries.",
+    "Another nearby read was \"a one-clue surface theme\". Early clues often tempt you to overfit the board around one obvious surface similarity. The final answer works because it keeps every clue at the same level of specificity, not because one clue happens to fit first.",
+    "Once I read the set through a category board focused on things, examples like \"delivered a speech\" and \"delivered the daily newspaper\" stopped feeling loose and started landing cleanly.",
+    "The mail, A knockout blow, Restaurant food brought to you keep the clues at the same category level, which is what makes the board feel like one exact set instead of a broad umbrella theme.",
+    "The answer was \"Things that are delivered\". More precisely, the board resolves as one concrete category with members that stay at the same level of specificity as Things that are delivered, which is why \"Things that are delivered\" fits better than \"a broader umbrella topic\" or \"a one-clue surface theme\" once the full set is checked."
+  ],
+  "solutionNarrative": [
+    "I started by testing A speech and The daily newspaper, but that only gave me a loose direction. I initially drifted toward a broader umbrella topic, because the first clues could still fit several nearby ideas. I held the guess until one clue gave me a more specific way to read the list.",
+    "The turn came when I let \"Restaurant food brought to you\" lead the solve. After that, The mail and A knockout blow became the real confirmation check, because they had to fit the same idea without changing the rule or stretching the answer.",
+    "For the final pass, I checked A speech, The daily newspaper, The mail, A knockout blow, Restaurant food brought to you one by one. The answer worked only if the whole list could stay inside one tight reading, not because one early clue happened to match a broad topic.",
+    "The answer was \"Things that are delivered\"."
+  ],
+  "lessons": [
+    {
+      "title": "\"A speech\" and \"The daily newspaper\" can look like they belong to different categories at first",
+      "body": "When the opening clues feel broad, wait for the clue that turns one fuzzy theme into a testable answer."
+    },
+    {
+      "title": "\"Restaurant food brought to you\" is what makes the answer feel concrete instead of broad",
+      "body": "A strong Pinpoint answer should explain why every clue belongs, not just why the words feel loosely related."
+    },
+    {
+      "title": "Re-check the early clues once \"Restaurant food brought to you\" sharpens the answer",
+      "body": "Once \"Restaurant food brought to you\" lands, go back and test the earlier clues under that same answer before locking it in."
+    }
+  ],
+  "display": {
+    "connectorSummary": "a category board focused on things",
+    "fastStrategy": "When the opening clues feel broad, wait for the clue that turns one fuzzy theme into a testable answer.",
+    "clueTableRows": [
+      {
+        "clue": "A speech",
+        "examplePhrase": "delivered a speech",
+        "connectionExplained": "\"delivered a speech\" fits more cleanly once the board is tested under the same answer as the other clues."
+      },
+      {
+        "clue": "The daily newspaper",
+        "examplePhrase": "delivered the daily newspaper",
+        "connectionExplained": "\"delivered the daily newspaper\" helps confirm the same answer instead of pulling the board back toward a looser guess."
+      },
+      {
+        "clue": "The mail",
+        "examplePhrase": "delivered the mail",
+        "connectionExplained": "\"delivered the mail\" belongs in the same set as the rest of the board, which is why the answer sharpens once this pattern becomes visible."
+      },
+      {
+        "clue": "A knockout blow",
+        "examplePhrase": "delivered a knockout blow",
+        "connectionExplained": "\"delivered a knockout blow\" fits more cleanly once the board is tested under the same answer as the other clues."
+      },
+      {
+        "clue": "Restaurant food brought to you",
+        "examplePhrase": "delivered restaurant food brought to you",
+        "connectionExplained": "\"Restaurant food brought to you\" is the clue that makes the shared answer concrete enough to test across the full board."
+      }
+    ]
+  },
+  "faqs": [
+    {
+      "question": "What final category connects \"A speech\" and \"The daily newspaper\" in LinkedIn Pinpoint #837?",
+      "answer": "The answer is \"Things that are delivered\". That reading is the first one that explains the whole set without forcing any clue."
+    },
+    {
+      "question": "How do \"A speech\" and \"The daily newspaper\" connect in LinkedIn Pinpoint #837?",
+      "answer": "The connection is a category board focused on things. The clues read more cleanly once they are tested under that same idea instead of as a loose theme."
+    },
+    {
+      "question": "Why is \"Restaurant food brought to you\" the key clue in LinkedIn Pinpoint #837?",
+      "answer": "\"Restaurant food brought to you\" is the turning point because it makes the answer concrete enough to test across all five clues."
+    }
+  ],
+  "solvePath": {
+    "firstRead": "At first, A speech and The daily newspaper pointed in a few different directions, so the board still felt wider than one exact category.",
+    "falseStarts": [
+      "a broader umbrella topic",
+      "a one-clue surface theme"
+    ],
+    "whyFalseStartPlausible": [
+      "A speech, The daily newspaper can point toward several nearby themes before one clue makes the exact category level visible.",
+      "Early clues often tempt you to overfit the board around one obvious surface similarity."
+    ],
+    "breakingClue": "Restaurant food brought to you",
+    "pivot": "I started by testing A speech and The daily newspaper, but that only gave me a loose direction. I initially drifted toward a broader umbrella topic, because the first clues could still fit several nearby ideas. I held the guess until one clue gave me a more specific way to read the list.\n\nThe turn came when I let \"Restaurant food brought to you\" lead the solve. After that, The mail and A knockout blow became the real confirmation check, because they had to fit the same idea without changing the rule or stretching the answer.\n\nFor the final pass, I checked A speech, The daily newspaper, The mail, A knockout blow, Restaurant food brought to you one by one. The answer worked only if the whole list could stay inside one tight reading, not because one early clue happened to match a broad topic.\n\nThe answer was \"Things that are delivered\".",
+    "fullBoardConfirmation": "Once I read the set through a category board focused on things, examples like \"delivered a speech\" and \"delivered the daily newspaper\" stopped feeling loose and started landing cleanly."
+  },
+  "turningPoint": {
+    "clue": "Restaurant food brought to you",
+    "whyDecisive": "Restaurant food brought to you is the clue that makes the shared answer concrete enough to test across the full board.",
+    "whatChangedAfterIt": "Once Restaurant food brought to you lands, the earlier clues stop feeling broad and start reading under the same answer."
+  },
+  "clueRows": [
+    {
+      "clue": "A speech",
+      "surfaceMisread": "a broader umbrella topic",
+      "resolvedPhraseOrMember": "delivered a speech",
+      "nonObviousWhy": "\"delivered a speech\" fits more cleanly once the board is tested under the same answer as the other clues.",
+      "searchableContext": "delivered a speech",
+      "phraseExample": "delivered a speech"
+    },
+    {
+      "clue": "The daily newspaper",
+      "surfaceMisread": "a broader umbrella topic",
+      "resolvedPhraseOrMember": "delivered the daily newspaper",
+      "nonObviousWhy": "\"delivered the daily newspaper\" helps confirm the same answer instead of pulling the board back toward a looser guess.",
+      "searchableContext": "delivered the daily newspaper",
+      "phraseExample": "delivered the daily newspaper"
+    },
+    {
+      "clue": "The mail",
+      "surfaceMisread": "a broader umbrella topic",
+      "resolvedPhraseOrMember": "delivered the mail",
+      "nonObviousWhy": "\"delivered the mail\" belongs in the same set as the rest of the board, which is why the answer sharpens once this pattern becomes visible.",
+      "searchableContext": "delivered the mail",
+      "phraseExample": "delivered the mail"
+    },
+    {
+      "clue": "A knockout blow",
+      "surfaceMisread": "a broader umbrella topic",
+      "resolvedPhraseOrMember": "delivered a knockout blow",
+      "nonObviousWhy": "\"delivered a knockout blow\" fits more cleanly once the board is tested under the same answer as the other clues.",
+      "searchableContext": "delivered a knockout blow",
+      "phraseExample": "delivered a knockout blow"
+    },
+    {
+      "clue": "Restaurant food brought to you",
+      "surfaceMisread": "a broader umbrella topic",
+      "resolvedPhraseOrMember": "delivered restaurant food brought to you",
+      "nonObviousWhy": "\"Restaurant food brought to you\" is the clue that makes the shared answer concrete enough to test across the full board.",
+      "searchableContext": "delivered restaurant food brought to you",
+      "phraseExample": "delivered restaurant food brought to you"
+    }
+  ],
+  "faqItems": [
+    {
+      "intentType": "solve_strategy",
+      "question": "What final category connects \"A speech\" and \"The daily newspaper\" in LinkedIn Pinpoint #837?",
+      "answer": "The answer is \"Things that are delivered\". That reading is the first one that explains the whole set without forcing any clue.",
+      "tiedClue": "A speech"
+    },
+    {
+      "intentType": "solve_strategy",
+      "question": "How do \"A speech\" and \"The daily newspaper\" connect in LinkedIn Pinpoint #837?",
+      "answer": "The connection is a category board focused on things. The clues read more cleanly once they are tested under that same idea instead of as a loose theme.",
+      "tiedClue": "A speech"
+    },
+    {
+      "intentType": "clue_background",
+      "question": "Why is \"Restaurant food brought to you\" the key clue in LinkedIn Pinpoint #837?",
+      "answer": "\"Restaurant food brought to you\" is the turning point because it makes the answer concrete enough to test across all five clues.",
+      "tiedClue": "Restaurant food brought to you"
+    }
+  ],
+  "uniquenessSignals": {
+    "angle": "a category board focused on things",
+    "relatedEntities": [
+      "delivered a speech",
+      "delivered the daily newspaper",
+      "delivered the mail",
+      "delivered a knockout blow",
+      "delivered restaurant food brought to you"
+    ],
+    "doNotRepeatPatterns": [
+      "a category board focused on things",
+      "delivered a speech",
+      "delivered the daily newspaper",
+      "delivered the mail",
+      "delivered a knockout blow"
+    ]
+  },
+  "wrongGuessCandidates": [
+    {
+      "label": "a broader umbrella topic",
+      "whyPlausible": "A speech, The daily newspaper can point toward several nearby themes before one clue makes the exact category level visible.",
+      "whyRejected": "Restaurant food brought to you is the clue that narrows the board into one category with clearer boundaries."
+    },
+    {
+      "label": "a one-clue surface theme",
+      "whyPlausible": "Early clues often tempt you to overfit the board around one obvious surface similarity.",
+      "whyRejected": "The final answer works because it keeps every clue at the same level of specificity, not because one clue happens to fit first."
+    }
+  ],
+  "setValidationSummary": "The mail, A knockout blow, Restaurant food brought to you keep the clues at the same category level, which is what makes the board feel like one exact set instead of a broad umbrella theme.",
+  "categoryPrecisionNote": "one concrete category with members that stay at the same level of specificity as Things that are delivered"
+}

--- a/data/puzzles/pinpoint-answer-838.json
+++ b/data/puzzles/pinpoint-answer-838.json
@@ -1,0 +1,218 @@
+{
+  "puzzleNumber": 838,
+  "slug": "pinpoint-answer-838",
+  "publishDate": "2026-08-16",
+  "isoDate": "2026-08-16",
+  "detailState": "fallback_full",
+  "bodyMode": "standard",
+  "pageExperienceMode": "full-analysis",
+  "questionType": "phrase",
+  "difficultyBand": "hard",
+  "clues": [
+    "Freeze",
+    "Time",
+    "Bed",
+    "Door",
+    "Picture (🖼️)"
+  ],
+  "answer": "Words that come before “frame”",
+  "category": "Words that come before “frame”",
+  "wordHints": {
+    "Freeze": "\"Freeze frame\" is a familiar phrase, so it helps reveal the shared word quickly.",
+    "Time": "\"Time frame\" is common enough to confirm the same missing word without stretching the phrasing.",
+    "Bed": "Once the shared word is in place, \"Bed frame\" reads like ordinary language instead of a forced compound.",
+    "Door": "\"Door frame\" is a familiar phrase, so it helps reveal the shared word quickly.",
+    "Picture (🖼️)": "The familiar expression \"Picture frame\" makes the missing word \"frame\" obvious in plain language."
+  },
+  "spoilerHints": {
+    "Freeze": "Try reading Freeze as part of a familiar phrase in words that come before “frame” instead of as a standalone word.",
+    "Time": "Time works better once you test a fixed phrase pattern rather than a broad topic.",
+    "Bed": "Look for a natural expression that absorbs Bed cleanly before locking the board.",
+    "Door": "Try reading Door as part of a familiar phrase in words that come before “frame” instead of as a standalone word.",
+    "Picture (🖼️)": "Picture (🖼️) is the clue that makes the phrase pattern in words that come before “frame” concrete enough to test."
+  },
+  "articleBlocks": [
+    "The first clues make it clear this is a shared-word phrase puzzle, but not which ending word belongs after every clue without forcing the read. A nearby read was \"Freeze and Time phrase pairing\". Freeze, Time can support more than one phrase read before Picture (🖼️) shows where the repeated word belongs. Picture (🖼️) behaves like a proof clue for one fixed phrase pattern, not just an early two-clue guess.",
+    "Another easy trap was \"Picture (🖼️) as an outlier clue\". Picture (🖼️) can look like the odd clue if the earlier words are read without a shared phrase slot. Once Picture (🖼️) locks the phrase position, the full board resolves under one repeated word instead of five separate definitions.",
+    "Once that phrase appears, examples like \"Freeze frame\" and \"Time frame\" stop feeling guessed and start reading like ordinary language under familiar phrases completed by one shared ending word.",
+    "Bed frame, Door frame, Picture frame show that the same shared word fits in the same slot across the whole board, so the answer behaves like one complete phrase family instead of a few lucky matches.",
+    "The answer was \"Words that come before “frame”\". More precisely, the board resolves as one shared ending word placed after each clue, not a loose topic grouping, which is why \"Words that come before “frame”\" fits better than \"Freeze and Time phrase pairing\" or \"Picture (🖼️) as an outlier clue\" once the full set is checked."
+  ],
+  "solutionNarrative": [
+    "I started with Freeze and first tried Freeze and Time phrase pairing. That was plausible for a moment, because the opening clues were broad enough to support a few loose phrase reads. But none of those guesses made \"Picture (🖼️)\" feel exact.",
+    "Once \"Picture (🖼️)\" clicked, I stopped treating it like an outlier and tested the phrase position directly. The missing word could fit after the earlier clues without forcing them, which changed the solve from a topic guess into a repeatable word-slot check.",
+    "Then I used Bed and Door as the confirmation round. The strong solve was not just that two clues worked; it was that Freeze, Time, Bed, Door, Picture (🖼️) could all use the same slot and still sound like ordinary language.",
+    "The answer was \"Words that come before “frame”\"."
+  ],
+  "lessons": [
+    {
+      "title": "A false start with \"Freeze\" and \"Time\"",
+      "body": "\"Freeze\" and \"Time\" each work in multiple phrase frames, so it is better to wait for a clue that forces one exact missing word before committing."
+    },
+    {
+      "title": "\"Picture (🖼️)\" changes the frame pattern from guess to test",
+      "body": "Once \"Picture (🖼️)\" lands, place the same word after the other clues and make sure they read naturally right away."
+    },
+    {
+      "title": "For Pinpoint 838, the frame phrase test has to work five times",
+      "body": "A good answer should create phrases people actually say, not just words that seem related from a distance."
+    }
+  ],
+  "display": {
+    "connectorSummary": "familiar phrases completed by one shared ending word",
+    "fastStrategy": "\"Freeze\" and \"Time\" each work in multiple phrase frames, so it is better to wait for a clue that forces one exact missing word before committing.",
+    "clueTableRows": [
+      {
+        "clue": "Freeze",
+        "examplePhrase": "Freeze frame",
+        "connectionExplained": "\"Freeze frame\" is a familiar phrase, so it helps reveal the shared word quickly."
+      },
+      {
+        "clue": "Time",
+        "examplePhrase": "Time frame",
+        "connectionExplained": "\"Time frame\" is common enough to confirm the same missing word without stretching the phrasing."
+      },
+      {
+        "clue": "Bed",
+        "examplePhrase": "Bed frame",
+        "connectionExplained": "Once the shared word is in place, \"Bed frame\" reads like ordinary language instead of a forced compound."
+      },
+      {
+        "clue": "Door",
+        "examplePhrase": "Door frame",
+        "connectionExplained": "\"Door frame\" is a familiar phrase, so it helps reveal the shared word quickly."
+      },
+      {
+        "clue": "Picture (🖼️)",
+        "examplePhrase": "Picture frame",
+        "connectionExplained": "The familiar expression \"Picture frame\" makes the missing word \"frame\" obvious in plain language."
+      }
+    ]
+  },
+  "faqs": [
+    {
+      "question": "What shared word links \"Freeze\" and \"Time\" in LinkedIn Pinpoint #838?",
+      "answer": "The answer is \"Words that come before “frame”\". That reading is the first one that turns all five clues into familiar phrases or common terms."
+    },
+    {
+      "question": "How do \"Freeze\" and \"Time\" connect in LinkedIn Pinpoint #838?",
+      "answer": "The connection is familiar phrases completed by one shared ending word. The same word fits after every clue to create familiar phrases or everyday terms."
+    },
+    {
+      "question": "Why is \"Picture (🖼️)\" the key clue in LinkedIn Pinpoint #838?",
+      "answer": "\"Picture (🖼️)\" is the strongest clue because \"Picture frame\" points to one exact phrase much faster than the earlier clues do."
+    }
+  ],
+  "solvePath": {
+    "firstRead": "The first clues make it clear this is a shared-word phrase puzzle, but not which ending word belongs after every clue without forcing the read.",
+    "falseStarts": [
+      "Freeze and Time phrase pairing",
+      "Picture (🖼️) as an outlier clue"
+    ],
+    "whyFalseStartPlausible": [
+      "Freeze, Time can support more than one phrase read before Picture (🖼️) shows where the repeated word belongs.",
+      "Picture (🖼️) can look like the odd clue if the earlier words are read without a shared phrase slot."
+    ],
+    "breakingClue": "Picture (🖼️)",
+    "pivot": "I started with Freeze and first tried Freeze and Time phrase pairing. That was plausible for a moment, because the opening clues were broad enough to support a few loose phrase reads. But none of those guesses made \"Picture (🖼️)\" feel exact.\n\nOnce \"Picture (🖼️)\" clicked, I stopped treating it like an outlier and tested the phrase position directly. The missing word could fit after the earlier clues without forcing them, which changed the solve from a topic guess into a repeatable word-slot check.\n\nThen I used Bed and Door as the confirmation round. The strong solve was not just that two clues worked; it was that Freeze, Time, Bed, Door, Picture (🖼️) could all use the same slot and still sound like ordinary language.\n\nThe answer was \"Words that come before “frame”\".",
+    "fullBoardConfirmation": "Another easy trap was \"Picture (🖼️) as an outlier clue\". Picture (🖼️) can look like the odd clue if the earlier words are read without a shared phrase slot. Once Picture (🖼️) locks the phrase position, the full board resolves under one repeated word instead of five separate definitions."
+  },
+  "turningPoint": {
+    "clue": "Picture (🖼️)",
+    "whyDecisive": "Picture (🖼️) is the clue that makes the shared answer concrete enough to test across the full board.",
+    "whatChangedAfterIt": "Once Picture (🖼️) lands, the earlier clues stop feeling broad and start reading under the same answer."
+  },
+  "clueRows": [
+    {
+      "clue": "Freeze",
+      "surfaceMisread": "Freeze and Time phrase pairing",
+      "resolvedPhraseOrMember": "Freeze frame",
+      "nonObviousWhy": "\"Freeze frame\" is a familiar phrase, so it helps reveal the shared word quickly.",
+      "searchableContext": "Freeze frame",
+      "phraseExample": "Freeze frame"
+    },
+    {
+      "clue": "Time",
+      "surfaceMisread": "Freeze and Time phrase pairing",
+      "resolvedPhraseOrMember": "Time frame",
+      "nonObviousWhy": "\"Time frame\" is common enough to confirm the same missing word without stretching the phrasing.",
+      "searchableContext": "Time frame",
+      "phraseExample": "Time frame"
+    },
+    {
+      "clue": "Bed",
+      "surfaceMisread": "Freeze and Time phrase pairing",
+      "resolvedPhraseOrMember": "Bed frame",
+      "nonObviousWhy": "Once the shared word is in place, \"Bed frame\" reads like ordinary language instead of a forced compound.",
+      "searchableContext": "Bed frame",
+      "phraseExample": "Bed frame"
+    },
+    {
+      "clue": "Door",
+      "surfaceMisread": "Freeze and Time phrase pairing",
+      "resolvedPhraseOrMember": "Door frame",
+      "nonObviousWhy": "\"Door frame\" is a familiar phrase, so it helps reveal the shared word quickly.",
+      "searchableContext": "Door frame",
+      "phraseExample": "Door frame"
+    },
+    {
+      "clue": "Picture (🖼️)",
+      "surfaceMisread": "Freeze and Time phrase pairing",
+      "resolvedPhraseOrMember": "Picture frame",
+      "nonObviousWhy": "The familiar expression \"Picture frame\" makes the missing word \"frame\" obvious in plain language.",
+      "searchableContext": "Picture frame",
+      "phraseExample": "Picture frame"
+    }
+  ],
+  "faqItems": [
+    {
+      "intentType": "solve_strategy",
+      "question": "What shared word links \"Freeze\" and \"Time\" in LinkedIn Pinpoint #838?",
+      "answer": "The answer is \"Words that come before “frame”\". That reading is the first one that turns all five clues into familiar phrases or common terms.",
+      "tiedClue": "Freeze"
+    },
+    {
+      "intentType": "solve_strategy",
+      "question": "How do \"Freeze\" and \"Time\" connect in LinkedIn Pinpoint #838?",
+      "answer": "The connection is familiar phrases completed by one shared ending word. The same word fits after every clue to create familiar phrases or everyday terms.",
+      "tiedClue": "Freeze"
+    },
+    {
+      "intentType": "clue_background",
+      "question": "Why is \"Picture (🖼️)\" the key clue in LinkedIn Pinpoint #838?",
+      "answer": "\"Picture (🖼️)\" is the strongest clue because \"Picture frame\" points to one exact phrase much faster than the earlier clues do.",
+      "tiedClue": "Picture (🖼️)"
+    }
+  ],
+  "uniquenessSignals": {
+    "angle": "familiar phrases completed by one shared ending word",
+    "relatedEntities": [
+      "Freeze frame",
+      "Time frame",
+      "Bed frame",
+      "Door frame",
+      "Picture frame"
+    ],
+    "doNotRepeatPatterns": [
+      "familiar phrases completed by one shared ending word",
+      "Freeze frame",
+      "Time frame",
+      "Bed frame",
+      "Door frame"
+    ]
+  },
+  "wrongGuessCandidates": [
+    {
+      "label": "Freeze and Time phrase pairing",
+      "whyPlausible": "Freeze, Time can support more than one phrase read before Picture (🖼️) shows where the repeated word belongs.",
+      "whyRejected": "Picture (🖼️) behaves like a proof clue for one fixed phrase pattern, not just an early two-clue guess."
+    },
+    {
+      "label": "Picture (🖼️) as an outlier clue",
+      "whyPlausible": "Picture (🖼️) can look like the odd clue if the earlier words are read without a shared phrase slot.",
+      "whyRejected": "Once Picture (🖼️) locks the phrase position, the full board resolves under one repeated word instead of five separate definitions."
+    }
+  ],
+  "setValidationSummary": "Bed frame, Door frame, Picture frame show that the same shared word fits in the same slot across the whole board, so the answer behaves like one complete phrase family instead of a few lucky matches.",
+  "categoryPrecisionNote": "one shared ending word placed after each clue, not a loose topic grouping"
+}

--- a/data/puzzles/pinpoint-answer-839.json
+++ b/data/puzzles/pinpoint-answer-839.json
@@ -1,0 +1,217 @@
+{
+  "puzzleNumber": 839,
+  "slug": "pinpoint-answer-839",
+  "publishDate": "2026-08-17",
+  "isoDate": "2026-08-17",
+  "detailState": "fallback_full",
+  "bodyMode": "standard",
+  "pageExperienceMode": "full-analysis",
+  "questionType": "category",
+  "difficultyBand": "hard",
+  "clues": [
+    "Dram",
+    "Krone",
+    "Rupee",
+    "Peso",
+    "Euro (€)"
+  ],
+  "answer": "Names of world currencies",
+  "category": "Names of world currencies",
+  "wordHints": {
+    "Dram": "\"Dram as a world currency\" fits more cleanly once the board is tested under the same answer as the other clues.",
+    "Krone": "\"Krone as a world currency\" helps confirm the same answer instead of pulling the board back toward a looser guess.",
+    "Rupee": "\"Rupee as a world currency\" belongs in the same set as the rest of the board, which is why the answer sharpens once this pattern becomes visible.",
+    "Peso": "\"Peso as a world currency\" fits more cleanly once the board is tested under the same answer as the other clues.",
+    "Euro (€)": "\"Euro (€)\" is the clue that makes the shared answer concrete enough to test across the full board."
+  },
+  "spoilerHints": {
+    "Dram": "Dram should be tested as part of names of world currencies, not as a standalone reference.",
+    "Krone": "Keep Krone in mind, then see whether Euro (€) supports the same answer.",
+    "Rupee": "Rupee works best after the board narrows toward names of world currencies.",
+    "Peso": "Peso should be tested as part of names of world currencies, not as a standalone reference.",
+    "Euro (€)": "Euro (€) is the clue that makes names of world currencies concrete enough to test across the full board."
+  },
+  "articleBlocks": [
+    "At first, Dram and Krone pointed in a few different directions, so the board still felt wider than one exact category. One tempting read was \"a broader umbrella topic\". Dram, Krone can point toward several nearby themes before one clue makes the exact category level visible. Euro (€) is the clue that narrows the board into one category with clearer boundaries. Another nearby read was \"a one-clue surface theme\". Early clues often tempt you to overfit the board around one obvious surface similarity. The final answer works because it keeps every clue at the same level of specificity, not because one clue happens to fit first.",
+    "Once I read the set through a category board focused on names, examples like \"Dram as a world currency\" and \"Krone as a world currency\" stopped feeling loose and started landing cleanly.",
+    "Rupee, Peso, Euro (€) keep the clues at the same category level, which is what makes the board feel like one exact set instead of a broad umbrella theme.",
+    "The answer was \"Names of world currencies\". More precisely, the board resolves as one concrete category with members that stay at the same level of specificity as Names of world currencies, which is why \"Names of world currencies\" fits better than \"a broader umbrella topic\" or \"a one-clue surface theme\" once the full set is checked."
+  ],
+  "solutionNarrative": [
+    "I started by testing Dram and Krone, but that only gave me a loose direction. I initially drifted toward a broader umbrella topic, because the first clues could still fit several nearby ideas. I held the guess until one clue gave me a more specific way to read the list.",
+    "The turn came when I let \"Euro (€)\" lead the solve. After that, Rupee and Peso became the real confirmation check, because they had to fit the same idea without changing the rule or stretching the answer.",
+    "For the final pass, I checked Dram, Krone, Rupee, Peso, Euro (€) one by one. The answer worked only if the whole list could stay inside one tight reading, not because one early clue happened to match a broad topic.",
+    "The answer was \"Names of world currencies\"."
+  ],
+  "lessons": [
+    {
+      "title": "\"Dram\" and \"Krone\" can look like they belong to different categories at first",
+      "body": "When the opening clues feel broad, wait for the clue that turns one fuzzy theme into a testable answer."
+    },
+    {
+      "title": "\"Euro (€)\" is what makes the answer feel concrete instead of broad",
+      "body": "A strong Pinpoint answer should explain why every clue belongs, not just why the words feel loosely related."
+    },
+    {
+      "title": "Re-check the early clues once \"Euro (€)\" sharpens the answer",
+      "body": "Once \"Euro (€)\" lands, go back and test the earlier clues under that same answer before locking it in."
+    }
+  ],
+  "display": {
+    "connectorSummary": "a category board focused on names",
+    "fastStrategy": "When the opening clues feel broad, wait for the clue that turns one fuzzy theme into a testable answer.",
+    "clueTableRows": [
+      {
+        "clue": "Dram",
+        "examplePhrase": "Dram as a world currency",
+        "connectionExplained": "\"Dram as a world currency\" fits more cleanly once the board is tested under the same answer as the other clues."
+      },
+      {
+        "clue": "Krone",
+        "examplePhrase": "Krone as a world currency",
+        "connectionExplained": "\"Krone as a world currency\" helps confirm the same answer instead of pulling the board back toward a looser guess."
+      },
+      {
+        "clue": "Rupee",
+        "examplePhrase": "Rupee as a world currency",
+        "connectionExplained": "\"Rupee as a world currency\" belongs in the same set as the rest of the board, which is why the answer sharpens once this pattern becomes visible."
+      },
+      {
+        "clue": "Peso",
+        "examplePhrase": "Peso as a world currency",
+        "connectionExplained": "\"Peso as a world currency\" fits more cleanly once the board is tested under the same answer as the other clues."
+      },
+      {
+        "clue": "Euro (€)",
+        "examplePhrase": "Euro as a world currency",
+        "connectionExplained": "\"Euro (€)\" is the clue that makes the shared answer concrete enough to test across the full board."
+      }
+    ]
+  },
+  "faqs": [
+    {
+      "question": "What final category connects \"Dram\" and \"Krone\" in LinkedIn Pinpoint #839?",
+      "answer": "The answer is \"Names of world currencies\". That reading is the first one that explains the whole set without forcing any clue."
+    },
+    {
+      "question": "How do \"Dram\" and \"Krone\" connect in LinkedIn Pinpoint #839?",
+      "answer": "The connection is a category board focused on names. The clues read more cleanly once they are tested under that same idea instead of as a loose theme."
+    },
+    {
+      "question": "Why is \"Euro (€)\" the key clue in LinkedIn Pinpoint #839?",
+      "answer": "\"Euro (€)\" is the turning point because it makes the answer concrete enough to test across all five clues."
+    }
+  ],
+  "solvePath": {
+    "firstRead": "At first, Dram and Krone pointed in a few different directions, so the board still felt wider than one exact category.",
+    "falseStarts": [
+      "a broader umbrella topic",
+      "a one-clue surface theme"
+    ],
+    "whyFalseStartPlausible": [
+      "Dram, Krone can point toward several nearby themes before one clue makes the exact category level visible.",
+      "Early clues often tempt you to overfit the board around one obvious surface similarity."
+    ],
+    "breakingClue": "Euro (€)",
+    "pivot": "I started by testing Dram and Krone, but that only gave me a loose direction. I initially drifted toward a broader umbrella topic, because the first clues could still fit several nearby ideas. I held the guess until one clue gave me a more specific way to read the list.\n\nThe turn came when I let \"Euro (€)\" lead the solve. After that, Rupee and Peso became the real confirmation check, because they had to fit the same idea without changing the rule or stretching the answer.\n\nFor the final pass, I checked Dram, Krone, Rupee, Peso, Euro (€) one by one. The answer worked only if the whole list could stay inside one tight reading, not because one early clue happened to match a broad topic.\n\nThe answer was \"Names of world currencies\".",
+    "fullBoardConfirmation": "Once I read the set through a category board focused on names, examples like \"Dram as a world currency\" and \"Krone as a world currency\" stopped feeling loose and started landing cleanly."
+  },
+  "turningPoint": {
+    "clue": "Euro (€)",
+    "whyDecisive": "Euro (€) is the clue that makes the shared answer concrete enough to test across the full board.",
+    "whatChangedAfterIt": "Once Euro (€) lands, the earlier clues stop feeling broad and start reading under the same answer."
+  },
+  "clueRows": [
+    {
+      "clue": "Dram",
+      "surfaceMisread": "a broader umbrella topic",
+      "resolvedPhraseOrMember": "Dram as a world currency",
+      "nonObviousWhy": "\"Dram as a world currency\" fits more cleanly once the board is tested under the same answer as the other clues.",
+      "searchableContext": "Dram as a world currency",
+      "phraseExample": "Dram as a world currency"
+    },
+    {
+      "clue": "Krone",
+      "surfaceMisread": "a broader umbrella topic",
+      "resolvedPhraseOrMember": "Krone as a world currency",
+      "nonObviousWhy": "\"Krone as a world currency\" helps confirm the same answer instead of pulling the board back toward a looser guess.",
+      "searchableContext": "Krone as a world currency",
+      "phraseExample": "Krone as a world currency"
+    },
+    {
+      "clue": "Rupee",
+      "surfaceMisread": "a broader umbrella topic",
+      "resolvedPhraseOrMember": "Rupee as a world currency",
+      "nonObviousWhy": "\"Rupee as a world currency\" belongs in the same set as the rest of the board, which is why the answer sharpens once this pattern becomes visible.",
+      "searchableContext": "Rupee as a world currency",
+      "phraseExample": "Rupee as a world currency"
+    },
+    {
+      "clue": "Peso",
+      "surfaceMisread": "a broader umbrella topic",
+      "resolvedPhraseOrMember": "Peso as a world currency",
+      "nonObviousWhy": "\"Peso as a world currency\" fits more cleanly once the board is tested under the same answer as the other clues.",
+      "searchableContext": "Peso as a world currency",
+      "phraseExample": "Peso as a world currency"
+    },
+    {
+      "clue": "Euro (€)",
+      "surfaceMisread": "a broader umbrella topic",
+      "resolvedPhraseOrMember": "Euro as a world currency",
+      "nonObviousWhy": "\"Euro (€)\" is the clue that makes the shared answer concrete enough to test across the full board.",
+      "searchableContext": "Euro as a world currency",
+      "phraseExample": "Euro as a world currency"
+    }
+  ],
+  "faqItems": [
+    {
+      "intentType": "solve_strategy",
+      "question": "What final category connects \"Dram\" and \"Krone\" in LinkedIn Pinpoint #839?",
+      "answer": "The answer is \"Names of world currencies\". That reading is the first one that explains the whole set without forcing any clue.",
+      "tiedClue": "Dram"
+    },
+    {
+      "intentType": "solve_strategy",
+      "question": "How do \"Dram\" and \"Krone\" connect in LinkedIn Pinpoint #839?",
+      "answer": "The connection is a category board focused on names. The clues read more cleanly once they are tested under that same idea instead of as a loose theme.",
+      "tiedClue": "Dram"
+    },
+    {
+      "intentType": "clue_background",
+      "question": "Why is \"Euro (€)\" the key clue in LinkedIn Pinpoint #839?",
+      "answer": "\"Euro (€)\" is the turning point because it makes the answer concrete enough to test across all five clues.",
+      "tiedClue": "Euro (€)"
+    }
+  ],
+  "uniquenessSignals": {
+    "angle": "a category board focused on names",
+    "relatedEntities": [
+      "Dram as a world currency",
+      "Krone as a world currency",
+      "Rupee as a world currency",
+      "Peso as a world currency",
+      "Euro as a world currency"
+    ],
+    "doNotRepeatPatterns": [
+      "a category board focused on names",
+      "Dram as a world currency",
+      "Krone as a world currency",
+      "Rupee as a world currency",
+      "Peso as a world currency"
+    ]
+  },
+  "wrongGuessCandidates": [
+    {
+      "label": "a broader umbrella topic",
+      "whyPlausible": "Dram, Krone can point toward several nearby themes before one clue makes the exact category level visible.",
+      "whyRejected": "Euro (€) is the clue that narrows the board into one category with clearer boundaries."
+    },
+    {
+      "label": "a one-clue surface theme",
+      "whyPlausible": "Early clues often tempt you to overfit the board around one obvious surface similarity.",
+      "whyRejected": "The final answer works because it keeps every clue at the same level of specificity, not because one clue happens to fit first."
+    }
+  ],
+  "setValidationSummary": "Rupee, Peso, Euro (€) keep the clues at the same category level, which is what makes the board feel like one exact set instead of a broad umbrella theme.",
+  "categoryPrecisionNote": "one concrete category with members that stay at the same level of specificity as Names of world currencies"
+}

--- a/data/puzzles/pinpoint-answer-840.json
+++ b/data/puzzles/pinpoint-answer-840.json
@@ -1,0 +1,218 @@
+{
+  "puzzleNumber": 840,
+  "slug": "pinpoint-answer-840",
+  "publishDate": "2026-08-18",
+  "isoDate": "2026-08-18",
+  "detailState": "fallback_full",
+  "bodyMode": "standard",
+  "pageExperienceMode": "full-analysis",
+  "questionType": "category",
+  "difficultyBand": "hard",
+  "clues": [
+    "The Muppets",
+    "Star Wars",
+    "Marvel",
+    "Pixar",
+    "Mickey Mouse"
+  ],
+  "answer": "Properties of The Walt Disney Company",
+  "category": "Properties of The Walt Disney Company",
+  "wordHints": {
+    "The Muppets": "\"The Muppets\" is the clue that makes the shared answer concrete enough to test across the full board.",
+    "Star Wars": "\"Category example: Star Wars\" helps confirm the same answer instead of pulling the board back toward a looser guess.",
+    "Marvel": "\"Category example: Marvel\" belongs in the same set as the rest of the board, which is why the answer sharpens once this pattern becomes visible.",
+    "Pixar": "\"Category example: Pixar\" fits more cleanly once the board is tested under the same answer as the other clues.",
+    "Mickey Mouse": "\"Category example: Mickey Mouse\" helps confirm the same answer instead of pulling the board back toward a looser guess."
+  },
+  "spoilerHints": {
+    "The Muppets": "The Muppets is the clue that makes properties of the walt disney company concrete enough to test across the full board.",
+    "Star Wars": "Keep Star Wars in mind, then see whether The Muppets supports the same answer.",
+    "Marvel": "Marvel works best after the board narrows toward properties of the walt disney company.",
+    "Pixar": "Pixar should be tested as part of properties of the walt disney company, not as a standalone reference.",
+    "Mickey Mouse": "Keep Mickey Mouse in mind, then see whether The Muppets supports the same answer."
+  },
+  "articleBlocks": [
+    "At first, The Muppets and Star Wars pointed in a few different directions, so the board still felt wider than one exact category. One tempting read was \"a broader umbrella topic\". The Muppets, Star Wars can point toward several nearby themes before one clue makes the exact category level visible. The Muppets is the clue that narrows the board into one category with clearer boundaries.",
+    "Another nearby read was \"a one-clue surface theme\". Early clues often tempt you to overfit the board around one obvious surface similarity. The final answer works because it keeps every clue at the same level of specificity, not because one clue happens to fit first.",
+    "Once I read the set through a category board focused on properties, examples like \"Category example: The Muppets\" and \"Category example: Star Wars\" stopped feeling loose and started landing cleanly.",
+    "Marvel, Pixar, Mickey Mouse keep the clues at the same category level, which is what makes the board feel like one exact set instead of a broad umbrella theme.",
+    "The answer was \"Properties of The Walt Disney Company\". More precisely, the board resolves as one concrete category with members that stay at the same level of specificity as Properties of The Walt Disney Company, which is why \"Properties of The Walt Disney Company\" fits better than \"a broader umbrella topic\" or \"a one-clue surface theme\" once the full set is checked."
+  ],
+  "solutionNarrative": [
+    "I started by testing Star Wars and Marvel, but that only gave me a loose direction. I initially drifted toward a broader umbrella topic, because the first clues could still fit several nearby ideas. I held the guess until one clue gave me a more specific way to read the list.",
+    "The turn came when I let \"The Muppets\" lead the solve. After that, Pixar and Mickey Mouse became the real confirmation check, because they had to fit the same idea without changing the rule or stretching the answer.",
+    "For the final pass, I checked The Muppets, Star Wars, Marvel, Pixar, Mickey Mouse one by one. The answer worked only if the whole list could stay inside one tight reading, not because one early clue happened to match a broad topic.",
+    "The answer was \"Properties of The Walt Disney Company\"."
+  ],
+  "lessons": [
+    {
+      "title": "\"The Muppets\" and \"Star Wars\" can look like they belong to different categories at first",
+      "body": "When the opening clues feel broad, wait for the clue that turns one fuzzy theme into a testable answer."
+    },
+    {
+      "title": "\"The Muppets\" is what makes the answer feel concrete instead of broad",
+      "body": "A strong Pinpoint answer should explain why every clue belongs, not just why the words feel loosely related."
+    },
+    {
+      "title": "Re-check the early clues once \"The Muppets\" sharpens the answer",
+      "body": "Once \"The Muppets\" lands, go back and test the earlier clues under that same answer before locking it in."
+    }
+  ],
+  "display": {
+    "connectorSummary": "a category board focused on properties",
+    "fastStrategy": "When the opening clues feel broad, wait for the clue that turns one fuzzy theme into a testable answer.",
+    "clueTableRows": [
+      {
+        "clue": "The Muppets",
+        "examplePhrase": "Category example: The Muppets",
+        "connectionExplained": "\"The Muppets\" is the clue that makes the shared answer concrete enough to test across the full board."
+      },
+      {
+        "clue": "Star Wars",
+        "examplePhrase": "Category example: Star Wars",
+        "connectionExplained": "\"Category example: Star Wars\" helps confirm the same answer instead of pulling the board back toward a looser guess."
+      },
+      {
+        "clue": "Marvel",
+        "examplePhrase": "Category example: Marvel",
+        "connectionExplained": "\"Category example: Marvel\" belongs in the same set as the rest of the board, which is why the answer sharpens once this pattern becomes visible."
+      },
+      {
+        "clue": "Pixar",
+        "examplePhrase": "Category example: Pixar",
+        "connectionExplained": "\"Category example: Pixar\" fits more cleanly once the board is tested under the same answer as the other clues."
+      },
+      {
+        "clue": "Mickey Mouse",
+        "examplePhrase": "Category example: Mickey Mouse",
+        "connectionExplained": "\"Category example: Mickey Mouse\" helps confirm the same answer instead of pulling the board back toward a looser guess."
+      }
+    ]
+  },
+  "faqs": [
+    {
+      "question": "What final category connects \"The Muppets\" and \"Star Wars\" in LinkedIn Pinpoint #840?",
+      "answer": "The answer is \"Properties of The Walt Disney Company\". That reading is the first one that explains the whole set without forcing any clue."
+    },
+    {
+      "question": "How do \"The Muppets\" and \"Star Wars\" connect in LinkedIn Pinpoint #840?",
+      "answer": "The connection is a category board focused on properties. The clues read more cleanly once they are tested under that same idea instead of as a loose theme."
+    },
+    {
+      "question": "Why is \"The Muppets\" the key clue in LinkedIn Pinpoint #840?",
+      "answer": "\"The Muppets\" is the turning point because it makes the answer concrete enough to test across all five clues."
+    }
+  ],
+  "solvePath": {
+    "firstRead": "At first, The Muppets and Star Wars pointed in a few different directions, so the board still felt wider than one exact category.",
+    "falseStarts": [
+      "a broader umbrella topic",
+      "a one-clue surface theme"
+    ],
+    "whyFalseStartPlausible": [
+      "The Muppets, Star Wars can point toward several nearby themes before one clue makes the exact category level visible.",
+      "Early clues often tempt you to overfit the board around one obvious surface similarity."
+    ],
+    "breakingClue": "The Muppets",
+    "pivot": "I started by testing Star Wars and Marvel, but that only gave me a loose direction. I initially drifted toward a broader umbrella topic, because the first clues could still fit several nearby ideas. I held the guess until one clue gave me a more specific way to read the list.\n\nThe turn came when I let \"The Muppets\" lead the solve. After that, Pixar and Mickey Mouse became the real confirmation check, because they had to fit the same idea without changing the rule or stretching the answer.\n\nFor the final pass, I checked The Muppets, Star Wars, Marvel, Pixar, Mickey Mouse one by one. The answer worked only if the whole list could stay inside one tight reading, not because one early clue happened to match a broad topic.\n\nThe answer was \"Properties of The Walt Disney Company\".",
+    "fullBoardConfirmation": "Once I read the set through a category board focused on properties, examples like \"Category example: The Muppets\" and \"Category example: Star Wars\" stopped feeling loose and started landing cleanly."
+  },
+  "turningPoint": {
+    "clue": "The Muppets",
+    "whyDecisive": "The Muppets is the clue that makes the shared answer concrete enough to test across the full board.",
+    "whatChangedAfterIt": "Once The Muppets lands, the earlier clues stop feeling broad and start reading under the same answer."
+  },
+  "clueRows": [
+    {
+      "clue": "The Muppets",
+      "surfaceMisread": "a broader umbrella topic",
+      "resolvedPhraseOrMember": "Category example: The Muppets",
+      "nonObviousWhy": "\"The Muppets\" is the clue that makes the shared answer concrete enough to test across the full board.",
+      "searchableContext": "Category example: The Muppets",
+      "phraseExample": "Category example: The Muppets"
+    },
+    {
+      "clue": "Star Wars",
+      "surfaceMisread": "a broader umbrella topic",
+      "resolvedPhraseOrMember": "Category example: Star Wars",
+      "nonObviousWhy": "\"Category example: Star Wars\" helps confirm the same answer instead of pulling the board back toward a looser guess.",
+      "searchableContext": "Category example: Star Wars",
+      "phraseExample": "Category example: Star Wars"
+    },
+    {
+      "clue": "Marvel",
+      "surfaceMisread": "a broader umbrella topic",
+      "resolvedPhraseOrMember": "Category example: Marvel",
+      "nonObviousWhy": "\"Category example: Marvel\" belongs in the same set as the rest of the board, which is why the answer sharpens once this pattern becomes visible.",
+      "searchableContext": "Category example: Marvel",
+      "phraseExample": "Category example: Marvel"
+    },
+    {
+      "clue": "Pixar",
+      "surfaceMisread": "a broader umbrella topic",
+      "resolvedPhraseOrMember": "Category example: Pixar",
+      "nonObviousWhy": "\"Category example: Pixar\" fits more cleanly once the board is tested under the same answer as the other clues.",
+      "searchableContext": "Category example: Pixar",
+      "phraseExample": "Category example: Pixar"
+    },
+    {
+      "clue": "Mickey Mouse",
+      "surfaceMisread": "a broader umbrella topic",
+      "resolvedPhraseOrMember": "Category example: Mickey Mouse",
+      "nonObviousWhy": "\"Category example: Mickey Mouse\" helps confirm the same answer instead of pulling the board back toward a looser guess.",
+      "searchableContext": "Category example: Mickey Mouse",
+      "phraseExample": "Category example: Mickey Mouse"
+    }
+  ],
+  "faqItems": [
+    {
+      "intentType": "solve_strategy",
+      "question": "What final category connects \"The Muppets\" and \"Star Wars\" in LinkedIn Pinpoint #840?",
+      "answer": "The answer is \"Properties of The Walt Disney Company\". That reading is the first one that explains the whole set without forcing any clue.",
+      "tiedClue": "The Muppets"
+    },
+    {
+      "intentType": "solve_strategy",
+      "question": "How do \"The Muppets\" and \"Star Wars\" connect in LinkedIn Pinpoint #840?",
+      "answer": "The connection is a category board focused on properties. The clues read more cleanly once they are tested under that same idea instead of as a loose theme.",
+      "tiedClue": "The Muppets"
+    },
+    {
+      "intentType": "clue_background",
+      "question": "Why is \"The Muppets\" the key clue in LinkedIn Pinpoint #840?",
+      "answer": "\"The Muppets\" is the turning point because it makes the answer concrete enough to test across all five clues.",
+      "tiedClue": "The Muppets"
+    }
+  ],
+  "uniquenessSignals": {
+    "angle": "a category board focused on properties",
+    "relatedEntities": [
+      "Category example: The Muppets",
+      "Category example: Star Wars",
+      "Category example: Marvel",
+      "Category example: Pixar",
+      "Category example: Mickey Mouse"
+    ],
+    "doNotRepeatPatterns": [
+      "a category board focused on properties",
+      "Category example: The Muppets",
+      "Category example: Star Wars",
+      "Category example: Marvel",
+      "Category example: Pixar"
+    ]
+  },
+  "wrongGuessCandidates": [
+    {
+      "label": "a broader umbrella topic",
+      "whyPlausible": "The Muppets, Star Wars can point toward several nearby themes before one clue makes the exact category level visible.",
+      "whyRejected": "The Muppets is the clue that narrows the board into one category with clearer boundaries."
+    },
+    {
+      "label": "a one-clue surface theme",
+      "whyPlausible": "Early clues often tempt you to overfit the board around one obvious surface similarity.",
+      "whyRejected": "The final answer works because it keeps every clue at the same level of specificity, not because one clue happens to fit first."
+    }
+  ],
+  "setValidationSummary": "Marvel, Pixar, Mickey Mouse keep the clues at the same category level, which is what makes the board feel like one exact set instead of a broad umbrella theme.",
+  "categoryPrecisionNote": "one concrete category with members that stay at the same level of specificity as Properties of The Walt Disney Company"
+}

--- a/data/puzzles/pinpoint-answer-841.json
+++ b/data/puzzles/pinpoint-answer-841.json
@@ -1,0 +1,218 @@
+{
+  "puzzleNumber": 841,
+  "slug": "pinpoint-answer-841",
+  "publishDate": "2026-08-19",
+  "isoDate": "2026-08-19",
+  "detailState": "fallback_full",
+  "bodyMode": "standard",
+  "pageExperienceMode": "full-analysis",
+  "questionType": "category",
+  "difficultyBand": "hard",
+  "clues": [
+    "William and Caroline Herschel",
+    "Tycho Brahe",
+    "Carl Sagan",
+    "Nicolaus Copernicus",
+    "Galileo Galilei"
+  ],
+  "answer": "Famous astronomers",
+  "category": "Famous astronomers",
+  "wordHints": {
+    "William and Caroline Herschel": "\"William and Caroline Herschel\" is the clue that makes the shared answer concrete enough to test across the full board.",
+    "Tycho Brahe": "\"Category example: Tycho Brahe\" helps confirm the same answer instead of pulling the board back toward a looser guess.",
+    "Carl Sagan": "\"Category example: Carl Sagan\" belongs in the same set as the rest of the board, which is why the answer sharpens once this pattern becomes visible.",
+    "Nicolaus Copernicus": "\"Category example: Nicolaus Copernicus\" fits more cleanly once the board is tested under the same answer as the other clues.",
+    "Galileo Galilei": "\"Category example: Galileo Galilei\" helps confirm the same answer instead of pulling the board back toward a looser guess."
+  },
+  "spoilerHints": {
+    "William and Caroline Herschel": "William and Caroline Herschel is the clue that makes famous astronomers concrete enough to test across the full board.",
+    "Tycho Brahe": "Keep Tycho Brahe in mind, then see whether William and Caroline Herschel supports the same answer.",
+    "Carl Sagan": "Carl Sagan works best after the board narrows toward famous astronomers.",
+    "Nicolaus Copernicus": "Nicolaus Copernicus should be tested as part of famous astronomers, not as a standalone reference.",
+    "Galileo Galilei": "Keep Galileo Galilei in mind, then see whether William and Caroline Herschel supports the same answer."
+  },
+  "articleBlocks": [
+    "At first, William and Caroline Herschel and Tycho Brahe pointed in a few different directions, so the board still felt wider than one exact category. One tempting read was \"a broader umbrella topic\". William and Caroline Herschel, Tycho Brahe can point toward several nearby themes before one clue makes the exact category level visible. William and Caroline Herschel is the clue that narrows the board into one category with clearer boundaries.",
+    "Another nearby read was \"a one-clue surface theme\". Early clues often tempt you to overfit the board around one obvious surface similarity. The final answer works because it keeps every clue at the same level of specificity, not because one clue happens to fit first.",
+    "Once I read the set through a category board focused on famous, examples like \"Category example: William and Caroline Herschel\" and \"Category example: Tycho Brahe\" stopped feeling loose and started landing cleanly.",
+    "Carl Sagan, Nicolaus Copernicus, Galileo Galilei keep the clues at the same category level, which is what makes the board feel like one exact set instead of a broad umbrella theme.",
+    "The answer was \"Famous astronomers\". More precisely, the board resolves as one concrete category with members that stay at the same level of specificity as Famous astronomers, which is why \"Famous astronomers\" fits better than \"a broader umbrella topic\" or \"a one-clue surface theme\" once the full set is checked."
+  ],
+  "solutionNarrative": [
+    "I started by testing Tycho Brahe and Carl Sagan, but that only gave me a loose direction. I initially drifted toward a broader umbrella topic, because the first clues could still fit several nearby ideas. I held the guess until one clue gave me a more specific way to read the list.",
+    "The turn came when I let \"William and Caroline Herschel\" lead the solve. After that, Nicolaus Copernicus and Galileo Galilei became the real confirmation check, because they had to fit the same idea without changing the rule or stretching the answer.",
+    "For the final pass, I checked William and Caroline Herschel, Tycho Brahe, Carl Sagan, Nicolaus Copernicus, Galileo Galilei one by one. The answer worked only if the whole list could stay inside one tight reading, not because one early clue happened to match a broad topic.",
+    "The answer was \"Famous astronomers\"."
+  ],
+  "lessons": [
+    {
+      "title": "\"William and Caroline Herschel\" and \"Tycho Brahe\" can look like they belong to different categories at first",
+      "body": "When the opening clues feel broad, wait for the clue that turns one fuzzy theme into a testable answer."
+    },
+    {
+      "title": "\"William and Caroline Herschel\" is what makes the answer feel concrete instead of broad",
+      "body": "A strong Pinpoint answer should explain why every clue belongs, not just why the words feel loosely related."
+    },
+    {
+      "title": "Re-check the early clues once \"William and Caroline Herschel\" sharpens the answer",
+      "body": "Once \"William and Caroline Herschel\" lands, go back and test the earlier clues under that same answer before locking it in."
+    }
+  ],
+  "display": {
+    "connectorSummary": "a category board focused on famous",
+    "fastStrategy": "When the opening clues feel broad, wait for the clue that turns one fuzzy theme into a testable answer.",
+    "clueTableRows": [
+      {
+        "clue": "William and Caroline Herschel",
+        "examplePhrase": "Category example: William and Caroline Herschel",
+        "connectionExplained": "\"William and Caroline Herschel\" is the clue that makes the shared answer concrete enough to test across the full board."
+      },
+      {
+        "clue": "Tycho Brahe",
+        "examplePhrase": "Category example: Tycho Brahe",
+        "connectionExplained": "\"Category example: Tycho Brahe\" helps confirm the same answer instead of pulling the board back toward a looser guess."
+      },
+      {
+        "clue": "Carl Sagan",
+        "examplePhrase": "Category example: Carl Sagan",
+        "connectionExplained": "\"Category example: Carl Sagan\" belongs in the same set as the rest of the board, which is why the answer sharpens once this pattern becomes visible."
+      },
+      {
+        "clue": "Nicolaus Copernicus",
+        "examplePhrase": "Category example: Nicolaus Copernicus",
+        "connectionExplained": "\"Category example: Nicolaus Copernicus\" fits more cleanly once the board is tested under the same answer as the other clues."
+      },
+      {
+        "clue": "Galileo Galilei",
+        "examplePhrase": "Category example: Galileo Galilei",
+        "connectionExplained": "\"Category example: Galileo Galilei\" helps confirm the same answer instead of pulling the board back toward a looser guess."
+      }
+    ]
+  },
+  "faqs": [
+    {
+      "question": "What final category connects \"William and Caroline Herschel\" and \"Tycho Brahe\" in LinkedIn Pinpoint #841?",
+      "answer": "The answer is \"Famous astronomers\". That reading is the first one that explains the whole set without forcing any clue."
+    },
+    {
+      "question": "How do \"William and Caroline Herschel\" and \"Tycho Brahe\" connect in LinkedIn Pinpoint #841?",
+      "answer": "The connection is a category board focused on famous. The clues read more cleanly once they are tested under that same idea instead of as a loose theme."
+    },
+    {
+      "question": "Why is \"William and Caroline Herschel\" the key clue in LinkedIn Pinpoint #841?",
+      "answer": "\"William and Caroline Herschel\" is the turning point because it makes the answer concrete enough to test across all five clues."
+    }
+  ],
+  "solvePath": {
+    "firstRead": "At first, William and Caroline Herschel and Tycho Brahe pointed in a few different directions, so the board still felt wider than one exact category.",
+    "falseStarts": [
+      "a broader umbrella topic",
+      "a one-clue surface theme"
+    ],
+    "whyFalseStartPlausible": [
+      "William and Caroline Herschel, Tycho Brahe can point toward several nearby themes before one clue makes the exact category level visible.",
+      "Early clues often tempt you to overfit the board around one obvious surface similarity."
+    ],
+    "breakingClue": "William and Caroline Herschel",
+    "pivot": "I started by testing Tycho Brahe and Carl Sagan, but that only gave me a loose direction. I initially drifted toward a broader umbrella topic, because the first clues could still fit several nearby ideas. I held the guess until one clue gave me a more specific way to read the list.\n\nThe turn came when I let \"William and Caroline Herschel\" lead the solve. After that, Nicolaus Copernicus and Galileo Galilei became the real confirmation check, because they had to fit the same idea without changing the rule or stretching the answer.\n\nFor the final pass, I checked William and Caroline Herschel, Tycho Brahe, Carl Sagan, Nicolaus Copernicus, Galileo Galilei one by one. The answer worked only if the whole list could stay inside one tight reading, not because one early clue happened to match a broad topic.\n\nThe answer was \"Famous astronomers\".",
+    "fullBoardConfirmation": "Once I read the set through a category board focused on famous, examples like \"Category example: William and Caroline Herschel\" and \"Category example: Tycho Brahe\" stopped feeling loose and started landing cleanly."
+  },
+  "turningPoint": {
+    "clue": "William and Caroline Herschel",
+    "whyDecisive": "William and Caroline Herschel is the clue that makes the shared answer concrete enough to test across the full board.",
+    "whatChangedAfterIt": "Once William and Caroline Herschel lands, the earlier clues stop feeling broad and start reading under the same answer."
+  },
+  "clueRows": [
+    {
+      "clue": "William and Caroline Herschel",
+      "surfaceMisread": "a broader umbrella topic",
+      "resolvedPhraseOrMember": "Category example: William and Caroline Herschel",
+      "nonObviousWhy": "\"William and Caroline Herschel\" is the clue that makes the shared answer concrete enough to test across the full board.",
+      "searchableContext": "Category example: William and Caroline Herschel",
+      "phraseExample": "Category example: William and Caroline Herschel"
+    },
+    {
+      "clue": "Tycho Brahe",
+      "surfaceMisread": "a broader umbrella topic",
+      "resolvedPhraseOrMember": "Category example: Tycho Brahe",
+      "nonObviousWhy": "\"Category example: Tycho Brahe\" helps confirm the same answer instead of pulling the board back toward a looser guess.",
+      "searchableContext": "Category example: Tycho Brahe",
+      "phraseExample": "Category example: Tycho Brahe"
+    },
+    {
+      "clue": "Carl Sagan",
+      "surfaceMisread": "a broader umbrella topic",
+      "resolvedPhraseOrMember": "Category example: Carl Sagan",
+      "nonObviousWhy": "\"Category example: Carl Sagan\" belongs in the same set as the rest of the board, which is why the answer sharpens once this pattern becomes visible.",
+      "searchableContext": "Category example: Carl Sagan",
+      "phraseExample": "Category example: Carl Sagan"
+    },
+    {
+      "clue": "Nicolaus Copernicus",
+      "surfaceMisread": "a broader umbrella topic",
+      "resolvedPhraseOrMember": "Category example: Nicolaus Copernicus",
+      "nonObviousWhy": "\"Category example: Nicolaus Copernicus\" fits more cleanly once the board is tested under the same answer as the other clues.",
+      "searchableContext": "Category example: Nicolaus Copernicus",
+      "phraseExample": "Category example: Nicolaus Copernicus"
+    },
+    {
+      "clue": "Galileo Galilei",
+      "surfaceMisread": "a broader umbrella topic",
+      "resolvedPhraseOrMember": "Category example: Galileo Galilei",
+      "nonObviousWhy": "\"Category example: Galileo Galilei\" helps confirm the same answer instead of pulling the board back toward a looser guess.",
+      "searchableContext": "Category example: Galileo Galilei",
+      "phraseExample": "Category example: Galileo Galilei"
+    }
+  ],
+  "faqItems": [
+    {
+      "intentType": "solve_strategy",
+      "question": "What final category connects \"William and Caroline Herschel\" and \"Tycho Brahe\" in LinkedIn Pinpoint #841?",
+      "answer": "The answer is \"Famous astronomers\". That reading is the first one that explains the whole set without forcing any clue.",
+      "tiedClue": "William and Caroline Herschel"
+    },
+    {
+      "intentType": "solve_strategy",
+      "question": "How do \"William and Caroline Herschel\" and \"Tycho Brahe\" connect in LinkedIn Pinpoint #841?",
+      "answer": "The connection is a category board focused on famous. The clues read more cleanly once they are tested under that same idea instead of as a loose theme.",
+      "tiedClue": "William and Caroline Herschel"
+    },
+    {
+      "intentType": "clue_background",
+      "question": "Why is \"William and Caroline Herschel\" the key clue in LinkedIn Pinpoint #841?",
+      "answer": "\"William and Caroline Herschel\" is the turning point because it makes the answer concrete enough to test across all five clues.",
+      "tiedClue": "William and Caroline Herschel"
+    }
+  ],
+  "uniquenessSignals": {
+    "angle": "a category board focused on famous",
+    "relatedEntities": [
+      "Category example: William and Caroline Herschel",
+      "Category example: Tycho Brahe",
+      "Category example: Carl Sagan",
+      "Category example: Nicolaus Copernicus",
+      "Category example: Galileo Galilei"
+    ],
+    "doNotRepeatPatterns": [
+      "a category board focused on famous",
+      "Category example: William and Caroline Herschel",
+      "Category example: Tycho Brahe",
+      "Category example: Carl Sagan",
+      "Category example: Nicolaus Copernicus"
+    ]
+  },
+  "wrongGuessCandidates": [
+    {
+      "label": "a broader umbrella topic",
+      "whyPlausible": "William and Caroline Herschel, Tycho Brahe can point toward several nearby themes before one clue makes the exact category level visible.",
+      "whyRejected": "William and Caroline Herschel is the clue that narrows the board into one category with clearer boundaries."
+    },
+    {
+      "label": "a one-clue surface theme",
+      "whyPlausible": "Early clues often tempt you to overfit the board around one obvious surface similarity.",
+      "whyRejected": "The final answer works because it keeps every clue at the same level of specificity, not because one clue happens to fit first."
+    }
+  ],
+  "setValidationSummary": "Carl Sagan, Nicolaus Copernicus, Galileo Galilei keep the clues at the same category level, which is what makes the board feel like one exact set instead of a broad umbrella theme.",
+  "categoryPrecisionNote": "one concrete category with members that stay at the same level of specificity as Famous astronomers"
+}

--- a/data/puzzles/pinpoint-answer-842.json
+++ b/data/puzzles/pinpoint-answer-842.json
@@ -1,0 +1,217 @@
+{
+  "puzzleNumber": 842,
+  "slug": "pinpoint-answer-842",
+  "publishDate": "2026-08-20",
+  "isoDate": "2026-08-20",
+  "detailState": "fallback_full",
+  "bodyMode": "standard",
+  "pageExperienceMode": "full-analysis",
+  "questionType": "category",
+  "difficultyBand": "hard",
+  "clues": [
+    "Nori",
+    "Jerky",
+    "Instant coffee",
+    "Prunes",
+    "Raisins"
+  ],
+  "answer": "Food items that are dehydrated",
+  "category": "Food items that are dehydrated",
+  "wordHints": {
+    "Nori": "\"Category example: Nori\" fits more cleanly once the board is tested under the same answer as the other clues.",
+    "Jerky": "\"Category example: Jerky\" helps confirm the same answer instead of pulling the board back toward a looser guess.",
+    "Instant coffee": "\"Instant coffee\" is the clue that makes the shared answer concrete enough to test across the full board.",
+    "Prunes": "\"Category example: Prunes\" fits more cleanly once the board is tested under the same answer as the other clues.",
+    "Raisins": "\"Category example: Raisins\" helps confirm the same answer instead of pulling the board back toward a looser guess."
+  },
+  "spoilerHints": {
+    "Nori": "Nori should be tested as part of food items that are dehydrated, not as a standalone reference.",
+    "Jerky": "Keep Jerky in mind, then see whether Instant coffee supports the same answer.",
+    "Instant coffee": "Instant coffee is the clue that makes food items that are dehydrated concrete enough to test across the full board.",
+    "Prunes": "Prunes should be tested as part of food items that are dehydrated, not as a standalone reference.",
+    "Raisins": "Keep Raisins in mind, then see whether Instant coffee supports the same answer."
+  },
+  "articleBlocks": [
+    "At first, Nori and Jerky pointed in a few different directions, so the board still felt wider than one exact category. One tempting read was \"a broader umbrella topic\". Nori, Jerky can point toward several nearby themes before one clue makes the exact category level visible. Instant coffee is the clue that narrows the board into one category with clearer boundaries. Another nearby read was \"a one-clue surface theme\". Early clues often tempt you to overfit the board around one obvious surface similarity. The final answer works because it keeps every clue at the same level of specificity, not because one clue happens to fit first.",
+    "Once I read the set through a category board focused on food, examples like \"Category example: Nori\" and \"Category example: Jerky\" stopped feeling loose and started landing cleanly.",
+    "Instant coffee, Prunes, Raisins keep the clues at the same category level, which is what makes the board feel like one exact set instead of a broad umbrella theme.",
+    "The answer was \"Food items that are dehydrated\". More precisely, the board resolves as one concrete category with members that stay at the same level of specificity as Food items that are dehydrated, which is why \"Food items that are dehydrated\" fits better than \"a broader umbrella topic\" or \"a one-clue surface theme\" once the full set is checked."
+  ],
+  "solutionNarrative": [
+    "I started by testing Nori and Jerky, but that only gave me a loose direction. I initially drifted toward a broader umbrella topic, because the first clues could still fit several nearby ideas. I held the guess until one clue gave me a more specific way to read the list.",
+    "The turn came when I let \"Instant coffee\" lead the solve. After that, Prunes and Raisins became the real confirmation check, because they had to fit the same idea without changing the rule or stretching the answer.",
+    "For the final pass, I checked Nori, Jerky, Instant coffee, Prunes, Raisins one by one. The answer worked only if the whole list could stay inside one tight reading, not because one early clue happened to match a broad topic.",
+    "The answer was \"Food items that are dehydrated\"."
+  ],
+  "lessons": [
+    {
+      "title": "\"Nori\" and \"Jerky\" can look like they belong to different categories at first",
+      "body": "When the opening clues feel broad, wait for the clue that turns one fuzzy theme into a testable answer."
+    },
+    {
+      "title": "\"Instant coffee\" is what makes the answer feel concrete instead of broad",
+      "body": "A strong Pinpoint answer should explain why every clue belongs, not just why the words feel loosely related."
+    },
+    {
+      "title": "Re-check the early clues once \"Instant coffee\" sharpens the answer",
+      "body": "Once \"Instant coffee\" lands, go back and test the earlier clues under that same answer before locking it in."
+    }
+  ],
+  "display": {
+    "connectorSummary": "a category board focused on food",
+    "fastStrategy": "When the opening clues feel broad, wait for the clue that turns one fuzzy theme into a testable answer.",
+    "clueTableRows": [
+      {
+        "clue": "Nori",
+        "examplePhrase": "Category example: Nori",
+        "connectionExplained": "\"Category example: Nori\" fits more cleanly once the board is tested under the same answer as the other clues."
+      },
+      {
+        "clue": "Jerky",
+        "examplePhrase": "Category example: Jerky",
+        "connectionExplained": "\"Category example: Jerky\" helps confirm the same answer instead of pulling the board back toward a looser guess."
+      },
+      {
+        "clue": "Instant coffee",
+        "examplePhrase": "Category example: Instant coffee",
+        "connectionExplained": "\"Instant coffee\" is the clue that makes the shared answer concrete enough to test across the full board."
+      },
+      {
+        "clue": "Prunes",
+        "examplePhrase": "Category example: Prunes",
+        "connectionExplained": "\"Category example: Prunes\" fits more cleanly once the board is tested under the same answer as the other clues."
+      },
+      {
+        "clue": "Raisins",
+        "examplePhrase": "Category example: Raisins",
+        "connectionExplained": "\"Category example: Raisins\" helps confirm the same answer instead of pulling the board back toward a looser guess."
+      }
+    ]
+  },
+  "faqs": [
+    {
+      "question": "What final category connects \"Nori\" and \"Jerky\" in LinkedIn Pinpoint #842?",
+      "answer": "The answer is \"Food items that are dehydrated\". That reading is the first one that explains the whole set without forcing any clue."
+    },
+    {
+      "question": "How do \"Nori\" and \"Jerky\" connect in LinkedIn Pinpoint #842?",
+      "answer": "The connection is a category board focused on food. The clues read more cleanly once they are tested under that same idea instead of as a loose theme."
+    },
+    {
+      "question": "Why is \"Instant coffee\" the key clue in LinkedIn Pinpoint #842?",
+      "answer": "\"Instant coffee\" is the turning point because it makes the answer concrete enough to test across all five clues."
+    }
+  ],
+  "solvePath": {
+    "firstRead": "At first, Nori and Jerky pointed in a few different directions, so the board still felt wider than one exact category.",
+    "falseStarts": [
+      "a broader umbrella topic",
+      "a one-clue surface theme"
+    ],
+    "whyFalseStartPlausible": [
+      "Nori, Jerky can point toward several nearby themes before one clue makes the exact category level visible.",
+      "Early clues often tempt you to overfit the board around one obvious surface similarity."
+    ],
+    "breakingClue": "Instant coffee",
+    "pivot": "I started by testing Nori and Jerky, but that only gave me a loose direction. I initially drifted toward a broader umbrella topic, because the first clues could still fit several nearby ideas. I held the guess until one clue gave me a more specific way to read the list.\n\nThe turn came when I let \"Instant coffee\" lead the solve. After that, Prunes and Raisins became the real confirmation check, because they had to fit the same idea without changing the rule or stretching the answer.\n\nFor the final pass, I checked Nori, Jerky, Instant coffee, Prunes, Raisins one by one. The answer worked only if the whole list could stay inside one tight reading, not because one early clue happened to match a broad topic.\n\nThe answer was \"Food items that are dehydrated\".",
+    "fullBoardConfirmation": "Once I read the set through a category board focused on food, examples like \"Category example: Nori\" and \"Category example: Jerky\" stopped feeling loose and started landing cleanly."
+  },
+  "turningPoint": {
+    "clue": "Instant coffee",
+    "whyDecisive": "Instant coffee is the clue that makes the shared answer concrete enough to test across the full board.",
+    "whatChangedAfterIt": "Once Instant coffee lands, the earlier clues stop feeling broad and start reading under the same answer."
+  },
+  "clueRows": [
+    {
+      "clue": "Nori",
+      "surfaceMisread": "a broader umbrella topic",
+      "resolvedPhraseOrMember": "Category example: Nori",
+      "nonObviousWhy": "\"Category example: Nori\" fits more cleanly once the board is tested under the same answer as the other clues.",
+      "searchableContext": "Category example: Nori",
+      "phraseExample": "Category example: Nori"
+    },
+    {
+      "clue": "Jerky",
+      "surfaceMisread": "a broader umbrella topic",
+      "resolvedPhraseOrMember": "Category example: Jerky",
+      "nonObviousWhy": "\"Category example: Jerky\" helps confirm the same answer instead of pulling the board back toward a looser guess.",
+      "searchableContext": "Category example: Jerky",
+      "phraseExample": "Category example: Jerky"
+    },
+    {
+      "clue": "Instant coffee",
+      "surfaceMisread": "a broader umbrella topic",
+      "resolvedPhraseOrMember": "Category example: Instant coffee",
+      "nonObviousWhy": "\"Instant coffee\" is the clue that makes the shared answer concrete enough to test across the full board.",
+      "searchableContext": "Category example: Instant coffee",
+      "phraseExample": "Category example: Instant coffee"
+    },
+    {
+      "clue": "Prunes",
+      "surfaceMisread": "a broader umbrella topic",
+      "resolvedPhraseOrMember": "Category example: Prunes",
+      "nonObviousWhy": "\"Category example: Prunes\" fits more cleanly once the board is tested under the same answer as the other clues.",
+      "searchableContext": "Category example: Prunes",
+      "phraseExample": "Category example: Prunes"
+    },
+    {
+      "clue": "Raisins",
+      "surfaceMisread": "a broader umbrella topic",
+      "resolvedPhraseOrMember": "Category example: Raisins",
+      "nonObviousWhy": "\"Category example: Raisins\" helps confirm the same answer instead of pulling the board back toward a looser guess.",
+      "searchableContext": "Category example: Raisins",
+      "phraseExample": "Category example: Raisins"
+    }
+  ],
+  "faqItems": [
+    {
+      "intentType": "solve_strategy",
+      "question": "What final category connects \"Nori\" and \"Jerky\" in LinkedIn Pinpoint #842?",
+      "answer": "The answer is \"Food items that are dehydrated\". That reading is the first one that explains the whole set without forcing any clue.",
+      "tiedClue": "Nori"
+    },
+    {
+      "intentType": "solve_strategy",
+      "question": "How do \"Nori\" and \"Jerky\" connect in LinkedIn Pinpoint #842?",
+      "answer": "The connection is a category board focused on food. The clues read more cleanly once they are tested under that same idea instead of as a loose theme.",
+      "tiedClue": "Nori"
+    },
+    {
+      "intentType": "clue_background",
+      "question": "Why is \"Instant coffee\" the key clue in LinkedIn Pinpoint #842?",
+      "answer": "\"Instant coffee\" is the turning point because it makes the answer concrete enough to test across all five clues.",
+      "tiedClue": "Instant coffee"
+    }
+  ],
+  "uniquenessSignals": {
+    "angle": "a category board focused on food",
+    "relatedEntities": [
+      "Category example: Nori",
+      "Category example: Jerky",
+      "Category example: Instant coffee",
+      "Category example: Prunes",
+      "Category example: Raisins"
+    ],
+    "doNotRepeatPatterns": [
+      "a category board focused on food",
+      "Category example: Nori",
+      "Category example: Jerky",
+      "Category example: Instant coffee",
+      "Category example: Prunes"
+    ]
+  },
+  "wrongGuessCandidates": [
+    {
+      "label": "a broader umbrella topic",
+      "whyPlausible": "Nori, Jerky can point toward several nearby themes before one clue makes the exact category level visible.",
+      "whyRejected": "Instant coffee is the clue that narrows the board into one category with clearer boundaries."
+    },
+    {
+      "label": "a one-clue surface theme",
+      "whyPlausible": "Early clues often tempt you to overfit the board around one obvious surface similarity.",
+      "whyRejected": "The final answer works because it keeps every clue at the same level of specificity, not because one clue happens to fit first."
+    }
+  ],
+  "setValidationSummary": "Instant coffee, Prunes, Raisins keep the clues at the same category level, which is what makes the board feel like one exact set instead of a broad umbrella theme.",
+  "categoryPrecisionNote": "one concrete category with members that stay at the same level of specificity as Food items that are dehydrated"
+}

--- a/data/puzzles/pinpoint-answer-843.json
+++ b/data/puzzles/pinpoint-answer-843.json
@@ -1,0 +1,235 @@
+{
+  "puzzleNumber": 843,
+  "slug": "pinpoint-answer-843",
+  "publishDate": "2026-08-21",
+  "isoDate": "2026-08-21",
+  "detailState": "published",
+  "bodyMode": "standard",
+  "pageExperienceMode": "full-analysis",
+  "questionType": "category",
+  "difficultyBand": "hard",
+  "clues": [
+    "A video",
+    "A glance",
+    "The messenger",
+    "Fish in a barrel",
+    "Oneself in the foot"
+  ],
+  "answer": "Things you might “shoot”",
+  "category": "Things you might “shoot”",
+  "wordHints": {
+    "A video": "The word 'shoot' can refer to the act of recording or filming something.",
+    "A glance": "The word 'shoot' can refer to the act of looking or glancing at something, especially in the context of targeting or aiming.",
+    "The messenger": "The phrase 'shoot the messenger' is a common idiom that means to blame or attack the person who brings bad news.",
+    "Fish in a barrel": "The phrase 'fish in a barrel' is a common idiom that refers to an easy or helpless target, and the act of shooting fish in a barrel is a literal example of this.",
+    "Oneself in the foot": "The phrase 'shoot oneself in the foot' is a common idiom that means to accidentally harm or hinder oneself, often through one's own actions or words."
+  },
+  "spoilerHints": {
+    "A video": "A video should be tested as part of things you might “shoot”, not as a standalone reference.",
+    "A glance": "Keep A glance in mind, then see whether Oneself in the foot supports the same answer.",
+    "The messenger": "The messenger works best after the board narrows toward things you might “shoot”.",
+    "Fish in a barrel": "Fish in a barrel should be tested as part of things you might “shoot”, not as a standalone reference.",
+    "Oneself in the foot": "Oneself in the foot is the clue that makes things you might “shoot” concrete enough to test across the full board."
+  },
+  "articleBlocks": [
+    "I first thought that the clues might be related to film or photography, but then I realized that the answer was more general.",
+    "The clue 'fish in a barrel' was the turning point, as it made me realize that the answer was not just related to film or photography, but to the idea of 'shooting' something in a more general sense.",
+    "I considered the clues and realized that each one could be related to the idea of 'shooting' something, whether it's a video, a glance, a message, or even oneself in the foot.",
+    "The answer is a specific category of things that can be 'shot', which is more precise than a broader category like 'actions' or 'verbs'.",
+    "The puzzle is tricky because the clues can be misleading at first, and it takes some thought to realize that each one can be related to the idea of 'shooting' something.",
+    "The phrase 'shoot the messenger' is a common idiom that means to blame or attack the person who brings bad news.",
+    "The phrase 'fish in a barrel' is a common idiom that refers to an easy or helpless target, and the act of shooting fish in a barrel is a literal example of this.",
+    "The phrase 'shoot oneself in the foot' is a common idiom that means to accidentally harm or hinder oneself, often through one's own actions or words.",
+    "Be careful not to jump to conclusions based on the surface meaning of the clues, and consider how each one might fit into a larger category or theme.",
+    "The answer to the puzzle is 'Things you might 'shoot''.",
+    "I arrived at the answer by considering the clues and realizing that each one could be related to the idea of 'shooting' something.",
+    "The uniqueness of the answer lies in its specificity and precision, as it is a specific category of things that can be 'shot', rather than a broader category like 'actions' or 'verbs'."
+  ],
+  "solutionNarrative": [
+    "A video and A glance first pulled me toward movie terms, so that was the first path I tested. It held together for a moment, but fish in a barrel never really fit it. The more I pushed that first read, the more the board sounded stitched together instead of naturally solved.",
+    "The solve turned when I stopped treating fish in a barrel as just another clue and asked what kind of thing each clue could really be describing. I was no longer trying to rescue movie terms; I was checking whether A video and A glance could survive the same tighter read.",
+    "Then I used The messenger, Fish in a barrel, and Oneself in the foot as the confirmation round. The messenger, Fish in a barrel, and Oneself in the foot stayed inside the real category, so the answer felt earned instead of guessed. The answer was Things you might shoot."
+  ],
+  "lessons": [
+    {
+      "title": "\"A video\" and \"A glance\" can look like they belong to different categories at first",
+      "body": "\"A video\" and \"A glance\" both fit several loose themes, so it is often better to wait for a more specific word before locking in a category."
+    },
+    {
+      "title": "\"Fish in a barrel\" anchors a shared category board with one concrete theme",
+      "body": "Fish in a barrel organizes this board. Once one clue produces a precise natural reading, re-check the earlier clues under that same frame."
+    },
+    {
+      "title": "Use \"Fish in a barrel\" to re-check \"A video\" under a shared category board with one concrete theme",
+      "body": "Be careful not to jump to conclusions based on the surface meaning of the clues, and consider how each one might fit into a larger category or theme."
+    }
+  ],
+  "display": {
+    "connectorSummary": "a category board focused on things",
+    "fastStrategy": "\"A video\" and \"A glance\" both fit several loose themes, so it is often better to wait for a more specific word before locking in a category.",
+    "clueTableRows": [
+      {
+        "clue": "A video",
+        "examplePhrase": "A type of thing you might shoot",
+        "connectionExplained": "The word 'shoot' can refer to the act of recording or filming something."
+      },
+      {
+        "clue": "A glance",
+        "examplePhrase": "A type of thing you might shoot",
+        "connectionExplained": "The word 'shoot' can refer to the act of looking or glancing at something, especially in the context of targeting or aiming."
+      },
+      {
+        "clue": "The messenger",
+        "examplePhrase": "The messenger",
+        "connectionExplained": "The phrase 'shoot the messenger' is a common idiom that means to blame or attack the person who brings bad news."
+      },
+      {
+        "clue": "Fish in a barrel",
+        "examplePhrase": "A type of thing you might shoot",
+        "connectionExplained": "The phrase 'fish in a barrel' is a common idiom that refers to an easy or helpless target, and the act of shooting fish in a barrel is a literal example of this."
+      },
+      {
+        "clue": "Oneself in the foot",
+        "examplePhrase": "A type of thing you might shoot",
+        "connectionExplained": "The phrase 'shoot oneself in the foot' is a common idiom that means to accidentally harm or hinder oneself, often through one's own actions or words."
+      }
+    ]
+  },
+  "faqs": [
+    {
+      "question": "What final category connects \"A video\" and \"A glance\" in LinkedIn Pinpoint #843?",
+      "answer": "The answer is \"Things you might shoot\" because that reading explains the full set cleanly, including the final clue."
+    },
+    {
+      "question": "How do \"A video\" and \"A glance\" connect in LinkedIn Pinpoint #843?",
+      "answer": "The connection is that all 5 clues point back to one specific category instead of a loose umbrella theme. Fish in a barrel is what keeps the category reading precise instead of broad."
+    },
+    {
+      "question": "Why is \"Fish in a barrel\" the key clue in LinkedIn Pinpoint #843?",
+      "answer": "Fish in a barrel is the turning clue because \"A type of thing you might shoot\" makes the shared category frame explicit. It also makes A video read cleanly as \"A type of thing you might shoot\". The puzzle is tricky because the clues can be misleading at first, and it takes some thought to realize that each one can be related to the idea of 'shooting' something."
+    },
+    {
+      "question": "How does \"A video\" fit the same category as \"Fish in a barrel\" in LinkedIn Pinpoint #843?",
+      "answer": "\"A video\" reads as \"A type of thing you might shoot\" under the same answer, so it supports the category instead of pulling toward a broader guess."
+    }
+  ],
+  "solvePath": {
+    "firstRead": "A video, A glance, and The messenger do not immediately look like the same kind of thing, so the first read can wander in the wrong direction. That is why a first read like \"movie terms\" can feel plausible before one clue makes the answer feel concrete. Fish in a barrel is the clue that finally breaks that first read and makes the real category feel concrete.",
+    "falseStarts": [
+      "movie terms",
+      "idiomatic phrases"
+    ],
+    "whyFalseStartPlausible": [
+      "While some of the clues are related to film or photography, not all of them fit this category, and the answer is more specific than just any movie term.",
+      "idiomatic phrases feels plausible early on, but it falls apart once fish in a barrel demands a more exact reading."
+    ],
+    "breakingClue": "Fish in a barrel",
+    "pivot": "The solve turned when I stopped treating fish in a barrel as just another clue and asked what kind of thing each clue could really be describing. I was no longer trying to rescue movie terms; I was checking whether A video and A glance could survive the same tighter read.",
+    "fullBoardConfirmation": "From there, reading them through one specific category frame explains the board much more cleanly. Entries like A video, A glance, and The messenger stop feeling disconnected and start looking like they belong together. Once fish in a barrel is read the right way, the earlier clues stop pulling in different directions and start behaving like parts of the same answer. The puzzle is tricky because the clues can be misleading at first, and it takes some thought to realize that each one can be related to the idea of 'shooting' something."
+  },
+  "turningPoint": {
+    "clue": "Fish in a barrel",
+    "whyDecisive": "The clue 'fish in a barrel' made me realize that the answer was more general than just film or photography.",
+    "whatChangedAfterIt": "Once Fish in a barrel landed, the earlier clues stopped pulling in different directions and started reinforcing the same answer."
+  },
+  "clueRows": [
+    {
+      "clue": "A video",
+      "surfaceMisread": "an early broad guess",
+      "resolvedPhraseOrMember": "A type of thing you might shoot",
+      "nonObviousWhy": "The word 'shoot' can refer to the act of recording or filming something.",
+      "searchableContext": "The word 'shoot' comes from the Old English word 'scēotan', which means 'to shoot or throw'",
+      "phraseExample": "The word 'shoot' comes from the Old English word 'scēotan', which means 'to shoot or throw'"
+    },
+    {
+      "clue": "A glance",
+      "surfaceMisread": "an early broad guess",
+      "resolvedPhraseOrMember": "A type of thing you might shoot",
+      "nonObviousWhy": "The word 'shoot' can refer to the act of looking or glancing at something, especially in the context of targeting or aiming.",
+      "searchableContext": "The word 'glance' comes from the Old French word 'glacer', which means 'to look or gaze'",
+      "phraseExample": "The word 'glance' comes from the Old French word 'glacer', which means 'to look or gaze'"
+    },
+    {
+      "clue": "The messenger",
+      "surfaceMisread": "an early broad guess",
+      "resolvedPhraseOrMember": "The messenger",
+      "nonObviousWhy": "The phrase 'shoot the messenger' is a common idiom that means to blame or attack the person who brings bad news.",
+      "searchableContext": "The phrase 'shoot the messenger' comes from the ancient Greek practice of killing the messenger who brought bad news",
+      "phraseExample": "The phrase 'shoot the messenger' comes from the ancient Greek practice of killing the messenger who brought bad news"
+    },
+    {
+      "clue": "Fish in a barrel",
+      "surfaceMisread": "an early broad guess",
+      "resolvedPhraseOrMember": "A type of thing you might shoot",
+      "nonObviousWhy": "The phrase 'fish in a barrel' is a common idiom that refers to an easy or helpless target, and the act of shooting fish in a barrel is a literal example of this.",
+      "searchableContext": "The phrase 'fish in a barrel' comes from the idea of shooting fish in a barrel, which is a relatively easy task",
+      "phraseExample": "The phrase 'fish in a barrel' comes from the idea of shooting fish in a barrel, which is a relatively easy task"
+    },
+    {
+      "clue": "Oneself in the foot",
+      "surfaceMisread": "an early broad guess",
+      "resolvedPhraseOrMember": "A type of thing you might shoot",
+      "nonObviousWhy": "The phrase 'shoot oneself in the foot' is a common idiom that means to accidentally harm or hinder oneself, often through one's own actions or words.",
+      "searchableContext": "The phrase 'shoot oneself in the foot' comes from the idea of accidentally shooting oneself in the foot, which is a self-inflicted injury",
+      "phraseExample": "The phrase 'shoot oneself in the foot' comes from the idea of accidentally shooting oneself in the foot, which is a self-inflicted injury"
+    }
+  ],
+  "faqItems": [
+    {
+      "intentType": "solve_strategy",
+      "question": "What final category connects \"A video\" and \"A glance\" in LinkedIn Pinpoint #843?",
+      "answer": "The answer is \"Things you might shoot\" because that reading explains the full set cleanly, including the final clue.",
+      "tiedClue": "A video"
+    },
+    {
+      "intentType": "solve_strategy",
+      "question": "How do \"A video\" and \"A glance\" connect in LinkedIn Pinpoint #843?",
+      "answer": "The connection is that all 5 clues point back to one specific category instead of a loose umbrella theme. Fish in a barrel is what keeps the category reading precise instead of broad.",
+      "tiedClue": "A video"
+    },
+    {
+      "intentType": "clue_background",
+      "question": "Why is \"Fish in a barrel\" the key clue in LinkedIn Pinpoint #843?",
+      "answer": "Fish in a barrel is the turning clue because \"A type of thing you might shoot\" makes the shared category frame explicit. It also makes A video read cleanly as \"A type of thing you might shoot\". The puzzle is tricky because the clues can be misleading at first, and it takes some thought to realize that each one can be related to the idea of 'shooting' something.",
+      "tiedClue": "Fish in a barrel"
+    },
+    {
+      "intentType": "solve_strategy",
+      "question": "How does \"A video\" fit the same category as \"Fish in a barrel\" in LinkedIn Pinpoint #843?",
+      "answer": "\"A video\" reads as \"A type of thing you might shoot\" under the same answer, so it supports the category instead of pulling toward a broader guess.",
+      "tiedClue": "A video"
+    }
+  ],
+  "uniquenessSignals": {
+    "angle": "a shared category board with one concrete theme",
+    "relatedEntities": [
+      "A type of thing you might shoot",
+      "A type of thing you might shoot",
+      "The messenger",
+      "A type of thing you might shoot",
+      "A type of thing you might shoot"
+    ],
+    "doNotRepeatPatterns": [
+      "a shared category board with one concrete theme",
+      "\"A video\" and \"A glance\" can look like they belong to different categories at first",
+      "\"Fish in a barrel\" anchors a shared category board with one concrete theme",
+      "Use \"Fish in a barrel\" to re-check \"A video\" under a shared category board with one concrete theme",
+      "The word 'shoot' comes from the Old English word 'scēotan', which means 'to shoot or throw'",
+      "The word 'glance' comes from the Old French word 'glacer', which means 'to look or gaze'"
+    ]
+  },
+  "wrongGuessCandidates": [
+    {
+      "label": "movie terms",
+      "whyPlausible": "While some of the clues are related to film or photography, not all of them fit this category, and the answer is more specific than just any movie term.",
+      "whyRejected": "Once Fish in a barrel lands, the final answer explains the board more cleanly than movie terms."
+    },
+    {
+      "label": "idiomatic phrases",
+      "whyPlausible": "idiomatic phrases feels plausible early on, but it falls apart once fish in a barrel demands a more exact reading.",
+      "whyRejected": "Once Fish in a barrel lands, the final answer explains the board more cleanly than idiomatic phrases."
+    }
+  ],
+  "setValidationSummary": "The messenger, Fish in a barrel, Oneself in the foot keep confirming the same answer, so the board reads like one exact set instead of a broad bucket.",
+  "categoryPrecisionNote": "one concrete category with members that stay at the same level of specificity as Things you might shoot"
+}

--- a/data/puzzles/pinpoint-answer-844.json
+++ b/data/puzzles/pinpoint-answer-844.json
@@ -1,0 +1,218 @@
+{
+  "puzzleNumber": 844,
+  "slug": "pinpoint-answer-844",
+  "publishDate": "2026-08-22",
+  "isoDate": "2026-08-22",
+  "detailState": "fallback_full",
+  "bodyMode": "standard",
+  "pageExperienceMode": "full-analysis",
+  "questionType": "category",
+  "difficultyBand": "hard",
+  "clues": [
+    "Crushing ice",
+    "Removing nails",
+    "Tenderizing meat",
+    "Shaping metal (over an anvil)",
+    "Chiseling stone (hit with this)"
+  ],
+  "answer": "Different ways to use a hammer (besides the most common one)",
+  "category": "Different ways to use a hammer (besides the most common one)",
+  "wordHints": {
+    "Crushing ice": "\"Category example: Crushing ice\" fits more cleanly once the board is tested under the same answer as the other clues.",
+    "Removing nails": "\"Category example: Removing nails\" helps confirm the same answer instead of pulling the board back toward a looser guess.",
+    "Tenderizing meat": "\"Category example: Tenderizing meat\" belongs in the same set as the rest of the board, which is why the answer sharpens once this pattern becomes visible.",
+    "Shaping metal (over an anvil)": "\"Category example: Shaping metal\" fits more cleanly once the board is tested under the same answer as the other clues.",
+    "Chiseling stone (hit with this)": "\"Chiseling stone (hit with this)\" is the clue that makes the shared answer concrete enough to test across the full board."
+  },
+  "spoilerHints": {
+    "Crushing ice": "Crushing ice should be tested as part of different ways to use a hammer (besides the most common one), not as a standalone reference.",
+    "Removing nails": "Keep Removing nails in mind, then see whether Chiseling stone (hit with this) supports the same answer.",
+    "Tenderizing meat": "Tenderizing meat works best after the board narrows toward different ways to use a hammer (besides the most common one).",
+    "Shaping metal (over an anvil)": "Shaping metal (over an anvil) should be tested as part of different ways to use a hammer (besides the most common one), not as a standalone reference.",
+    "Chiseling stone (hit with this)": "Chiseling stone (hit with this) is the clue that makes different ways to use a hammer (besides the most common one) concrete enough to test across the full board."
+  },
+  "articleBlocks": [
+    "At first, Crushing ice and Removing nails pointed in a few different directions, so the board still felt wider than one exact category. One tempting read was \"a broader umbrella topic\". Crushing ice, Removing nails can point toward several nearby themes before one clue makes the exact category level visible. Chiseling stone (hit with this) is the clue that narrows the board into one category with clearer boundaries.",
+    "Another nearby read was \"a one-clue surface theme\". Early clues often tempt you to overfit the board around one obvious surface similarity. The final answer works because it keeps every clue at the same level of specificity, not because one clue happens to fit first.",
+    "Once I read the set through a category board focused on different, examples like \"Category example: Crushing ice\" and \"Category example: Removing nails\" stopped feeling loose and started landing cleanly.",
+    "Tenderizing meat, Shaping metal (over an anvil), Chiseling stone (hit with this) keep the clues at the same category level, which is what makes the board feel like one exact set instead of a broad umbrella theme.",
+    "The answer was \"Different ways to use a hammer (besides the most common one)\". More precisely, the board resolves as one concrete category with members that stay at the same level of specificity as Different ways to use a hammer (besides the most common one), which is why \"Different ways to use a hammer (besides the most common one)\" fits better than \"a broader umbrella topic\" or \"a one-clue surface theme\" once the full set is checked."
+  ],
+  "solutionNarrative": [
+    "I started by testing Crushing ice and Removing nails, but that only gave me a loose direction. I initially drifted toward a broader umbrella topic, because the first clues could still fit several nearby ideas. I held the guess until one clue gave me a more specific way to read the list.",
+    "The turn came when I let \"Chiseling stone (hit with this)\" lead the solve. After that, Tenderizing meat and Shaping metal (over an anvil) became the real confirmation check, because they had to fit the same idea without changing the rule or stretching the answer.",
+    "For the final pass, I checked Crushing ice, Removing nails, Tenderizing meat, Shaping metal (over an anvil), Chiseling stone (hit with this) one by one. The answer worked only if the whole list could stay inside one tight reading, not because one early clue happened to match a broad topic.",
+    "The answer was \"Different ways to use a hammer (besides the most common one)\"."
+  ],
+  "lessons": [
+    {
+      "title": "\"Crushing ice\" and \"Removing nails\" can look like they belong to different categories at first",
+      "body": "When the opening clues feel broad, wait for the clue that turns one fuzzy theme into a testable answer."
+    },
+    {
+      "title": "\"Chiseling stone (hit with this)\" is what makes the answer feel concrete instead of broad",
+      "body": "A strong Pinpoint answer should explain why every clue belongs, not just why the words feel loosely related."
+    },
+    {
+      "title": "Re-check the early clues once \"Chiseling stone (hit with this)\" sharpens the answer",
+      "body": "Once \"Chiseling stone (hit with this)\" lands, go back and test the earlier clues under that same answer before locking it in."
+    }
+  ],
+  "display": {
+    "connectorSummary": "a category board focused on different",
+    "fastStrategy": "When the opening clues feel broad, wait for the clue that turns one fuzzy theme into a testable answer.",
+    "clueTableRows": [
+      {
+        "clue": "Crushing ice",
+        "examplePhrase": "Category example: Crushing ice",
+        "connectionExplained": "\"Category example: Crushing ice\" fits more cleanly once the board is tested under the same answer as the other clues."
+      },
+      {
+        "clue": "Removing nails",
+        "examplePhrase": "Category example: Removing nails",
+        "connectionExplained": "\"Category example: Removing nails\" helps confirm the same answer instead of pulling the board back toward a looser guess."
+      },
+      {
+        "clue": "Tenderizing meat",
+        "examplePhrase": "Category example: Tenderizing meat",
+        "connectionExplained": "\"Category example: Tenderizing meat\" belongs in the same set as the rest of the board, which is why the answer sharpens once this pattern becomes visible."
+      },
+      {
+        "clue": "Shaping metal (over an anvil)",
+        "examplePhrase": "Category example: Shaping metal",
+        "connectionExplained": "\"Category example: Shaping metal\" fits more cleanly once the board is tested under the same answer as the other clues."
+      },
+      {
+        "clue": "Chiseling stone (hit with this)",
+        "examplePhrase": "Category example: Chiseling stone",
+        "connectionExplained": "\"Chiseling stone (hit with this)\" is the clue that makes the shared answer concrete enough to test across the full board."
+      }
+    ]
+  },
+  "faqs": [
+    {
+      "question": "What final category connects \"Crushing ice\" and \"Removing nails\" in LinkedIn Pinpoint #844?",
+      "answer": "The answer is \"Different ways to use a hammer (besides the most common one)\". That reading is the first one that explains the whole set without forcing any clue."
+    },
+    {
+      "question": "How do \"Crushing ice\" and \"Removing nails\" connect in LinkedIn Pinpoint #844?",
+      "answer": "The connection is a category board focused on different. The clues read more cleanly once they are tested under that same idea instead of as a loose theme."
+    },
+    {
+      "question": "Why is \"Chiseling stone (hit with this)\" the key clue in LinkedIn Pinpoint #844?",
+      "answer": "\"Chiseling stone (hit with this)\" is the turning point because it makes the answer concrete enough to test across all five clues."
+    }
+  ],
+  "solvePath": {
+    "firstRead": "At first, Crushing ice and Removing nails pointed in a few different directions, so the board still felt wider than one exact category.",
+    "falseStarts": [
+      "a broader umbrella topic",
+      "a one-clue surface theme"
+    ],
+    "whyFalseStartPlausible": [
+      "Crushing ice, Removing nails can point toward several nearby themes before one clue makes the exact category level visible.",
+      "Early clues often tempt you to overfit the board around one obvious surface similarity."
+    ],
+    "breakingClue": "Chiseling stone (hit with this)",
+    "pivot": "I started by testing Crushing ice and Removing nails, but that only gave me a loose direction. I initially drifted toward a broader umbrella topic, because the first clues could still fit several nearby ideas. I held the guess until one clue gave me a more specific way to read the list.\n\nThe turn came when I let \"Chiseling stone (hit with this)\" lead the solve. After that, Tenderizing meat and Shaping metal (over an anvil) became the real confirmation check, because they had to fit the same idea without changing the rule or stretching the answer.\n\nFor the final pass, I checked Crushing ice, Removing nails, Tenderizing meat, Shaping metal (over an anvil), Chiseling stone (hit with this) one by one. The answer worked only if the whole list could stay inside one tight reading, not because one early clue happened to match a broad topic.\n\nThe answer was \"Different ways to use a hammer (besides the most common one)\".",
+    "fullBoardConfirmation": "Once I read the set through a category board focused on different, examples like \"Category example: Crushing ice\" and \"Category example: Removing nails\" stopped feeling loose and started landing cleanly."
+  },
+  "turningPoint": {
+    "clue": "Chiseling stone (hit with this)",
+    "whyDecisive": "Chiseling stone (hit with this) is the clue that makes the shared answer concrete enough to test across the full board.",
+    "whatChangedAfterIt": "Once Chiseling stone (hit with this) lands, the earlier clues stop feeling broad and start reading under the same answer."
+  },
+  "clueRows": [
+    {
+      "clue": "Crushing ice",
+      "surfaceMisread": "a broader umbrella topic",
+      "resolvedPhraseOrMember": "Category example: Crushing ice",
+      "nonObviousWhy": "\"Category example: Crushing ice\" fits more cleanly once the board is tested under the same answer as the other clues.",
+      "searchableContext": "Category example: Crushing ice",
+      "phraseExample": "Category example: Crushing ice"
+    },
+    {
+      "clue": "Removing nails",
+      "surfaceMisread": "a broader umbrella topic",
+      "resolvedPhraseOrMember": "Category example: Removing nails",
+      "nonObviousWhy": "\"Category example: Removing nails\" helps confirm the same answer instead of pulling the board back toward a looser guess.",
+      "searchableContext": "Category example: Removing nails",
+      "phraseExample": "Category example: Removing nails"
+    },
+    {
+      "clue": "Tenderizing meat",
+      "surfaceMisread": "a broader umbrella topic",
+      "resolvedPhraseOrMember": "Category example: Tenderizing meat",
+      "nonObviousWhy": "\"Category example: Tenderizing meat\" belongs in the same set as the rest of the board, which is why the answer sharpens once this pattern becomes visible.",
+      "searchableContext": "Category example: Tenderizing meat",
+      "phraseExample": "Category example: Tenderizing meat"
+    },
+    {
+      "clue": "Shaping metal (over an anvil)",
+      "surfaceMisread": "a broader umbrella topic",
+      "resolvedPhraseOrMember": "Category example: Shaping metal",
+      "nonObviousWhy": "\"Category example: Shaping metal\" fits more cleanly once the board is tested under the same answer as the other clues.",
+      "searchableContext": "Category example: Shaping metal",
+      "phraseExample": "Category example: Shaping metal"
+    },
+    {
+      "clue": "Chiseling stone (hit with this)",
+      "surfaceMisread": "a broader umbrella topic",
+      "resolvedPhraseOrMember": "Category example: Chiseling stone",
+      "nonObviousWhy": "\"Chiseling stone (hit with this)\" is the clue that makes the shared answer concrete enough to test across the full board.",
+      "searchableContext": "Category example: Chiseling stone",
+      "phraseExample": "Category example: Chiseling stone"
+    }
+  ],
+  "faqItems": [
+    {
+      "intentType": "solve_strategy",
+      "question": "What final category connects \"Crushing ice\" and \"Removing nails\" in LinkedIn Pinpoint #844?",
+      "answer": "The answer is \"Different ways to use a hammer (besides the most common one)\". That reading is the first one that explains the whole set without forcing any clue.",
+      "tiedClue": "Crushing ice"
+    },
+    {
+      "intentType": "solve_strategy",
+      "question": "How do \"Crushing ice\" and \"Removing nails\" connect in LinkedIn Pinpoint #844?",
+      "answer": "The connection is a category board focused on different. The clues read more cleanly once they are tested under that same idea instead of as a loose theme.",
+      "tiedClue": "Crushing ice"
+    },
+    {
+      "intentType": "clue_background",
+      "question": "Why is \"Chiseling stone (hit with this)\" the key clue in LinkedIn Pinpoint #844?",
+      "answer": "\"Chiseling stone (hit with this)\" is the turning point because it makes the answer concrete enough to test across all five clues.",
+      "tiedClue": "Chiseling stone (hit with this)"
+    }
+  ],
+  "uniquenessSignals": {
+    "angle": "a category board focused on different",
+    "relatedEntities": [
+      "Category example: Crushing ice",
+      "Category example: Removing nails",
+      "Category example: Tenderizing meat",
+      "Category example: Shaping metal",
+      "Category example: Chiseling stone"
+    ],
+    "doNotRepeatPatterns": [
+      "a category board focused on different",
+      "Category example: Crushing ice",
+      "Category example: Removing nails",
+      "Category example: Tenderizing meat",
+      "Category example: Shaping metal"
+    ]
+  },
+  "wrongGuessCandidates": [
+    {
+      "label": "a broader umbrella topic",
+      "whyPlausible": "Crushing ice, Removing nails can point toward several nearby themes before one clue makes the exact category level visible.",
+      "whyRejected": "Chiseling stone (hit with this) is the clue that narrows the board into one category with clearer boundaries."
+    },
+    {
+      "label": "a one-clue surface theme",
+      "whyPlausible": "Early clues often tempt you to overfit the board around one obvious surface similarity.",
+      "whyRejected": "The final answer works because it keeps every clue at the same level of specificity, not because one clue happens to fit first."
+    }
+  ],
+  "setValidationSummary": "Tenderizing meat, Shaping metal (over an anvil), Chiseling stone (hit with this) keep the clues at the same category level, which is what makes the board feel like one exact set instead of a broad umbrella theme.",
+  "categoryPrecisionNote": "one concrete category with members that stay at the same level of specificity as Different ways to use a hammer (besides the most common one)"
+}

--- a/data/puzzles/pinpoint-answer-845.json
+++ b/data/puzzles/pinpoint-answer-845.json
@@ -1,0 +1,218 @@
+{
+  "puzzleNumber": 845,
+  "slug": "pinpoint-answer-845",
+  "publishDate": "2026-08-23",
+  "isoDate": "2026-08-23",
+  "detailState": "fallback_full",
+  "bodyMode": "standard",
+  "pageExperienceMode": "full-analysis",
+  "questionType": "phrase",
+  "difficultyBand": "hard",
+  "clues": [
+    "Tank",
+    "Piece",
+    "Twice",
+    "Out loud",
+    "Outside the box"
+  ],
+  "answer": "Words that come after “think”",
+  "category": "Words that come after “think”",
+  "wordHints": {
+    "Tank": "\"think Tank\" is a familiar phrase, so it helps reveal the shared word quickly.",
+    "Piece": "\"think Piece\" is common enough to confirm the same missing word without stretching the phrasing.",
+    "Twice": "Once the shared word is in place, \"think Twice\" reads like ordinary language instead of a forced compound.",
+    "Out loud": "\"think Out loud\" is a familiar phrase, so it helps reveal the shared word quickly.",
+    "Outside the box": "\"think Outside the box\" is common enough to confirm the same missing word without stretching the phrasing."
+  },
+  "spoilerHints": {
+    "Tank": "Try reading Tank as part of a familiar phrase in words that come after “think” instead of as a standalone word.",
+    "Piece": "Piece works better once you test a fixed phrase pattern rather than a broad topic.",
+    "Twice": "Look for a natural expression that absorbs Twice cleanly before locking the board.",
+    "Out loud": "Try reading Out loud as part of a familiar phrase in words that come after “think” instead of as a standalone word.",
+    "Outside the box": "Outside the box is the clue that makes the phrase pattern in words that come after “think” concrete enough to test."
+  },
+  "articleBlocks": [
+    "The first clues make it clear this is a shared-word phrase puzzle, but not which first word belongs before every clue without forcing the read. A nearby read was \"Tank and Piece phrase pairing\". Tank, Piece can support more than one phrase read before Outside the box shows where the repeated word belongs. Outside the box behaves like a proof clue for one fixed phrase pattern, not just an early two-clue guess.",
+    "Another easy trap was \"Outside the box as an outlier clue\". Outside the box can look like the odd clue if the earlier words are read without a shared phrase slot. Once Outside the box locks the phrase position, the full board resolves under one repeated word instead of five separate definitions.",
+    "Once that phrase appears, examples like \"think Tank\" and \"think Piece\" stop feeling guessed and start reading like ordinary language under familiar phrases and everyday terms built with one shared opening word.",
+    "think Twice, think Out loud, think Outside the box show that the same shared word fits in the same slot across the whole board, so the answer behaves like one complete phrase family instead of a few lucky matches.",
+    "The answer was \"Words that come after “think”\". More precisely, the board resolves as one shared opening word placed before each clue, not a loose topic grouping, which is why \"Words that come after “think”\" fits better than \"Tank and Piece phrase pairing\" or \"Outside the box as an outlier clue\" once the full set is checked."
+  ],
+  "solutionNarrative": [
+    "I started with Tank and first tried Tank and Piece phrase pairing. That was plausible for a moment, because the opening clues were broad enough to support a few loose phrase reads. But none of those guesses made \"Outside the box\" feel exact.",
+    "Once \"Outside the box\" clicked, I stopped treating it like an outlier and tested the phrase position directly. The missing word could fit before the earlier clues without forcing them, which changed the solve from a topic guess into a repeatable word-slot check.",
+    "Then I used Twice and Out loud as the confirmation round. The strong solve was not just that two clues worked; it was that Tank, Piece, Twice, Out loud, Outside the box could all use the same slot and still sound like ordinary language.",
+    "The answer was \"Words that come after “think”\"."
+  ],
+  "lessons": [
+    {
+      "title": "A false start with \"Tank\" and \"Piece\"",
+      "body": "\"Tank\" and \"Piece\" each work in multiple phrase frames, so it is better to wait for a clue that forces one exact missing word before committing."
+    },
+    {
+      "title": "\"Outside the box\" changes the think pattern from guess to test",
+      "body": "Once \"Outside the box\" lands, place the same word before the other clues and make sure they read naturally right away."
+    },
+    {
+      "title": "For Pinpoint 845, the think phrase test has to work five times",
+      "body": "A good answer should create phrases people actually say, not just words that seem related from a distance."
+    }
+  ],
+  "display": {
+    "connectorSummary": "familiar phrases and everyday terms built with one shared opening word",
+    "fastStrategy": "\"Tank\" and \"Piece\" each work in multiple phrase frames, so it is better to wait for a clue that forces one exact missing word before committing.",
+    "clueTableRows": [
+      {
+        "clue": "Tank",
+        "examplePhrase": "think Tank",
+        "connectionExplained": "\"think Tank\" is a familiar phrase, so it helps reveal the shared word quickly."
+      },
+      {
+        "clue": "Piece",
+        "examplePhrase": "think Piece",
+        "connectionExplained": "\"think Piece\" is common enough to confirm the same missing word without stretching the phrasing."
+      },
+      {
+        "clue": "Twice",
+        "examplePhrase": "think Twice",
+        "connectionExplained": "Once the shared word is in place, \"think Twice\" reads like ordinary language instead of a forced compound."
+      },
+      {
+        "clue": "Out loud",
+        "examplePhrase": "think Out loud",
+        "connectionExplained": "\"think Out loud\" is a familiar phrase, so it helps reveal the shared word quickly."
+      },
+      {
+        "clue": "Outside the box",
+        "examplePhrase": "think Outside the box",
+        "connectionExplained": "\"think Outside the box\" is common enough to confirm the same missing word without stretching the phrasing."
+      }
+    ]
+  },
+  "faqs": [
+    {
+      "question": "What shared word links \"Tank\" and \"Piece\" in LinkedIn Pinpoint #845?",
+      "answer": "The answer is \"Words that come after “think”\". That reading is the first one that turns all five clues into familiar phrases or common terms."
+    },
+    {
+      "question": "How do \"Tank\" and \"Piece\" connect in LinkedIn Pinpoint #845?",
+      "answer": "The connection is familiar phrases and everyday terms built with one shared opening word. The same word fits before every clue to create familiar phrases or everyday terms."
+    },
+    {
+      "question": "Why is \"Outside the box\" the key clue in LinkedIn Pinpoint #845?",
+      "answer": "\"Outside the box\" is the strongest clue because \"think Outside the box\" points to one exact phrase much faster than the earlier clues do."
+    }
+  ],
+  "solvePath": {
+    "firstRead": "The first clues make it clear this is a shared-word phrase puzzle, but not which first word belongs before every clue without forcing the read.",
+    "falseStarts": [
+      "Tank and Piece phrase pairing",
+      "Outside the box as an outlier clue"
+    ],
+    "whyFalseStartPlausible": [
+      "Tank, Piece can support more than one phrase read before Outside the box shows where the repeated word belongs.",
+      "Outside the box can look like the odd clue if the earlier words are read without a shared phrase slot."
+    ],
+    "breakingClue": "Outside the box",
+    "pivot": "I started with Tank and first tried Tank and Piece phrase pairing. That was plausible for a moment, because the opening clues were broad enough to support a few loose phrase reads. But none of those guesses made \"Outside the box\" feel exact.\n\nOnce \"Outside the box\" clicked, I stopped treating it like an outlier and tested the phrase position directly. The missing word could fit before the earlier clues without forcing them, which changed the solve from a topic guess into a repeatable word-slot check.\n\nThen I used Twice and Out loud as the confirmation round. The strong solve was not just that two clues worked; it was that Tank, Piece, Twice, Out loud, Outside the box could all use the same slot and still sound like ordinary language.\n\nThe answer was \"Words that come after “think”\".",
+    "fullBoardConfirmation": "Another easy trap was \"Outside the box as an outlier clue\". Outside the box can look like the odd clue if the earlier words are read without a shared phrase slot. Once Outside the box locks the phrase position, the full board resolves under one repeated word instead of five separate definitions."
+  },
+  "turningPoint": {
+    "clue": "Outside the box",
+    "whyDecisive": "Outside the box is the clue that makes the shared answer concrete enough to test across the full board.",
+    "whatChangedAfterIt": "Once Outside the box lands, the earlier clues stop feeling broad and start reading under the same answer."
+  },
+  "clueRows": [
+    {
+      "clue": "Tank",
+      "surfaceMisread": "Tank and Piece phrase pairing",
+      "resolvedPhraseOrMember": "think Tank",
+      "nonObviousWhy": "\"think Tank\" is a familiar phrase, so it helps reveal the shared word quickly.",
+      "searchableContext": "think Tank",
+      "phraseExample": "think Tank"
+    },
+    {
+      "clue": "Piece",
+      "surfaceMisread": "Tank and Piece phrase pairing",
+      "resolvedPhraseOrMember": "think Piece",
+      "nonObviousWhy": "\"think Piece\" is common enough to confirm the same missing word without stretching the phrasing.",
+      "searchableContext": "think Piece",
+      "phraseExample": "think Piece"
+    },
+    {
+      "clue": "Twice",
+      "surfaceMisread": "Tank and Piece phrase pairing",
+      "resolvedPhraseOrMember": "think Twice",
+      "nonObviousWhy": "Once the shared word is in place, \"think Twice\" reads like ordinary language instead of a forced compound.",
+      "searchableContext": "think Twice",
+      "phraseExample": "think Twice"
+    },
+    {
+      "clue": "Out loud",
+      "surfaceMisread": "Tank and Piece phrase pairing",
+      "resolvedPhraseOrMember": "think Out loud",
+      "nonObviousWhy": "\"think Out loud\" is a familiar phrase, so it helps reveal the shared word quickly.",
+      "searchableContext": "think Out loud",
+      "phraseExample": "think Out loud"
+    },
+    {
+      "clue": "Outside the box",
+      "surfaceMisread": "Tank and Piece phrase pairing",
+      "resolvedPhraseOrMember": "think Outside the box",
+      "nonObviousWhy": "\"think Outside the box\" is common enough to confirm the same missing word without stretching the phrasing.",
+      "searchableContext": "think Outside the box",
+      "phraseExample": "think Outside the box"
+    }
+  ],
+  "faqItems": [
+    {
+      "intentType": "solve_strategy",
+      "question": "What shared word links \"Tank\" and \"Piece\" in LinkedIn Pinpoint #845?",
+      "answer": "The answer is \"Words that come after “think”\". That reading is the first one that turns all five clues into familiar phrases or common terms.",
+      "tiedClue": "Tank"
+    },
+    {
+      "intentType": "solve_strategy",
+      "question": "How do \"Tank\" and \"Piece\" connect in LinkedIn Pinpoint #845?",
+      "answer": "The connection is familiar phrases and everyday terms built with one shared opening word. The same word fits before every clue to create familiar phrases or everyday terms.",
+      "tiedClue": "Tank"
+    },
+    {
+      "intentType": "clue_background",
+      "question": "Why is \"Outside the box\" the key clue in LinkedIn Pinpoint #845?",
+      "answer": "\"Outside the box\" is the strongest clue because \"think Outside the box\" points to one exact phrase much faster than the earlier clues do.",
+      "tiedClue": "Outside the box"
+    }
+  ],
+  "uniquenessSignals": {
+    "angle": "familiar phrases and everyday terms built with one shared opening word",
+    "relatedEntities": [
+      "think Tank",
+      "think Piece",
+      "think Twice",
+      "think Out loud",
+      "think Outside the box"
+    ],
+    "doNotRepeatPatterns": [
+      "familiar phrases and everyday terms built with one shared opening word",
+      "think Tank",
+      "think Piece",
+      "think Twice",
+      "think Out loud"
+    ]
+  },
+  "wrongGuessCandidates": [
+    {
+      "label": "Tank and Piece phrase pairing",
+      "whyPlausible": "Tank, Piece can support more than one phrase read before Outside the box shows where the repeated word belongs.",
+      "whyRejected": "Outside the box behaves like a proof clue for one fixed phrase pattern, not just an early two-clue guess."
+    },
+    {
+      "label": "Outside the box as an outlier clue",
+      "whyPlausible": "Outside the box can look like the odd clue if the earlier words are read without a shared phrase slot.",
+      "whyRejected": "Once Outside the box locks the phrase position, the full board resolves under one repeated word instead of five separate definitions."
+    }
+  ],
+  "setValidationSummary": "think Twice, think Out loud, think Outside the box show that the same shared word fits in the same slot across the whole board, so the answer behaves like one complete phrase family instead of a few lucky matches.",
+  "categoryPrecisionNote": "one shared opening word placed before each clue, not a loose topic grouping"
+}

--- a/data/puzzles/pinpoint-answer-846.json
+++ b/data/puzzles/pinpoint-answer-846.json
@@ -1,0 +1,228 @@
+{
+  "puzzleNumber": 846,
+  "slug": "pinpoint-answer-846",
+  "publishDate": "2026-08-24",
+  "isoDate": "2026-08-24",
+  "detailState": "fallback_full",
+  "bodyMode": "standard",
+  "pageExperienceMode": "full-analysis",
+  "questionType": "category",
+  "difficultyBand": "hard",
+  "clues": [
+    "Krait",
+    "Copperhead",
+    "Python",
+    "Viper",
+    "Boa constrictor"
+  ],
+  "answer": "Types of snakes",
+  "category": "Types of snakes",
+  "wordHints": {
+    "Krait": "\"Krait snake\" is a recognizable snake, so it gives the board a clean category fit.",
+    "Copperhead": "Once the board is read as snakes, \"Copperhead snake\" stops feeling broad and becomes an exact fit.",
+    "Python": "\"Python snake\" belongs in the same snake frame, which keeps the category specific instead of loose.",
+    "Viper": "\"Viper snake\" is a recognizable snake, so it gives the board a clean category fit.",
+    "Boa constrictor": "Once the board is read as snakes, \"Boa constrictor snake\" stops feeling broad and becomes an exact fit."
+  },
+  "spoilerHints": {
+    "Krait": "Treat Krait as one recognizable member of types of snakes, not as a broad topic on its own.",
+    "Copperhead": "Copperhead helps more once you ask what kind of thing it is rather than where you have seen it before.",
+    "Python": "Try reading Python as a specific type inside types of snakes instead of as a loose general reference.",
+    "Viper": "Treat Viper as one recognizable member of types of snakes, not as a broad topic on its own.",
+    "Boa constrictor": "Boa constrictor is the clue that makes types of snakes specific enough to verify across the whole board."
+  },
+  "articleBlocks": [
+    "At first, Krait and Copperhead can feel like they belong to a broad topic instead of one exact family, which is why typed-category boards often look looser than they really are at the start. One tempting read was \"a broader umbrella topic\". Krait, Copperhead can sound like they belong to the same general area before the board tells you what type of thing each clue actually names. Boa constrictor pushes the solve down to one exact type-level category instead of a vague umbrella topic.",
+    "Another nearby bucket was \"a loose mascot or named-entity cluster\". Capitalized or specific-looking clues can tempt you to group them by surface familiarity instead of by category level. The solved board works because every clue becomes a member of the same typed family, not because they simply feel related.",
+    "Once the board turned into a question about what kind of snake each clue could be, a category board focused on snakes stopped sounding generic and started behaving like a real category test. Examples like \"Krait snake\" and \"Copperhead snake\" then read like recognizable members of the same set rather than isolated references that merely share the same mood.",
+    "Python snake, Viper snake, Boa constrictor snake read like named members of the same typed category, which keeps the board precise all the way through instead of letting it drift back into a broad topic bucket.",
+    "The answer was \"Types of snakes\". More precisely, the board resolves as a typed category where each clue names a specific member of the same family around Types of snakes, which is why \"Types of snakes\" fits better than \"a broader umbrella topic\" or \"a loose mascot or named-entity cluster\" once the full set is checked."
+  ],
+  "solutionNarrative": [
+    "I started with Krait and Copperhead and first drifted toward a broader umbrella topic. That read was plausible because the early clues could sit inside a bigger umbrella topic, but it still felt too loose once \"Boa constrictor\" showed up.",
+    "The solve improved when I stopped asking what the clues vaguely shared and started asking what type of thing each clue specifically named. \"Boa constrictor\" was the clue that made that tighter test worth trying.",
+    "Then I used Python and Viper as the confirmation round. The answer held because Krait, Copperhead, Python, Viper, Boa constrictor could all stay inside one member family without changing the rule halfway through.",
+    "The answer was \"Types of snakes\"."
+  ],
+  "lessons": [
+    {
+      "title": "\"Krait\" and \"Copperhead\" can look like they belong to different categories at first",
+      "body": "Typed-category boards become easier once you stop sorting by vibe and start asking what kind of thing each clue specifically names."
+    },
+    {
+      "title": "\"Boa constrictor\" is what makes the category feel concrete instead of broad",
+      "body": "A good category answer does more than group the clues loosely. It should make each clue sound like a recognizable member of the same family."
+    },
+    {
+      "title": "For Pinpoint 846, every clue should stay at the snake level",
+      "body": "Once \"Boa constrictor\" lands, check whether the rest of the clues fit that same category at the same level of precision."
+    }
+  ],
+  "display": {
+    "connectorSummary": "a category board focused on snakes",
+    "fastStrategy": "Typed-category boards become easier once you stop sorting by vibe and start asking what kind of thing each clue specifically names.",
+    "clueTableRows": [
+      {
+        "clue": "Krait",
+        "examplePhrase": "Krait snake",
+        "connectionExplained": "\"Krait snake\" is a recognizable snake, so it gives the board a clean category fit."
+      },
+      {
+        "clue": "Copperhead",
+        "examplePhrase": "Copperhead snake",
+        "connectionExplained": "Once the board is read as snakes, \"Copperhead snake\" stops feeling broad and becomes an exact fit."
+      },
+      {
+        "clue": "Python",
+        "examplePhrase": "Python snake",
+        "connectionExplained": "\"Python snake\" belongs in the same snake frame, which keeps the category specific instead of loose."
+      },
+      {
+        "clue": "Viper",
+        "examplePhrase": "Viper snake",
+        "connectionExplained": "\"Viper snake\" is a recognizable snake, so it gives the board a clean category fit."
+      },
+      {
+        "clue": "Boa constrictor",
+        "examplePhrase": "Boa constrictor snake",
+        "connectionExplained": "Once the board is read as snakes, \"Boa constrictor snake\" stops feeling broad and becomes an exact fit."
+      }
+    ]
+  },
+  "faqs": [
+    {
+      "question": "Which type-level category connects \"Krait\" and \"Copperhead\" in LinkedIn Pinpoint #846?",
+      "answer": "The answer is \"Types of snakes\". That reading is the first one that turns the clues into recognizable members of the same typed category instead of one loose topic bucket."
+    },
+    {
+      "question": "How do \"Krait\" and \"Copperhead\" connect in LinkedIn Pinpoint #846?",
+      "answer": "The connection is a category board focused on snakes. The board gets easier once you ask what kind of thing each clue could specifically be, not just what they vaguely remind you of."
+    },
+    {
+      "question": "Why is \"Boa constrictor\" the key clue in LinkedIn Pinpoint #846?",
+      "answer": "\"Boa constrictor\" is the anchor clue because it sharpens the board into one exact type-level answer and makes the earlier clues easier to re-check under the same category noun."
+    },
+    {
+      "question": "How does \"Krait\" fit as a snake in LinkedIn Pinpoint #846?",
+      "answer": "\"Krait\" is a recognizable snake, which keeps the board specific instead of broadly themed."
+    }
+  ],
+  "solvePath": {
+    "firstRead": "At first, Krait and Copperhead can feel like they belong to a broad topic instead of one exact family, which is why typed-category boards often look looser than they really are at the start.",
+    "falseStarts": [
+      "a broader umbrella topic",
+      "a loose mascot or named-entity cluster"
+    ],
+    "whyFalseStartPlausible": [
+      "Krait, Copperhead can sound like they belong to the same general area before the board tells you what type of thing each clue actually names.",
+      "Capitalized or specific-looking clues can tempt you to group them by surface familiarity instead of by category level."
+    ],
+    "breakingClue": "Boa constrictor",
+    "pivot": "I started with Krait and Copperhead and first drifted toward a broader umbrella topic. That read was plausible because the early clues could sit inside a bigger umbrella topic, but it still felt too loose once \"Boa constrictor\" showed up.\n\nThe solve improved when I stopped asking what the clues vaguely shared and started asking what type of thing each clue specifically named. \"Boa constrictor\" was the clue that made that tighter test worth trying.\n\nThen I used Python and Viper as the confirmation round. The answer held because Krait, Copperhead, Python, Viper, Boa constrictor could all stay inside one member family without changing the rule halfway through.\n\nThe answer was \"Types of snakes\".",
+    "fullBoardConfirmation": "Once the board turned into a question about what kind of snake each clue could be, a category board focused on snakes stopped sounding generic and started behaving like a real category test. Examples like \"Krait snake\" and \"Copperhead snake\" then read like recognizable members of the same set rather than isolated references that merely share the same mood."
+  },
+  "turningPoint": {
+    "clue": "Boa constrictor",
+    "whyDecisive": "Boa constrictor is the clue that makes the shared answer concrete enough to test across the full board.",
+    "whatChangedAfterIt": "Once Boa constrictor lands, the earlier clues stop feeling broad and start reading under the same answer."
+  },
+  "clueRows": [
+    {
+      "clue": "Krait",
+      "surfaceMisread": "a broader umbrella topic",
+      "resolvedPhraseOrMember": "Krait snake",
+      "nonObviousWhy": "\"Krait snake\" is a recognizable snake, so it gives the board a clean category fit.",
+      "searchableContext": "Krait snake",
+      "phraseExample": "Krait snake"
+    },
+    {
+      "clue": "Copperhead",
+      "surfaceMisread": "a broader umbrella topic",
+      "resolvedPhraseOrMember": "Copperhead snake",
+      "nonObviousWhy": "Once the board is read as snakes, \"Copperhead snake\" stops feeling broad and becomes an exact fit.",
+      "searchableContext": "Copperhead snake",
+      "phraseExample": "Copperhead snake"
+    },
+    {
+      "clue": "Python",
+      "surfaceMisread": "a broader umbrella topic",
+      "resolvedPhraseOrMember": "Python snake",
+      "nonObviousWhy": "\"Python snake\" belongs in the same snake frame, which keeps the category specific instead of loose.",
+      "searchableContext": "Python snake",
+      "phraseExample": "Python snake"
+    },
+    {
+      "clue": "Viper",
+      "surfaceMisread": "a broader umbrella topic",
+      "resolvedPhraseOrMember": "Viper snake",
+      "nonObviousWhy": "\"Viper snake\" is a recognizable snake, so it gives the board a clean category fit.",
+      "searchableContext": "Viper snake",
+      "phraseExample": "Viper snake"
+    },
+    {
+      "clue": "Boa constrictor",
+      "surfaceMisread": "a broader umbrella topic",
+      "resolvedPhraseOrMember": "Boa constrictor snake",
+      "nonObviousWhy": "Once the board is read as snakes, \"Boa constrictor snake\" stops feeling broad and becomes an exact fit.",
+      "searchableContext": "Boa constrictor snake",
+      "phraseExample": "Boa constrictor snake"
+    }
+  ],
+  "faqItems": [
+    {
+      "intentType": "solve_strategy",
+      "question": "Which type-level category connects \"Krait\" and \"Copperhead\" in LinkedIn Pinpoint #846?",
+      "answer": "The answer is \"Types of snakes\". That reading is the first one that turns the clues into recognizable members of the same typed category instead of one loose topic bucket.",
+      "tiedClue": "Krait"
+    },
+    {
+      "intentType": "solve_strategy",
+      "question": "How do \"Krait\" and \"Copperhead\" connect in LinkedIn Pinpoint #846?",
+      "answer": "The connection is a category board focused on snakes. The board gets easier once you ask what kind of thing each clue could specifically be, not just what they vaguely remind you of.",
+      "tiedClue": "Krait"
+    },
+    {
+      "intentType": "clue_background",
+      "question": "Why is \"Boa constrictor\" the key clue in LinkedIn Pinpoint #846?",
+      "answer": "\"Boa constrictor\" is the anchor clue because it sharpens the board into one exact type-level answer and makes the earlier clues easier to re-check under the same category noun.",
+      "tiedClue": "Boa constrictor"
+    },
+    {
+      "intentType": "solve_strategy",
+      "question": "How does \"Krait\" fit as a snake in LinkedIn Pinpoint #846?",
+      "answer": "\"Krait\" is a recognizable snake, which keeps the board specific instead of broadly themed.",
+      "tiedClue": "Krait"
+    }
+  ],
+  "uniquenessSignals": {
+    "angle": "a category board focused on snakes",
+    "relatedEntities": [
+      "Krait snake",
+      "Copperhead snake",
+      "Python snake",
+      "Viper snake",
+      "Boa constrictor snake"
+    ],
+    "doNotRepeatPatterns": [
+      "a category board focused on snakes",
+      "Krait snake",
+      "Copperhead snake",
+      "Python snake",
+      "Viper snake"
+    ]
+  },
+  "wrongGuessCandidates": [
+    {
+      "label": "a broader umbrella topic",
+      "whyPlausible": "Krait, Copperhead can sound like they belong to the same general area before the board tells you what type of thing each clue actually names.",
+      "whyRejected": "Boa constrictor pushes the solve down to one exact type-level category instead of a vague umbrella topic."
+    },
+    {
+      "label": "a loose mascot or named-entity cluster",
+      "whyPlausible": "Capitalized or specific-looking clues can tempt you to group them by surface familiarity instead of by category level.",
+      "whyRejected": "The solved board works because every clue becomes a member of the same typed family, not because they simply feel related."
+    }
+  ],
+  "setValidationSummary": "Python snake, Viper snake, Boa constrictor snake read like named members of the same typed category, which keeps the board precise all the way through instead of letting it drift back into a broad topic bucket.",
+  "categoryPrecisionNote": "a typed category where each clue names a specific member of the same family around Types of snakes"
+}

--- a/data/puzzles/pinpoint-answer-847.json
+++ b/data/puzzles/pinpoint-answer-847.json
@@ -1,0 +1,218 @@
+{
+  "puzzleNumber": 847,
+  "slug": "pinpoint-answer-847",
+  "publishDate": "2026-08-25",
+  "isoDate": "2026-08-25",
+  "detailState": "fallback_full",
+  "bodyMode": "standard",
+  "pageExperienceMode": "full-analysis",
+  "questionType": "category",
+  "difficultyBand": "hard",
+  "clues": [
+    "Impact",
+    "Courier",
+    "Wingdings",
+    "Lucida Handwriting",
+    "Calibri or Aptos (in MS Office)"
+  ],
+  "answer": "Names of fonts",
+  "category": "Names of fonts",
+  "wordHints": {
+    "Impact": "\"Impact as a font\" fits more cleanly once the board is tested under the same answer as the other clues.",
+    "Courier": "\"Courier as a font\" helps confirm the same answer instead of pulling the board back toward a looser guess.",
+    "Wingdings": "\"Wingdings as a font\" belongs in the same set as the rest of the board, which is why the answer sharpens once this pattern becomes visible.",
+    "Lucida Handwriting": "\"Lucida Handwriting as a font\" fits more cleanly once the board is tested under the same answer as the other clues.",
+    "Calibri or Aptos (in MS Office)": "\"Calibri or Aptos (in MS Office)\" is the clue that makes the shared answer concrete enough to test across the full board."
+  },
+  "spoilerHints": {
+    "Impact": "Impact should be tested as part of names of fonts, not as a standalone reference.",
+    "Courier": "Keep Courier in mind, then see whether Calibri or Aptos (in MS Office) supports the same answer.",
+    "Wingdings": "Wingdings works best after the board narrows toward names of fonts.",
+    "Lucida Handwriting": "Lucida Handwriting should be tested as part of names of fonts, not as a standalone reference.",
+    "Calibri or Aptos (in MS Office)": "Calibri or Aptos (in MS Office) is the clue that makes names of fonts concrete enough to test across the full board."
+  },
+  "articleBlocks": [
+    "At first, Impact and Courier pointed in a few different directions, so the board still felt wider than one exact category. One tempting read was \"a broader umbrella topic\". Impact, Courier can point toward several nearby themes before one clue makes the exact category level visible. Calibri or Aptos (in MS Office) is the clue that narrows the board into one category with clearer boundaries.",
+    "Another nearby read was \"a one-clue surface theme\". Early clues often tempt you to overfit the board around one obvious surface similarity. The final answer works because it keeps every clue at the same level of specificity, not because one clue happens to fit first.",
+    "Once I read the set through a category board focused on names, examples like \"Impact as a font\" and \"Courier as a font\" stopped feeling loose and started landing cleanly.",
+    "Wingdings, Lucida Handwriting, Calibri or Aptos (in MS Office) keep the clues at the same category level, which is what makes the board feel like one exact set instead of a broad umbrella theme.",
+    "The answer was \"Names of fonts\". More precisely, the board resolves as one concrete category with members that stay at the same level of specificity as Names of fonts, which is why \"Names of fonts\" fits better than \"a broader umbrella topic\" or \"a one-clue surface theme\" once the full set is checked."
+  ],
+  "solutionNarrative": [
+    "I started by testing Impact and Courier, but that only gave me a loose direction. I initially drifted toward a broader umbrella topic, because the first clues could still fit several nearby ideas. I held the guess until one clue gave me a more specific way to read the list.",
+    "The turn came when I let \"Calibri or Aptos (in MS Office)\" lead the solve. After that, Wingdings and Lucida Handwriting became the real confirmation check, because they had to fit the same idea without changing the rule or stretching the answer.",
+    "For the final pass, I checked Impact, Courier, Wingdings, Lucida Handwriting, Calibri or Aptos (in MS Office) one by one. The answer worked only if the whole list could stay inside one tight reading, not because one early clue happened to match a broad topic.",
+    "The answer was \"Names of fonts\"."
+  ],
+  "lessons": [
+    {
+      "title": "\"Impact\" and \"Courier\" can look like they belong to different categories at first",
+      "body": "When the opening clues feel broad, wait for the clue that turns one fuzzy theme into a testable answer."
+    },
+    {
+      "title": "\"Calibri or Aptos (in MS Office)\" is what makes the answer feel concrete instead of broad",
+      "body": "A strong Pinpoint answer should explain why every clue belongs, not just why the words feel loosely related."
+    },
+    {
+      "title": "Re-check the early clues once \"Calibri or Aptos (in MS Office)\" sharpens the answer",
+      "body": "Once \"Calibri or Aptos (in MS Office)\" lands, go back and test the earlier clues under that same answer before locking it in."
+    }
+  ],
+  "display": {
+    "connectorSummary": "a category board focused on names",
+    "fastStrategy": "When the opening clues feel broad, wait for the clue that turns one fuzzy theme into a testable answer.",
+    "clueTableRows": [
+      {
+        "clue": "Impact",
+        "examplePhrase": "Impact as a font",
+        "connectionExplained": "\"Impact as a font\" fits more cleanly once the board is tested under the same answer as the other clues."
+      },
+      {
+        "clue": "Courier",
+        "examplePhrase": "Courier as a font",
+        "connectionExplained": "\"Courier as a font\" helps confirm the same answer instead of pulling the board back toward a looser guess."
+      },
+      {
+        "clue": "Wingdings",
+        "examplePhrase": "Wingdings as a font",
+        "connectionExplained": "\"Wingdings as a font\" belongs in the same set as the rest of the board, which is why the answer sharpens once this pattern becomes visible."
+      },
+      {
+        "clue": "Lucida Handwriting",
+        "examplePhrase": "Lucida Handwriting as a font",
+        "connectionExplained": "\"Lucida Handwriting as a font\" fits more cleanly once the board is tested under the same answer as the other clues."
+      },
+      {
+        "clue": "Calibri or Aptos (in MS Office)",
+        "examplePhrase": "Calibri or Aptos as a font",
+        "connectionExplained": "\"Calibri or Aptos (in MS Office)\" is the clue that makes the shared answer concrete enough to test across the full board."
+      }
+    ]
+  },
+  "faqs": [
+    {
+      "question": "What final category connects \"Impact\" and \"Courier\" in LinkedIn Pinpoint #847?",
+      "answer": "The answer is \"Names of fonts\". That reading is the first one that explains the whole set without forcing any clue."
+    },
+    {
+      "question": "How do \"Impact\" and \"Courier\" connect in LinkedIn Pinpoint #847?",
+      "answer": "The connection is a category board focused on names. The clues read more cleanly once they are tested under that same idea instead of as a loose theme."
+    },
+    {
+      "question": "Why is \"Calibri or Aptos (in MS Office)\" the key clue in LinkedIn Pinpoint #847?",
+      "answer": "\"Calibri or Aptos (in MS Office)\" is the turning point because it makes the answer concrete enough to test across all five clues."
+    }
+  ],
+  "solvePath": {
+    "firstRead": "At first, Impact and Courier pointed in a few different directions, so the board still felt wider than one exact category.",
+    "falseStarts": [
+      "a broader umbrella topic",
+      "a one-clue surface theme"
+    ],
+    "whyFalseStartPlausible": [
+      "Impact, Courier can point toward several nearby themes before one clue makes the exact category level visible.",
+      "Early clues often tempt you to overfit the board around one obvious surface similarity."
+    ],
+    "breakingClue": "Calibri or Aptos (in MS Office)",
+    "pivot": "I started by testing Impact and Courier, but that only gave me a loose direction. I initially drifted toward a broader umbrella topic, because the first clues could still fit several nearby ideas. I held the guess until one clue gave me a more specific way to read the list.\n\nThe turn came when I let \"Calibri or Aptos (in MS Office)\" lead the solve. After that, Wingdings and Lucida Handwriting became the real confirmation check, because they had to fit the same idea without changing the rule or stretching the answer.\n\nFor the final pass, I checked Impact, Courier, Wingdings, Lucida Handwriting, Calibri or Aptos (in MS Office) one by one. The answer worked only if the whole list could stay inside one tight reading, not because one early clue happened to match a broad topic.\n\nThe answer was \"Names of fonts\".",
+    "fullBoardConfirmation": "Once I read the set through a category board focused on names, examples like \"Impact as a font\" and \"Courier as a font\" stopped feeling loose and started landing cleanly."
+  },
+  "turningPoint": {
+    "clue": "Calibri or Aptos (in MS Office)",
+    "whyDecisive": "Calibri or Aptos (in MS Office) is the clue that makes the shared answer concrete enough to test across the full board.",
+    "whatChangedAfterIt": "Once Calibri or Aptos (in MS Office) lands, the earlier clues stop feeling broad and start reading under the same answer."
+  },
+  "clueRows": [
+    {
+      "clue": "Impact",
+      "surfaceMisread": "a broader umbrella topic",
+      "resolvedPhraseOrMember": "Impact as a font",
+      "nonObviousWhy": "\"Impact as a font\" fits more cleanly once the board is tested under the same answer as the other clues.",
+      "searchableContext": "Impact as a font",
+      "phraseExample": "Impact as a font"
+    },
+    {
+      "clue": "Courier",
+      "surfaceMisread": "a broader umbrella topic",
+      "resolvedPhraseOrMember": "Courier as a font",
+      "nonObviousWhy": "\"Courier as a font\" helps confirm the same answer instead of pulling the board back toward a looser guess.",
+      "searchableContext": "Courier as a font",
+      "phraseExample": "Courier as a font"
+    },
+    {
+      "clue": "Wingdings",
+      "surfaceMisread": "a broader umbrella topic",
+      "resolvedPhraseOrMember": "Wingdings as a font",
+      "nonObviousWhy": "\"Wingdings as a font\" belongs in the same set as the rest of the board, which is why the answer sharpens once this pattern becomes visible.",
+      "searchableContext": "Wingdings as a font",
+      "phraseExample": "Wingdings as a font"
+    },
+    {
+      "clue": "Lucida Handwriting",
+      "surfaceMisread": "a broader umbrella topic",
+      "resolvedPhraseOrMember": "Lucida Handwriting as a font",
+      "nonObviousWhy": "\"Lucida Handwriting as a font\" fits more cleanly once the board is tested under the same answer as the other clues.",
+      "searchableContext": "Lucida Handwriting as a font",
+      "phraseExample": "Lucida Handwriting as a font"
+    },
+    {
+      "clue": "Calibri or Aptos (in MS Office)",
+      "surfaceMisread": "a broader umbrella topic",
+      "resolvedPhraseOrMember": "Calibri or Aptos as a font",
+      "nonObviousWhy": "\"Calibri or Aptos (in MS Office)\" is the clue that makes the shared answer concrete enough to test across the full board.",
+      "searchableContext": "Calibri or Aptos as a font",
+      "phraseExample": "Calibri or Aptos as a font"
+    }
+  ],
+  "faqItems": [
+    {
+      "intentType": "solve_strategy",
+      "question": "What final category connects \"Impact\" and \"Courier\" in LinkedIn Pinpoint #847?",
+      "answer": "The answer is \"Names of fonts\". That reading is the first one that explains the whole set without forcing any clue.",
+      "tiedClue": "Impact"
+    },
+    {
+      "intentType": "solve_strategy",
+      "question": "How do \"Impact\" and \"Courier\" connect in LinkedIn Pinpoint #847?",
+      "answer": "The connection is a category board focused on names. The clues read more cleanly once they are tested under that same idea instead of as a loose theme.",
+      "tiedClue": "Impact"
+    },
+    {
+      "intentType": "clue_background",
+      "question": "Why is \"Calibri or Aptos (in MS Office)\" the key clue in LinkedIn Pinpoint #847?",
+      "answer": "\"Calibri or Aptos (in MS Office)\" is the turning point because it makes the answer concrete enough to test across all five clues.",
+      "tiedClue": "Calibri or Aptos (in MS Office)"
+    }
+  ],
+  "uniquenessSignals": {
+    "angle": "a category board focused on names",
+    "relatedEntities": [
+      "Impact as a font",
+      "Courier as a font",
+      "Wingdings as a font",
+      "Lucida Handwriting as a font",
+      "Calibri or Aptos as a font"
+    ],
+    "doNotRepeatPatterns": [
+      "a category board focused on names",
+      "Impact as a font",
+      "Courier as a font",
+      "Wingdings as a font",
+      "Lucida Handwriting as a font"
+    ]
+  },
+  "wrongGuessCandidates": [
+    {
+      "label": "a broader umbrella topic",
+      "whyPlausible": "Impact, Courier can point toward several nearby themes before one clue makes the exact category level visible.",
+      "whyRejected": "Calibri or Aptos (in MS Office) is the clue that narrows the board into one category with clearer boundaries."
+    },
+    {
+      "label": "a one-clue surface theme",
+      "whyPlausible": "Early clues often tempt you to overfit the board around one obvious surface similarity.",
+      "whyRejected": "The final answer works because it keeps every clue at the same level of specificity, not because one clue happens to fit first."
+    }
+  ],
+  "setValidationSummary": "Wingdings, Lucida Handwriting, Calibri or Aptos (in MS Office) keep the clues at the same category level, which is what makes the board feel like one exact set instead of a broad umbrella theme.",
+  "categoryPrecisionNote": "one concrete category with members that stay at the same level of specificity as Names of fonts"
+}

--- a/data/puzzles/pinpoint-answer-848.json
+++ b/data/puzzles/pinpoint-answer-848.json
@@ -1,0 +1,217 @@
+{
+  "puzzleNumber": 848,
+  "slug": "pinpoint-answer-848",
+  "publishDate": "2026-08-26",
+  "isoDate": "2026-08-26",
+  "detailState": "fallback_full",
+  "bodyMode": "standard",
+  "pageExperienceMode": "full-analysis",
+  "questionType": "category",
+  "difficultyBand": "hard",
+  "clues": [
+    "Twist",
+    "Floss",
+    "Robot",
+    "Moonwalk",
+    "Macarena"
+  ],
+  "answer": "Names of dance crazes",
+  "category": "Names of dance crazes",
+  "wordHints": {
+    "Twist": "\"Twist as a dance craz\" fits more cleanly once the board is tested under the same answer as the other clues.",
+    "Floss": "\"Floss as a dance craz\" helps confirm the same answer instead of pulling the board back toward a looser guess.",
+    "Robot": "\"Robot as a dance craz\" belongs in the same set as the rest of the board, which is why the answer sharpens once this pattern becomes visible.",
+    "Moonwalk": "\"Moonwalk as a dance craz\" fits more cleanly once the board is tested under the same answer as the other clues.",
+    "Macarena": "\"Macarena\" is the clue that makes the shared answer concrete enough to test across the full board."
+  },
+  "spoilerHints": {
+    "Twist": "Twist should be tested as part of names of dance crazes, not as a standalone reference.",
+    "Floss": "Keep Floss in mind, then see whether Macarena supports the same answer.",
+    "Robot": "Robot works best after the board narrows toward names of dance crazes.",
+    "Moonwalk": "Moonwalk should be tested as part of names of dance crazes, not as a standalone reference.",
+    "Macarena": "Macarena is the clue that makes names of dance crazes concrete enough to test across the full board."
+  },
+  "articleBlocks": [
+    "At first, Twist and Floss pointed in a few different directions, so the board still felt wider than one exact category. One tempting read was \"a broader umbrella topic\". Twist, Floss can point toward several nearby themes before one clue makes the exact category level visible. Macarena is the clue that narrows the board into one category with clearer boundaries. Another nearby read was \"a one-clue surface theme\". Early clues often tempt you to overfit the board around one obvious surface similarity. The final answer works because it keeps every clue at the same level of specificity, not because one clue happens to fit first.",
+    "Once I read the set through a category board focused on names, examples like \"Twist as a dance craz\" and \"Floss as a dance craz\" stopped feeling loose and started landing cleanly.",
+    "Robot, Moonwalk, Macarena keep the clues at the same category level, which is what makes the board feel like one exact set instead of a broad umbrella theme.",
+    "The answer was \"Names of dance crazes\". More precisely, the board resolves as one concrete category with members that stay at the same level of specificity as Names of dance crazes, which is why \"Names of dance crazes\" fits better than \"a broader umbrella topic\" or \"a one-clue surface theme\" once the full set is checked."
+  ],
+  "solutionNarrative": [
+    "I started by testing Twist and Floss, but that only gave me a loose direction. I initially drifted toward a broader umbrella topic, because the first clues could still fit several nearby ideas. I held the guess until one clue gave me a more specific way to read the list.",
+    "The turn came when I let \"Macarena\" lead the solve. After that, Robot and Moonwalk became the real confirmation check, because they had to fit the same idea without changing the rule or stretching the answer.",
+    "For the final pass, I checked Twist, Floss, Robot, Moonwalk, Macarena one by one. The answer worked only if the whole list could stay inside one tight reading, not because one early clue happened to match a broad topic.",
+    "The answer was \"Names of dance crazes\"."
+  ],
+  "lessons": [
+    {
+      "title": "\"Twist\" and \"Floss\" can look like they belong to different categories at first",
+      "body": "When the opening clues feel broad, wait for the clue that turns one fuzzy theme into a testable answer."
+    },
+    {
+      "title": "\"Macarena\" is what makes the answer feel concrete instead of broad",
+      "body": "A strong Pinpoint answer should explain why every clue belongs, not just why the words feel loosely related."
+    },
+    {
+      "title": "Re-check the early clues once \"Macarena\" sharpens the answer",
+      "body": "Once \"Macarena\" lands, go back and test the earlier clues under that same answer before locking it in."
+    }
+  ],
+  "display": {
+    "connectorSummary": "a category board focused on names",
+    "fastStrategy": "When the opening clues feel broad, wait for the clue that turns one fuzzy theme into a testable answer.",
+    "clueTableRows": [
+      {
+        "clue": "Twist",
+        "examplePhrase": "Twist as a dance craz",
+        "connectionExplained": "\"Twist as a dance craz\" fits more cleanly once the board is tested under the same answer as the other clues."
+      },
+      {
+        "clue": "Floss",
+        "examplePhrase": "Floss as a dance craz",
+        "connectionExplained": "\"Floss as a dance craz\" helps confirm the same answer instead of pulling the board back toward a looser guess."
+      },
+      {
+        "clue": "Robot",
+        "examplePhrase": "Robot as a dance craz",
+        "connectionExplained": "\"Robot as a dance craz\" belongs in the same set as the rest of the board, which is why the answer sharpens once this pattern becomes visible."
+      },
+      {
+        "clue": "Moonwalk",
+        "examplePhrase": "Moonwalk as a dance craz",
+        "connectionExplained": "\"Moonwalk as a dance craz\" fits more cleanly once the board is tested under the same answer as the other clues."
+      },
+      {
+        "clue": "Macarena",
+        "examplePhrase": "Macarena as a dance craz",
+        "connectionExplained": "\"Macarena\" is the clue that makes the shared answer concrete enough to test across the full board."
+      }
+    ]
+  },
+  "faqs": [
+    {
+      "question": "What final category connects \"Twist\" and \"Floss\" in LinkedIn Pinpoint #848?",
+      "answer": "The answer is \"Names of dance crazes\". That reading is the first one that explains the whole set without forcing any clue."
+    },
+    {
+      "question": "How do \"Twist\" and \"Floss\" connect in LinkedIn Pinpoint #848?",
+      "answer": "The connection is a category board focused on names. The clues read more cleanly once they are tested under that same idea instead of as a loose theme."
+    },
+    {
+      "question": "Why is \"Macarena\" the key clue in LinkedIn Pinpoint #848?",
+      "answer": "\"Macarena\" is the turning point because it makes the answer concrete enough to test across all five clues."
+    }
+  ],
+  "solvePath": {
+    "firstRead": "At first, Twist and Floss pointed in a few different directions, so the board still felt wider than one exact category.",
+    "falseStarts": [
+      "a broader umbrella topic",
+      "a one-clue surface theme"
+    ],
+    "whyFalseStartPlausible": [
+      "Twist, Floss can point toward several nearby themes before one clue makes the exact category level visible.",
+      "Early clues often tempt you to overfit the board around one obvious surface similarity."
+    ],
+    "breakingClue": "Macarena",
+    "pivot": "I started by testing Twist and Floss, but that only gave me a loose direction. I initially drifted toward a broader umbrella topic, because the first clues could still fit several nearby ideas. I held the guess until one clue gave me a more specific way to read the list.\n\nThe turn came when I let \"Macarena\" lead the solve. After that, Robot and Moonwalk became the real confirmation check, because they had to fit the same idea without changing the rule or stretching the answer.\n\nFor the final pass, I checked Twist, Floss, Robot, Moonwalk, Macarena one by one. The answer worked only if the whole list could stay inside one tight reading, not because one early clue happened to match a broad topic.\n\nThe answer was \"Names of dance crazes\".",
+    "fullBoardConfirmation": "Once I read the set through a category board focused on names, examples like \"Twist as a dance craz\" and \"Floss as a dance craz\" stopped feeling loose and started landing cleanly."
+  },
+  "turningPoint": {
+    "clue": "Macarena",
+    "whyDecisive": "Macarena is the clue that makes the shared answer concrete enough to test across the full board.",
+    "whatChangedAfterIt": "Once Macarena lands, the earlier clues stop feeling broad and start reading under the same answer."
+  },
+  "clueRows": [
+    {
+      "clue": "Twist",
+      "surfaceMisread": "a broader umbrella topic",
+      "resolvedPhraseOrMember": "Twist as a dance craz",
+      "nonObviousWhy": "\"Twist as a dance craz\" fits more cleanly once the board is tested under the same answer as the other clues.",
+      "searchableContext": "Twist as a dance craz",
+      "phraseExample": "Twist as a dance craz"
+    },
+    {
+      "clue": "Floss",
+      "surfaceMisread": "a broader umbrella topic",
+      "resolvedPhraseOrMember": "Floss as a dance craz",
+      "nonObviousWhy": "\"Floss as a dance craz\" helps confirm the same answer instead of pulling the board back toward a looser guess.",
+      "searchableContext": "Floss as a dance craz",
+      "phraseExample": "Floss as a dance craz"
+    },
+    {
+      "clue": "Robot",
+      "surfaceMisread": "a broader umbrella topic",
+      "resolvedPhraseOrMember": "Robot as a dance craz",
+      "nonObviousWhy": "\"Robot as a dance craz\" belongs in the same set as the rest of the board, which is why the answer sharpens once this pattern becomes visible.",
+      "searchableContext": "Robot as a dance craz",
+      "phraseExample": "Robot as a dance craz"
+    },
+    {
+      "clue": "Moonwalk",
+      "surfaceMisread": "a broader umbrella topic",
+      "resolvedPhraseOrMember": "Moonwalk as a dance craz",
+      "nonObviousWhy": "\"Moonwalk as a dance craz\" fits more cleanly once the board is tested under the same answer as the other clues.",
+      "searchableContext": "Moonwalk as a dance craz",
+      "phraseExample": "Moonwalk as a dance craz"
+    },
+    {
+      "clue": "Macarena",
+      "surfaceMisread": "a broader umbrella topic",
+      "resolvedPhraseOrMember": "Macarena as a dance craz",
+      "nonObviousWhy": "\"Macarena\" is the clue that makes the shared answer concrete enough to test across the full board.",
+      "searchableContext": "Macarena as a dance craz",
+      "phraseExample": "Macarena as a dance craz"
+    }
+  ],
+  "faqItems": [
+    {
+      "intentType": "solve_strategy",
+      "question": "What final category connects \"Twist\" and \"Floss\" in LinkedIn Pinpoint #848?",
+      "answer": "The answer is \"Names of dance crazes\". That reading is the first one that explains the whole set without forcing any clue.",
+      "tiedClue": "Twist"
+    },
+    {
+      "intentType": "solve_strategy",
+      "question": "How do \"Twist\" and \"Floss\" connect in LinkedIn Pinpoint #848?",
+      "answer": "The connection is a category board focused on names. The clues read more cleanly once they are tested under that same idea instead of as a loose theme.",
+      "tiedClue": "Twist"
+    },
+    {
+      "intentType": "clue_background",
+      "question": "Why is \"Macarena\" the key clue in LinkedIn Pinpoint #848?",
+      "answer": "\"Macarena\" is the turning point because it makes the answer concrete enough to test across all five clues.",
+      "tiedClue": "Macarena"
+    }
+  ],
+  "uniquenessSignals": {
+    "angle": "a category board focused on names",
+    "relatedEntities": [
+      "Twist as a dance craz",
+      "Floss as a dance craz",
+      "Robot as a dance craz",
+      "Moonwalk as a dance craz",
+      "Macarena as a dance craz"
+    ],
+    "doNotRepeatPatterns": [
+      "a category board focused on names",
+      "Twist as a dance craz",
+      "Floss as a dance craz",
+      "Robot as a dance craz",
+      "Moonwalk as a dance craz"
+    ]
+  },
+  "wrongGuessCandidates": [
+    {
+      "label": "a broader umbrella topic",
+      "whyPlausible": "Twist, Floss can point toward several nearby themes before one clue makes the exact category level visible.",
+      "whyRejected": "Macarena is the clue that narrows the board into one category with clearer boundaries."
+    },
+    {
+      "label": "a one-clue surface theme",
+      "whyPlausible": "Early clues often tempt you to overfit the board around one obvious surface similarity.",
+      "whyRejected": "The final answer works because it keeps every clue at the same level of specificity, not because one clue happens to fit first."
+    }
+  ],
+  "setValidationSummary": "Robot, Moonwalk, Macarena keep the clues at the same category level, which is what makes the board feel like one exact set instead of a broad umbrella theme.",
+  "categoryPrecisionNote": "one concrete category with members that stay at the same level of specificity as Names of dance crazes"
+}

--- a/data/puzzles/pinpoint-answer-849.json
+++ b/data/puzzles/pinpoint-answer-849.json
@@ -1,0 +1,218 @@
+{
+  "puzzleNumber": 849,
+  "slug": "pinpoint-answer-849",
+  "publishDate": "2026-08-27",
+  "isoDate": "2026-08-27",
+  "detailState": "fallback_full",
+  "bodyMode": "standard",
+  "pageExperienceMode": "full-analysis",
+  "questionType": "category",
+  "difficultyBand": "hard",
+  "clues": [
+    "Octopuses",
+    "Arctic hares (twice a year)",
+    "Mood rings",
+    "Leaves (in autumn)",
+    "Chameleons"
+  ],
+  "answer": "Things that change colors",
+  "category": "Things that change colors",
+  "wordHints": {
+    "Octopuses": "\"Category example: Octopuses\" fits more cleanly once the board is tested under the same answer as the other clues.",
+    "Arctic hares (twice a year)": "\"Arctic hares (twice a year)\" is the clue that makes the shared answer concrete enough to test across the full board.",
+    "Mood rings": "\"Category example: Mood rings\" belongs in the same set as the rest of the board, which is why the answer sharpens once this pattern becomes visible.",
+    "Leaves (in autumn)": "\"Category example: Leaves\" fits more cleanly once the board is tested under the same answer as the other clues.",
+    "Chameleons": "\"Category example: Chameleons\" helps confirm the same answer instead of pulling the board back toward a looser guess."
+  },
+  "spoilerHints": {
+    "Octopuses": "Octopuses should be tested as part of things that change colors, not as a standalone reference.",
+    "Arctic hares (twice a year)": "Arctic hares (twice a year) is the clue that makes things that change colors concrete enough to test across the full board.",
+    "Mood rings": "Mood rings works best after the board narrows toward things that change colors.",
+    "Leaves (in autumn)": "Leaves (in autumn) should be tested as part of things that change colors, not as a standalone reference.",
+    "Chameleons": "Keep Chameleons in mind, then see whether Arctic hares (twice a year) supports the same answer."
+  },
+  "articleBlocks": [
+    "At first, Octopuses and Arctic hares (twice a year) pointed in a few different directions, so the board still felt wider than one exact category. One tempting read was \"a broader umbrella topic\". Octopuses, Arctic hares (twice a year) can point toward several nearby themes before one clue makes the exact category level visible. Arctic hares (twice a year) is the clue that narrows the board into one category with clearer boundaries.",
+    "Another nearby read was \"a one-clue surface theme\". Early clues often tempt you to overfit the board around one obvious surface similarity. The final answer works because it keeps every clue at the same level of specificity, not because one clue happens to fit first.",
+    "Once I read the set through a category board focused on things, examples like \"Category example: Octopuses\" and \"Category example: Arctic hares\" stopped feeling loose and started landing cleanly.",
+    "Mood rings, Leaves (in autumn), Chameleons keep the clues at the same category level, which is what makes the board feel like one exact set instead of a broad umbrella theme.",
+    "The answer was \"Things that change colors\". More precisely, the board resolves as one concrete category with members that stay at the same level of specificity as Things that change colors, which is why \"Things that change colors\" fits better than \"a broader umbrella topic\" or \"a one-clue surface theme\" once the full set is checked."
+  ],
+  "solutionNarrative": [
+    "I started by testing Octopuses and Mood rings, but that only gave me a loose direction. I initially drifted toward a broader umbrella topic, because the first clues could still fit several nearby ideas. I held the guess until one clue gave me a more specific way to read the list.",
+    "The turn came when I let \"Arctic hares (twice a year)\" lead the solve. After that, Leaves (in autumn) and Chameleons became the real confirmation check, because they had to fit the same idea without changing the rule or stretching the answer.",
+    "For the final pass, I checked Octopuses, Arctic hares (twice a year), Mood rings, Leaves (in autumn), Chameleons one by one. The answer worked only if the whole list could stay inside one tight reading, not because one early clue happened to match a broad topic.",
+    "The answer was \"Things that change colors\"."
+  ],
+  "lessons": [
+    {
+      "title": "\"Octopuses\" and \"Arctic hares (twice a year)\" can look like they belong to different categories at first",
+      "body": "When the opening clues feel broad, wait for the clue that turns one fuzzy theme into a testable answer."
+    },
+    {
+      "title": "\"Arctic hares (twice a year)\" is what makes the answer feel concrete instead of broad",
+      "body": "A strong Pinpoint answer should explain why every clue belongs, not just why the words feel loosely related."
+    },
+    {
+      "title": "Re-check the early clues once \"Arctic hares (twice a year)\" sharpens the answer",
+      "body": "Once \"Arctic hares (twice a year)\" lands, go back and test the earlier clues under that same answer before locking it in."
+    }
+  ],
+  "display": {
+    "connectorSummary": "a category board focused on things",
+    "fastStrategy": "When the opening clues feel broad, wait for the clue that turns one fuzzy theme into a testable answer.",
+    "clueTableRows": [
+      {
+        "clue": "Octopuses",
+        "examplePhrase": "Category example: Octopuses",
+        "connectionExplained": "\"Category example: Octopuses\" fits more cleanly once the board is tested under the same answer as the other clues."
+      },
+      {
+        "clue": "Arctic hares (twice a year)",
+        "examplePhrase": "Category example: Arctic hares",
+        "connectionExplained": "\"Arctic hares (twice a year)\" is the clue that makes the shared answer concrete enough to test across the full board."
+      },
+      {
+        "clue": "Mood rings",
+        "examplePhrase": "Category example: Mood rings",
+        "connectionExplained": "\"Category example: Mood rings\" belongs in the same set as the rest of the board, which is why the answer sharpens once this pattern becomes visible."
+      },
+      {
+        "clue": "Leaves (in autumn)",
+        "examplePhrase": "Category example: Leaves",
+        "connectionExplained": "\"Category example: Leaves\" fits more cleanly once the board is tested under the same answer as the other clues."
+      },
+      {
+        "clue": "Chameleons",
+        "examplePhrase": "Category example: Chameleons",
+        "connectionExplained": "\"Category example: Chameleons\" helps confirm the same answer instead of pulling the board back toward a looser guess."
+      }
+    ]
+  },
+  "faqs": [
+    {
+      "question": "What final category connects \"Octopuses\" and \"Arctic hares (twice a year)\" in LinkedIn Pinpoint #849?",
+      "answer": "The answer is \"Things that change colors\". That reading is the first one that explains the whole set without forcing any clue."
+    },
+    {
+      "question": "How do \"Octopuses\" and \"Arctic hares (twice a year)\" connect in LinkedIn Pinpoint #849?",
+      "answer": "The connection is a category board focused on things. The clues read more cleanly once they are tested under that same idea instead of as a loose theme."
+    },
+    {
+      "question": "Why is \"Arctic hares (twice a year)\" the key clue in LinkedIn Pinpoint #849?",
+      "answer": "\"Arctic hares (twice a year)\" is the turning point because it makes the answer concrete enough to test across all five clues."
+    }
+  ],
+  "solvePath": {
+    "firstRead": "At first, Octopuses and Arctic hares (twice a year) pointed in a few different directions, so the board still felt wider than one exact category.",
+    "falseStarts": [
+      "a broader umbrella topic",
+      "a one-clue surface theme"
+    ],
+    "whyFalseStartPlausible": [
+      "Octopuses, Arctic hares (twice a year) can point toward several nearby themes before one clue makes the exact category level visible.",
+      "Early clues often tempt you to overfit the board around one obvious surface similarity."
+    ],
+    "breakingClue": "Arctic hares (twice a year)",
+    "pivot": "I started by testing Octopuses and Mood rings, but that only gave me a loose direction. I initially drifted toward a broader umbrella topic, because the first clues could still fit several nearby ideas. I held the guess until one clue gave me a more specific way to read the list.\n\nThe turn came when I let \"Arctic hares (twice a year)\" lead the solve. After that, Leaves (in autumn) and Chameleons became the real confirmation check, because they had to fit the same idea without changing the rule or stretching the answer.\n\nFor the final pass, I checked Octopuses, Arctic hares (twice a year), Mood rings, Leaves (in autumn), Chameleons one by one. The answer worked only if the whole list could stay inside one tight reading, not because one early clue happened to match a broad topic.\n\nThe answer was \"Things that change colors\".",
+    "fullBoardConfirmation": "Once I read the set through a category board focused on things, examples like \"Category example: Octopuses\" and \"Category example: Arctic hares\" stopped feeling loose and started landing cleanly."
+  },
+  "turningPoint": {
+    "clue": "Arctic hares (twice a year)",
+    "whyDecisive": "Arctic hares (twice a year) is the clue that makes the shared answer concrete enough to test across the full board.",
+    "whatChangedAfterIt": "Once Arctic hares (twice a year) lands, the earlier clues stop feeling broad and start reading under the same answer."
+  },
+  "clueRows": [
+    {
+      "clue": "Octopuses",
+      "surfaceMisread": "a broader umbrella topic",
+      "resolvedPhraseOrMember": "Category example: Octopuses",
+      "nonObviousWhy": "\"Category example: Octopuses\" fits more cleanly once the board is tested under the same answer as the other clues.",
+      "searchableContext": "Category example: Octopuses",
+      "phraseExample": "Category example: Octopuses"
+    },
+    {
+      "clue": "Arctic hares (twice a year)",
+      "surfaceMisread": "a broader umbrella topic",
+      "resolvedPhraseOrMember": "Category example: Arctic hares",
+      "nonObviousWhy": "\"Arctic hares (twice a year)\" is the clue that makes the shared answer concrete enough to test across the full board.",
+      "searchableContext": "Category example: Arctic hares",
+      "phraseExample": "Category example: Arctic hares"
+    },
+    {
+      "clue": "Mood rings",
+      "surfaceMisread": "a broader umbrella topic",
+      "resolvedPhraseOrMember": "Category example: Mood rings",
+      "nonObviousWhy": "\"Category example: Mood rings\" belongs in the same set as the rest of the board, which is why the answer sharpens once this pattern becomes visible.",
+      "searchableContext": "Category example: Mood rings",
+      "phraseExample": "Category example: Mood rings"
+    },
+    {
+      "clue": "Leaves (in autumn)",
+      "surfaceMisread": "a broader umbrella topic",
+      "resolvedPhraseOrMember": "Category example: Leaves",
+      "nonObviousWhy": "\"Category example: Leaves\" fits more cleanly once the board is tested under the same answer as the other clues.",
+      "searchableContext": "Category example: Leaves",
+      "phraseExample": "Category example: Leaves"
+    },
+    {
+      "clue": "Chameleons",
+      "surfaceMisread": "a broader umbrella topic",
+      "resolvedPhraseOrMember": "Category example: Chameleons",
+      "nonObviousWhy": "\"Category example: Chameleons\" helps confirm the same answer instead of pulling the board back toward a looser guess.",
+      "searchableContext": "Category example: Chameleons",
+      "phraseExample": "Category example: Chameleons"
+    }
+  ],
+  "faqItems": [
+    {
+      "intentType": "solve_strategy",
+      "question": "What final category connects \"Octopuses\" and \"Arctic hares (twice a year)\" in LinkedIn Pinpoint #849?",
+      "answer": "The answer is \"Things that change colors\". That reading is the first one that explains the whole set without forcing any clue.",
+      "tiedClue": "Octopuses"
+    },
+    {
+      "intentType": "solve_strategy",
+      "question": "How do \"Octopuses\" and \"Arctic hares (twice a year)\" connect in LinkedIn Pinpoint #849?",
+      "answer": "The connection is a category board focused on things. The clues read more cleanly once they are tested under that same idea instead of as a loose theme.",
+      "tiedClue": "Octopuses"
+    },
+    {
+      "intentType": "clue_background",
+      "question": "Why is \"Arctic hares (twice a year)\" the key clue in LinkedIn Pinpoint #849?",
+      "answer": "\"Arctic hares (twice a year)\" is the turning point because it makes the answer concrete enough to test across all five clues.",
+      "tiedClue": "Arctic hares (twice a year)"
+    }
+  ],
+  "uniquenessSignals": {
+    "angle": "a category board focused on things",
+    "relatedEntities": [
+      "Category example: Octopuses",
+      "Category example: Arctic hares",
+      "Category example: Mood rings",
+      "Category example: Leaves",
+      "Category example: Chameleons"
+    ],
+    "doNotRepeatPatterns": [
+      "a category board focused on things",
+      "Category example: Octopuses",
+      "Category example: Arctic hares",
+      "Category example: Mood rings",
+      "Category example: Leaves"
+    ]
+  },
+  "wrongGuessCandidates": [
+    {
+      "label": "a broader umbrella topic",
+      "whyPlausible": "Octopuses, Arctic hares (twice a year) can point toward several nearby themes before one clue makes the exact category level visible.",
+      "whyRejected": "Arctic hares (twice a year) is the clue that narrows the board into one category with clearer boundaries."
+    },
+    {
+      "label": "a one-clue surface theme",
+      "whyPlausible": "Early clues often tempt you to overfit the board around one obvious surface similarity.",
+      "whyRejected": "The final answer works because it keeps every clue at the same level of specificity, not because one clue happens to fit first."
+    }
+  ],
+  "setValidationSummary": "Mood rings, Leaves (in autumn), Chameleons keep the clues at the same category level, which is what makes the board feel like one exact set instead of a broad umbrella theme.",
+  "categoryPrecisionNote": "one concrete category with members that stay at the same level of specificity as Things that change colors"
+}

--- a/data/puzzles/pinpoint-answer-850.json
+++ b/data/puzzles/pinpoint-answer-850.json
@@ -1,0 +1,218 @@
+{
+  "puzzleNumber": 850,
+  "slug": "pinpoint-answer-850",
+  "publishDate": "2026-08-28",
+  "isoDate": "2026-08-28",
+  "detailState": "fallback_full",
+  "bodyMode": "standard",
+  "pageExperienceMode": "full-analysis",
+  "questionType": "phrase",
+  "difficultyBand": "hard",
+  "clues": [
+    "Will",
+    "Trade",
+    "Rein",
+    "Speech",
+    "As a bird"
+  ],
+  "answer": "Words that come after “free”",
+  "category": "Words that come after “free”",
+  "wordHints": {
+    "Will": "\"free Will\" is a familiar phrase, so it helps reveal the shared word quickly.",
+    "Trade": "\"free Trade\" is common enough to confirm the same missing word without stretching the phrasing.",
+    "Rein": "Once the shared word is in place, \"free Rein\" reads like ordinary language instead of a forced compound.",
+    "Speech": "\"free Speech\" is a familiar phrase, so it helps reveal the shared word quickly.",
+    "As a bird": "\"free As a bird\" is common enough to confirm the same missing word without stretching the phrasing."
+  },
+  "spoilerHints": {
+    "Will": "Try reading Will as part of a familiar phrase in words that come after “free” instead of as a standalone word.",
+    "Trade": "Trade works better once you test a fixed phrase pattern rather than a broad topic.",
+    "Rein": "Look for a natural expression that absorbs Rein cleanly before locking the board.",
+    "Speech": "Try reading Speech as part of a familiar phrase in words that come after “free” instead of as a standalone word.",
+    "As a bird": "As a bird is the clue that makes the phrase pattern in words that come after “free” concrete enough to test."
+  },
+  "articleBlocks": [
+    "The first clues make it clear this is a shared-word phrase puzzle, but not which first word belongs before every clue without forcing the read. A nearby read was \"Will and Trade phrase pairing\". Will, Trade can support more than one phrase read before As a bird shows where the repeated word belongs. As a bird behaves like a proof clue for one fixed phrase pattern, not just an early two-clue guess.",
+    "Another easy trap was \"As a bird as an outlier clue\". As a bird can look like the odd clue if the earlier words are read without a shared phrase slot. Once As a bird locks the phrase position, the full board resolves under one repeated word instead of five separate definitions.",
+    "Once that phrase appears, examples like \"free Will\" and \"free Trade\" stop feeling guessed and start reading like ordinary language under familiar phrases and everyday terms built with one shared opening word.",
+    "free Rein, free Speech, free As a bird show that the same shared word fits in the same slot across the whole board, so the answer behaves like one complete phrase family instead of a few lucky matches.",
+    "The answer was \"Words that come after “free”\". More precisely, the board resolves as one shared opening word placed before each clue, not a loose topic grouping, which is why \"Words that come after “free”\" fits better than \"Will and Trade phrase pairing\" or \"As a bird as an outlier clue\" once the full set is checked."
+  ],
+  "solutionNarrative": [
+    "I started with Will and first tried Will and Trade phrase pairing. That was plausible for a moment, because the opening clues were broad enough to support a few loose phrase reads. But none of those guesses made \"As a bird\" feel exact.",
+    "Once \"As a bird\" clicked, I stopped treating it like an outlier and tested the phrase position directly. The missing word could fit before the earlier clues without forcing them, which changed the solve from a topic guess into a repeatable word-slot check.",
+    "Then I used Rein and Speech as the confirmation round. The strong solve was not just that two clues worked; it was that Will, Trade, Rein, Speech, As a bird could all use the same slot and still sound like ordinary language.",
+    "The answer was \"Words that come after “free”\"."
+  ],
+  "lessons": [
+    {
+      "title": "A false start with \"Will\" and \"Trade\"",
+      "body": "\"Will\" and \"Trade\" each work in multiple phrase frames, so it is better to wait for a clue that forces one exact missing word before committing."
+    },
+    {
+      "title": "\"As a bird\" changes the free pattern from guess to test",
+      "body": "Once \"As a bird\" lands, place the same word before the other clues and make sure they read naturally right away."
+    },
+    {
+      "title": "For Pinpoint 850, the free phrase test has to work five times",
+      "body": "A good answer should create phrases people actually say, not just words that seem related from a distance."
+    }
+  ],
+  "display": {
+    "connectorSummary": "familiar phrases and everyday terms built with one shared opening word",
+    "fastStrategy": "\"Will\" and \"Trade\" each work in multiple phrase frames, so it is better to wait for a clue that forces one exact missing word before committing.",
+    "clueTableRows": [
+      {
+        "clue": "Will",
+        "examplePhrase": "free Will",
+        "connectionExplained": "\"free Will\" is a familiar phrase, so it helps reveal the shared word quickly."
+      },
+      {
+        "clue": "Trade",
+        "examplePhrase": "free Trade",
+        "connectionExplained": "\"free Trade\" is common enough to confirm the same missing word without stretching the phrasing."
+      },
+      {
+        "clue": "Rein",
+        "examplePhrase": "free Rein",
+        "connectionExplained": "Once the shared word is in place, \"free Rein\" reads like ordinary language instead of a forced compound."
+      },
+      {
+        "clue": "Speech",
+        "examplePhrase": "free Speech",
+        "connectionExplained": "\"free Speech\" is a familiar phrase, so it helps reveal the shared word quickly."
+      },
+      {
+        "clue": "As a bird",
+        "examplePhrase": "free As a bird",
+        "connectionExplained": "\"free As a bird\" is common enough to confirm the same missing word without stretching the phrasing."
+      }
+    ]
+  },
+  "faqs": [
+    {
+      "question": "What shared word links \"Will\" and \"Trade\" in LinkedIn Pinpoint #850?",
+      "answer": "The answer is \"Words that come after “free”\". That reading is the first one that turns all five clues into familiar phrases or common terms."
+    },
+    {
+      "question": "How do \"Will\" and \"Trade\" connect in LinkedIn Pinpoint #850?",
+      "answer": "The connection is familiar phrases and everyday terms built with one shared opening word. The same word fits before every clue to create familiar phrases or everyday terms."
+    },
+    {
+      "question": "Why is \"As a bird\" the key clue in LinkedIn Pinpoint #850?",
+      "answer": "\"As a bird\" is the strongest clue because \"free As a bird\" points to one exact phrase much faster than the earlier clues do."
+    }
+  ],
+  "solvePath": {
+    "firstRead": "The first clues make it clear this is a shared-word phrase puzzle, but not which first word belongs before every clue without forcing the read.",
+    "falseStarts": [
+      "Will and Trade phrase pairing",
+      "As a bird as an outlier clue"
+    ],
+    "whyFalseStartPlausible": [
+      "Will, Trade can support more than one phrase read before As a bird shows where the repeated word belongs.",
+      "As a bird can look like the odd clue if the earlier words are read without a shared phrase slot."
+    ],
+    "breakingClue": "As a bird",
+    "pivot": "I started with Will and first tried Will and Trade phrase pairing. That was plausible for a moment, because the opening clues were broad enough to support a few loose phrase reads. But none of those guesses made \"As a bird\" feel exact.\n\nOnce \"As a bird\" clicked, I stopped treating it like an outlier and tested the phrase position directly. The missing word could fit before the earlier clues without forcing them, which changed the solve from a topic guess into a repeatable word-slot check.\n\nThen I used Rein and Speech as the confirmation round. The strong solve was not just that two clues worked; it was that Will, Trade, Rein, Speech, As a bird could all use the same slot and still sound like ordinary language.\n\nThe answer was \"Words that come after “free”\".",
+    "fullBoardConfirmation": "Another easy trap was \"As a bird as an outlier clue\". As a bird can look like the odd clue if the earlier words are read without a shared phrase slot. Once As a bird locks the phrase position, the full board resolves under one repeated word instead of five separate definitions."
+  },
+  "turningPoint": {
+    "clue": "As a bird",
+    "whyDecisive": "As a bird is the clue that makes the shared answer concrete enough to test across the full board.",
+    "whatChangedAfterIt": "Once As a bird lands, the earlier clues stop feeling broad and start reading under the same answer."
+  },
+  "clueRows": [
+    {
+      "clue": "Will",
+      "surfaceMisread": "Will and Trade phrase pairing",
+      "resolvedPhraseOrMember": "free Will",
+      "nonObviousWhy": "\"free Will\" is a familiar phrase, so it helps reveal the shared word quickly.",
+      "searchableContext": "free Will",
+      "phraseExample": "free Will"
+    },
+    {
+      "clue": "Trade",
+      "surfaceMisread": "Will and Trade phrase pairing",
+      "resolvedPhraseOrMember": "free Trade",
+      "nonObviousWhy": "\"free Trade\" is common enough to confirm the same missing word without stretching the phrasing.",
+      "searchableContext": "free Trade",
+      "phraseExample": "free Trade"
+    },
+    {
+      "clue": "Rein",
+      "surfaceMisread": "Will and Trade phrase pairing",
+      "resolvedPhraseOrMember": "free Rein",
+      "nonObviousWhy": "Once the shared word is in place, \"free Rein\" reads like ordinary language instead of a forced compound.",
+      "searchableContext": "free Rein",
+      "phraseExample": "free Rein"
+    },
+    {
+      "clue": "Speech",
+      "surfaceMisread": "Will and Trade phrase pairing",
+      "resolvedPhraseOrMember": "free Speech",
+      "nonObviousWhy": "\"free Speech\" is a familiar phrase, so it helps reveal the shared word quickly.",
+      "searchableContext": "free Speech",
+      "phraseExample": "free Speech"
+    },
+    {
+      "clue": "As a bird",
+      "surfaceMisread": "Will and Trade phrase pairing",
+      "resolvedPhraseOrMember": "free As a bird",
+      "nonObviousWhy": "\"free As a bird\" is common enough to confirm the same missing word without stretching the phrasing.",
+      "searchableContext": "free As a bird",
+      "phraseExample": "free As a bird"
+    }
+  ],
+  "faqItems": [
+    {
+      "intentType": "solve_strategy",
+      "question": "What shared word links \"Will\" and \"Trade\" in LinkedIn Pinpoint #850?",
+      "answer": "The answer is \"Words that come after “free”\". That reading is the first one that turns all five clues into familiar phrases or common terms.",
+      "tiedClue": "Will"
+    },
+    {
+      "intentType": "solve_strategy",
+      "question": "How do \"Will\" and \"Trade\" connect in LinkedIn Pinpoint #850?",
+      "answer": "The connection is familiar phrases and everyday terms built with one shared opening word. The same word fits before every clue to create familiar phrases or everyday terms.",
+      "tiedClue": "Will"
+    },
+    {
+      "intentType": "clue_background",
+      "question": "Why is \"As a bird\" the key clue in LinkedIn Pinpoint #850?",
+      "answer": "\"As a bird\" is the strongest clue because \"free As a bird\" points to one exact phrase much faster than the earlier clues do.",
+      "tiedClue": "As a bird"
+    }
+  ],
+  "uniquenessSignals": {
+    "angle": "familiar phrases and everyday terms built with one shared opening word",
+    "relatedEntities": [
+      "free Will",
+      "free Trade",
+      "free Rein",
+      "free Speech",
+      "free As a bird"
+    ],
+    "doNotRepeatPatterns": [
+      "familiar phrases and everyday terms built with one shared opening word",
+      "free Will",
+      "free Trade",
+      "free Rein",
+      "free Speech"
+    ]
+  },
+  "wrongGuessCandidates": [
+    {
+      "label": "Will and Trade phrase pairing",
+      "whyPlausible": "Will, Trade can support more than one phrase read before As a bird shows where the repeated word belongs.",
+      "whyRejected": "As a bird behaves like a proof clue for one fixed phrase pattern, not just an early two-clue guess."
+    },
+    {
+      "label": "As a bird as an outlier clue",
+      "whyPlausible": "As a bird can look like the odd clue if the earlier words are read without a shared phrase slot.",
+      "whyRejected": "Once As a bird locks the phrase position, the full board resolves under one repeated word instead of five separate definitions."
+    }
+  ],
+  "setValidationSummary": "free Rein, free Speech, free As a bird show that the same shared word fits in the same slot across the whole board, so the answer behaves like one complete phrase family instead of a few lucky matches.",
+  "categoryPrecisionNote": "one shared opening word placed before each clue, not a loose topic grouping"
+}

--- a/data/puzzles/pinpoint-answer-851.json
+++ b/data/puzzles/pinpoint-answer-851.json
@@ -1,0 +1,217 @@
+{
+  "puzzleNumber": 851,
+  "slug": "pinpoint-answer-851",
+  "publishDate": "2026-08-29",
+  "isoDate": "2026-08-29",
+  "detailState": "fallback_full",
+  "bodyMode": "standard",
+  "pageExperienceMode": "full-analysis",
+  "questionType": "category",
+  "difficultyBand": "hard",
+  "clues": [
+    "Tents",
+    "Skiers",
+    "Barber shops",
+    "Olympic vaulters",
+    "Flags (as attached here: 🏁)"
+  ],
+  "answer": "All associated with poles",
+  "category": "All associated with poles",
+  "wordHints": {
+    "Tents": "\"Category example: Tents\" fits more cleanly once the board is tested under the same answer as the other clues.",
+    "Skiers": "\"Category example: Skiers\" helps confirm the same answer instead of pulling the board back toward a looser guess.",
+    "Barber shops": "\"Category example: Barber shops\" belongs in the same set as the rest of the board, which is why the answer sharpens once this pattern becomes visible.",
+    "Olympic vaulters": "\"Category example: Olympic vaulters\" fits more cleanly once the board is tested under the same answer as the other clues.",
+    "Flags (as attached here: 🏁)": "\"Flags (as attached here: 🏁)\" is the clue that makes the shared answer concrete enough to test across the full board."
+  },
+  "spoilerHints": {
+    "Tents": "Tents should be tested as part of all associated with poles, not as a standalone reference.",
+    "Skiers": "Keep Skiers in mind, then see whether Flags (as attached here: 🏁) supports the same answer.",
+    "Barber shops": "Barber shops works best after the board narrows toward all associated with poles.",
+    "Olympic vaulters": "Olympic vaulters should be tested as part of all associated with poles, not as a standalone reference.",
+    "Flags (as attached here: 🏁)": "Flags (as attached here: 🏁) is the clue that makes all associated with poles concrete enough to test across the full board."
+  },
+  "articleBlocks": [
+    "At first, Tents and Skiers pointed in a few different directions, so the board still felt wider than one exact category. One tempting read was \"a broader umbrella topic\". Tents, Skiers can point toward several nearby themes before one clue makes the exact category level visible. Flags (as attached here: 🏁) is the clue that narrows the board into one category with clearer boundaries. Another nearby read was \"a one-clue surface theme\". Early clues often tempt you to overfit the board around one obvious surface similarity. The final answer works because it keeps every clue at the same level of specificity, not because one clue happens to fit first.",
+    "Once I read the set through a category board focused on all, examples like \"Category example: Tents\" and \"Category example: Skiers\" stopped feeling loose and started landing cleanly.",
+    "Barber shops, Olympic vaulters, Flags (as attached here: 🏁) keep the clues at the same category level, which is what makes the board feel like one exact set instead of a broad umbrella theme.",
+    "The answer was \"All associated with poles\". More precisely, the board resolves as one concrete category with members that stay at the same level of specificity as All associated with poles, which is why \"All associated with poles\" fits better than \"a broader umbrella topic\" or \"a one-clue surface theme\" once the full set is checked."
+  ],
+  "solutionNarrative": [
+    "I started by testing Tents and Skiers, but that only gave me a loose direction. I initially drifted toward a broader umbrella topic, because the first clues could still fit several nearby ideas. I held the guess until one clue gave me a more specific way to read the list.",
+    "The turn came when I let \"Flags (as attached here: 🏁)\" lead the solve. After that, Barber shops and Olympic vaulters became the real confirmation check, because they had to fit the same idea without changing the rule or stretching the answer.",
+    "For the final pass, I checked Tents, Skiers, Barber shops, Olympic vaulters, Flags (as attached here: 🏁) one by one. The answer worked only if the whole list could stay inside one tight reading, not because one early clue happened to match a broad topic.",
+    "The answer was \"All associated with poles\"."
+  ],
+  "lessons": [
+    {
+      "title": "\"Tents\" and \"Skiers\" can look like they belong to different categories at first",
+      "body": "When the opening clues feel broad, wait for the clue that turns one fuzzy theme into a testable answer."
+    },
+    {
+      "title": "\"Flags (as attached here: 🏁)\" is what makes the answer feel concrete instead of broad",
+      "body": "A strong Pinpoint answer should explain why every clue belongs, not just why the words feel loosely related."
+    },
+    {
+      "title": "Re-check the early clues once \"Flags (as attached here: 🏁)\" sharpens the answer",
+      "body": "Once \"Flags (as attached here: 🏁)\" lands, go back and test the earlier clues under that same answer before locking it in."
+    }
+  ],
+  "display": {
+    "connectorSummary": "a category board focused on all",
+    "fastStrategy": "When the opening clues feel broad, wait for the clue that turns one fuzzy theme into a testable answer.",
+    "clueTableRows": [
+      {
+        "clue": "Tents",
+        "examplePhrase": "Category example: Tents",
+        "connectionExplained": "\"Category example: Tents\" fits more cleanly once the board is tested under the same answer as the other clues."
+      },
+      {
+        "clue": "Skiers",
+        "examplePhrase": "Category example: Skiers",
+        "connectionExplained": "\"Category example: Skiers\" helps confirm the same answer instead of pulling the board back toward a looser guess."
+      },
+      {
+        "clue": "Barber shops",
+        "examplePhrase": "Category example: Barber shops",
+        "connectionExplained": "\"Category example: Barber shops\" belongs in the same set as the rest of the board, which is why the answer sharpens once this pattern becomes visible."
+      },
+      {
+        "clue": "Olympic vaulters",
+        "examplePhrase": "Category example: Olympic vaulters",
+        "connectionExplained": "\"Category example: Olympic vaulters\" fits more cleanly once the board is tested under the same answer as the other clues."
+      },
+      {
+        "clue": "Flags (as attached here: 🏁)",
+        "examplePhrase": "Category example: Flags",
+        "connectionExplained": "\"Flags (as attached here: 🏁)\" is the clue that makes the shared answer concrete enough to test across the full board."
+      }
+    ]
+  },
+  "faqs": [
+    {
+      "question": "What final category connects \"Tents\" and \"Skiers\" in LinkedIn Pinpoint #851?",
+      "answer": "The answer is \"All associated with poles\". That reading is the first one that explains the whole set without forcing any clue."
+    },
+    {
+      "question": "How do \"Tents\" and \"Skiers\" connect in LinkedIn Pinpoint #851?",
+      "answer": "The connection is a category board focused on all. The clues read more cleanly once they are tested under that same idea instead of as a loose theme."
+    },
+    {
+      "question": "Why is \"Flags (as attached here: 🏁)\" the key clue in LinkedIn Pinpoint #851?",
+      "answer": "\"Flags (as attached here: 🏁)\" is the turning point because it makes the answer concrete enough to test across all five clues."
+    }
+  ],
+  "solvePath": {
+    "firstRead": "At first, Tents and Skiers pointed in a few different directions, so the board still felt wider than one exact category.",
+    "falseStarts": [
+      "a broader umbrella topic",
+      "a one-clue surface theme"
+    ],
+    "whyFalseStartPlausible": [
+      "Tents, Skiers can point toward several nearby themes before one clue makes the exact category level visible.",
+      "Early clues often tempt you to overfit the board around one obvious surface similarity."
+    ],
+    "breakingClue": "Flags (as attached here: 🏁)",
+    "pivot": "I started by testing Tents and Skiers, but that only gave me a loose direction. I initially drifted toward a broader umbrella topic, because the first clues could still fit several nearby ideas. I held the guess until one clue gave me a more specific way to read the list.\n\nThe turn came when I let \"Flags (as attached here: 🏁)\" lead the solve. After that, Barber shops and Olympic vaulters became the real confirmation check, because they had to fit the same idea without changing the rule or stretching the answer.\n\nFor the final pass, I checked Tents, Skiers, Barber shops, Olympic vaulters, Flags (as attached here: 🏁) one by one. The answer worked only if the whole list could stay inside one tight reading, not because one early clue happened to match a broad topic.\n\nThe answer was \"All associated with poles\".",
+    "fullBoardConfirmation": "Once I read the set through a category board focused on all, examples like \"Category example: Tents\" and \"Category example: Skiers\" stopped feeling loose and started landing cleanly."
+  },
+  "turningPoint": {
+    "clue": "Flags (as attached here: 🏁)",
+    "whyDecisive": "Flags (as attached here: 🏁) is the clue that makes the shared answer concrete enough to test across the full board.",
+    "whatChangedAfterIt": "Once Flags (as attached here: 🏁) lands, the earlier clues stop feeling broad and start reading under the same answer."
+  },
+  "clueRows": [
+    {
+      "clue": "Tents",
+      "surfaceMisread": "a broader umbrella topic",
+      "resolvedPhraseOrMember": "Category example: Tents",
+      "nonObviousWhy": "\"Category example: Tents\" fits more cleanly once the board is tested under the same answer as the other clues.",
+      "searchableContext": "Category example: Tents",
+      "phraseExample": "Category example: Tents"
+    },
+    {
+      "clue": "Skiers",
+      "surfaceMisread": "a broader umbrella topic",
+      "resolvedPhraseOrMember": "Category example: Skiers",
+      "nonObviousWhy": "\"Category example: Skiers\" helps confirm the same answer instead of pulling the board back toward a looser guess.",
+      "searchableContext": "Category example: Skiers",
+      "phraseExample": "Category example: Skiers"
+    },
+    {
+      "clue": "Barber shops",
+      "surfaceMisread": "a broader umbrella topic",
+      "resolvedPhraseOrMember": "Category example: Barber shops",
+      "nonObviousWhy": "\"Category example: Barber shops\" belongs in the same set as the rest of the board, which is why the answer sharpens once this pattern becomes visible.",
+      "searchableContext": "Category example: Barber shops",
+      "phraseExample": "Category example: Barber shops"
+    },
+    {
+      "clue": "Olympic vaulters",
+      "surfaceMisread": "a broader umbrella topic",
+      "resolvedPhraseOrMember": "Category example: Olympic vaulters",
+      "nonObviousWhy": "\"Category example: Olympic vaulters\" fits more cleanly once the board is tested under the same answer as the other clues.",
+      "searchableContext": "Category example: Olympic vaulters",
+      "phraseExample": "Category example: Olympic vaulters"
+    },
+    {
+      "clue": "Flags (as attached here: 🏁)",
+      "surfaceMisread": "a broader umbrella topic",
+      "resolvedPhraseOrMember": "Category example: Flags",
+      "nonObviousWhy": "\"Flags (as attached here: 🏁)\" is the clue that makes the shared answer concrete enough to test across the full board.",
+      "searchableContext": "Category example: Flags",
+      "phraseExample": "Category example: Flags"
+    }
+  ],
+  "faqItems": [
+    {
+      "intentType": "solve_strategy",
+      "question": "What final category connects \"Tents\" and \"Skiers\" in LinkedIn Pinpoint #851?",
+      "answer": "The answer is \"All associated with poles\". That reading is the first one that explains the whole set without forcing any clue.",
+      "tiedClue": "Tents"
+    },
+    {
+      "intentType": "solve_strategy",
+      "question": "How do \"Tents\" and \"Skiers\" connect in LinkedIn Pinpoint #851?",
+      "answer": "The connection is a category board focused on all. The clues read more cleanly once they are tested under that same idea instead of as a loose theme.",
+      "tiedClue": "Tents"
+    },
+    {
+      "intentType": "clue_background",
+      "question": "Why is \"Flags (as attached here: 🏁)\" the key clue in LinkedIn Pinpoint #851?",
+      "answer": "\"Flags (as attached here: 🏁)\" is the turning point because it makes the answer concrete enough to test across all five clues.",
+      "tiedClue": "Flags (as attached here: 🏁)"
+    }
+  ],
+  "uniquenessSignals": {
+    "angle": "a category board focused on all",
+    "relatedEntities": [
+      "Category example: Tents",
+      "Category example: Skiers",
+      "Category example: Barber shops",
+      "Category example: Olympic vaulters",
+      "Category example: Flags"
+    ],
+    "doNotRepeatPatterns": [
+      "a category board focused on all",
+      "Category example: Tents",
+      "Category example: Skiers",
+      "Category example: Barber shops",
+      "Category example: Olympic vaulters"
+    ]
+  },
+  "wrongGuessCandidates": [
+    {
+      "label": "a broader umbrella topic",
+      "whyPlausible": "Tents, Skiers can point toward several nearby themes before one clue makes the exact category level visible.",
+      "whyRejected": "Flags (as attached here: 🏁) is the clue that narrows the board into one category with clearer boundaries."
+    },
+    {
+      "label": "a one-clue surface theme",
+      "whyPlausible": "Early clues often tempt you to overfit the board around one obvious surface similarity.",
+      "whyRejected": "The final answer works because it keeps every clue at the same level of specificity, not because one clue happens to fit first."
+    }
+  ],
+  "setValidationSummary": "Barber shops, Olympic vaulters, Flags (as attached here: 🏁) keep the clues at the same category level, which is what makes the board feel like one exact set instead of a broad umbrella theme.",
+  "categoryPrecisionNote": "one concrete category with members that stay at the same level of specificity as All associated with poles"
+}

--- a/data/puzzles/pinpoint-answer-852.json
+++ b/data/puzzles/pinpoint-answer-852.json
@@ -1,0 +1,217 @@
+{
+  "puzzleNumber": 852,
+  "slug": "pinpoint-answer-852",
+  "publishDate": "2026-08-30",
+  "isoDate": "2026-08-30",
+  "detailState": "fallback_full",
+  "bodyMode": "standard",
+  "pageExperienceMode": "full-analysis",
+  "questionType": "category",
+  "difficultyBand": "hard",
+  "clues": [
+    "Everything",
+    "Anchor",
+    "A hint",
+    "A line",
+    "The ball"
+  ],
+  "answer": "Words that follow “drop” in common sayings",
+  "category": "Words that follow “drop” in common sayings",
+  "wordHints": {
+    "Everything": "\"Category example: Everything\" fits more cleanly once the board is tested under the same answer as the other clues.",
+    "Anchor": "\"Category example: Anchor\" helps confirm the same answer instead of pulling the board back toward a looser guess.",
+    "A hint": "\"Category example: A hint\" belongs in the same set as the rest of the board, which is why the answer sharpens once this pattern becomes visible.",
+    "A line": "\"Category example: A line\" fits more cleanly once the board is tested under the same answer as the other clues.",
+    "The ball": "\"The ball\" is the clue that makes the shared answer concrete enough to test across the full board."
+  },
+  "spoilerHints": {
+    "Everything": "Everything should be tested as part of words that follow “drop” in common sayings, not as a standalone reference.",
+    "Anchor": "Keep Anchor in mind, then see whether The ball supports the same answer.",
+    "A hint": "A hint works best after the board narrows toward words that follow “drop” in common sayings.",
+    "A line": "A line should be tested as part of words that follow “drop” in common sayings, not as a standalone reference.",
+    "The ball": "The ball is the clue that makes words that follow “drop” in common sayings concrete enough to test across the full board."
+  },
+  "articleBlocks": [
+    "At first, Everything and Anchor pointed in a few different directions, so the board still felt wider than one exact category. One tempting read was \"a broader umbrella topic\". Everything, Anchor can point toward several nearby themes before one clue makes the exact category level visible. The ball is the clue that narrows the board into one category with clearer boundaries. Another nearby read was \"a one-clue surface theme\". Early clues often tempt you to overfit the board around one obvious surface similarity. The final answer works because it keeps every clue at the same level of specificity, not because one clue happens to fit first.",
+    "Once I read the set through a category board focused on words, examples like \"Category example: Everything\" and \"Category example: Anchor\" stopped feeling loose and started landing cleanly.",
+    "A hint, A line, The ball keep the clues at the same category level, which is what makes the board feel like one exact set instead of a broad umbrella theme.",
+    "The answer was \"Words that follow “drop” in common sayings\". More precisely, the board resolves as one concrete category with members that stay at the same level of specificity as Words that follow “drop” in common sayings, which is why \"Words that follow “drop” in common sayings\" fits better than \"a broader umbrella topic\" or \"a one-clue surface theme\" once the full set is checked."
+  ],
+  "solutionNarrative": [
+    "I started by testing Everything and Anchor, but that only gave me a loose direction. I initially drifted toward a broader umbrella topic, because the first clues could still fit several nearby ideas. I held the guess until one clue gave me a more specific way to read the list.",
+    "The turn came when I let \"The ball\" lead the solve. After that, A hint and A line became the real confirmation check, because they had to fit the same idea without changing the rule or stretching the answer.",
+    "For the final pass, I checked Everything, Anchor, A hint, A line, The ball one by one. The answer worked only if the whole list could stay inside one tight reading, not because one early clue happened to match a broad topic.",
+    "The answer was \"Words that follow “drop” in common sayings\"."
+  ],
+  "lessons": [
+    {
+      "title": "\"Everything\" and \"Anchor\" can look like they belong to different categories at first",
+      "body": "When the opening clues feel broad, wait for the clue that turns one fuzzy theme into a testable answer."
+    },
+    {
+      "title": "\"The ball\" is what makes the answer feel concrete instead of broad",
+      "body": "A strong Pinpoint answer should explain why every clue belongs, not just why the words feel loosely related."
+    },
+    {
+      "title": "Re-check the early clues once \"The ball\" sharpens the answer",
+      "body": "Once \"The ball\" lands, go back and test the earlier clues under that same answer before locking it in."
+    }
+  ],
+  "display": {
+    "connectorSummary": "a category board focused on words",
+    "fastStrategy": "When the opening clues feel broad, wait for the clue that turns one fuzzy theme into a testable answer.",
+    "clueTableRows": [
+      {
+        "clue": "Everything",
+        "examplePhrase": "Category example: Everything",
+        "connectionExplained": "\"Category example: Everything\" fits more cleanly once the board is tested under the same answer as the other clues."
+      },
+      {
+        "clue": "Anchor",
+        "examplePhrase": "Category example: Anchor",
+        "connectionExplained": "\"Category example: Anchor\" helps confirm the same answer instead of pulling the board back toward a looser guess."
+      },
+      {
+        "clue": "A hint",
+        "examplePhrase": "Category example: A hint",
+        "connectionExplained": "\"Category example: A hint\" belongs in the same set as the rest of the board, which is why the answer sharpens once this pattern becomes visible."
+      },
+      {
+        "clue": "A line",
+        "examplePhrase": "Category example: A line",
+        "connectionExplained": "\"Category example: A line\" fits more cleanly once the board is tested under the same answer as the other clues."
+      },
+      {
+        "clue": "The ball",
+        "examplePhrase": "Category example: The ball",
+        "connectionExplained": "\"The ball\" is the clue that makes the shared answer concrete enough to test across the full board."
+      }
+    ]
+  },
+  "faqs": [
+    {
+      "question": "What final category connects \"Everything\" and \"Anchor\" in LinkedIn Pinpoint #852?",
+      "answer": "The answer is \"Words that follow “drop” in common sayings\". That reading is the first one that explains the whole set without forcing any clue."
+    },
+    {
+      "question": "How do \"Everything\" and \"Anchor\" connect in LinkedIn Pinpoint #852?",
+      "answer": "The connection is a category board focused on words. The clues read more cleanly once they are tested under that same idea instead of as a loose theme."
+    },
+    {
+      "question": "Why is \"The ball\" the key clue in LinkedIn Pinpoint #852?",
+      "answer": "\"The ball\" is the turning point because it makes the answer concrete enough to test across all five clues."
+    }
+  ],
+  "solvePath": {
+    "firstRead": "At first, Everything and Anchor pointed in a few different directions, so the board still felt wider than one exact category.",
+    "falseStarts": [
+      "a broader umbrella topic",
+      "a one-clue surface theme"
+    ],
+    "whyFalseStartPlausible": [
+      "Everything, Anchor can point toward several nearby themes before one clue makes the exact category level visible.",
+      "Early clues often tempt you to overfit the board around one obvious surface similarity."
+    ],
+    "breakingClue": "The ball",
+    "pivot": "I started by testing Everything and Anchor, but that only gave me a loose direction. I initially drifted toward a broader umbrella topic, because the first clues could still fit several nearby ideas. I held the guess until one clue gave me a more specific way to read the list.\n\nThe turn came when I let \"The ball\" lead the solve. After that, A hint and A line became the real confirmation check, because they had to fit the same idea without changing the rule or stretching the answer.\n\nFor the final pass, I checked Everything, Anchor, A hint, A line, The ball one by one. The answer worked only if the whole list could stay inside one tight reading, not because one early clue happened to match a broad topic.\n\nThe answer was \"Words that follow “drop” in common sayings\".",
+    "fullBoardConfirmation": "Once I read the set through a category board focused on words, examples like \"Category example: Everything\" and \"Category example: Anchor\" stopped feeling loose and started landing cleanly."
+  },
+  "turningPoint": {
+    "clue": "The ball",
+    "whyDecisive": "The ball is the clue that makes the shared answer concrete enough to test across the full board.",
+    "whatChangedAfterIt": "Once The ball lands, the earlier clues stop feeling broad and start reading under the same answer."
+  },
+  "clueRows": [
+    {
+      "clue": "Everything",
+      "surfaceMisread": "a broader umbrella topic",
+      "resolvedPhraseOrMember": "Category example: Everything",
+      "nonObviousWhy": "\"Category example: Everything\" fits more cleanly once the board is tested under the same answer as the other clues.",
+      "searchableContext": "Category example: Everything",
+      "phraseExample": "Category example: Everything"
+    },
+    {
+      "clue": "Anchor",
+      "surfaceMisread": "a broader umbrella topic",
+      "resolvedPhraseOrMember": "Category example: Anchor",
+      "nonObviousWhy": "\"Category example: Anchor\" helps confirm the same answer instead of pulling the board back toward a looser guess.",
+      "searchableContext": "Category example: Anchor",
+      "phraseExample": "Category example: Anchor"
+    },
+    {
+      "clue": "A hint",
+      "surfaceMisread": "a broader umbrella topic",
+      "resolvedPhraseOrMember": "Category example: A hint",
+      "nonObviousWhy": "\"Category example: A hint\" belongs in the same set as the rest of the board, which is why the answer sharpens once this pattern becomes visible.",
+      "searchableContext": "Category example: A hint",
+      "phraseExample": "Category example: A hint"
+    },
+    {
+      "clue": "A line",
+      "surfaceMisread": "a broader umbrella topic",
+      "resolvedPhraseOrMember": "Category example: A line",
+      "nonObviousWhy": "\"Category example: A line\" fits more cleanly once the board is tested under the same answer as the other clues.",
+      "searchableContext": "Category example: A line",
+      "phraseExample": "Category example: A line"
+    },
+    {
+      "clue": "The ball",
+      "surfaceMisread": "a broader umbrella topic",
+      "resolvedPhraseOrMember": "Category example: The ball",
+      "nonObviousWhy": "\"The ball\" is the clue that makes the shared answer concrete enough to test across the full board.",
+      "searchableContext": "Category example: The ball",
+      "phraseExample": "Category example: The ball"
+    }
+  ],
+  "faqItems": [
+    {
+      "intentType": "solve_strategy",
+      "question": "What final category connects \"Everything\" and \"Anchor\" in LinkedIn Pinpoint #852?",
+      "answer": "The answer is \"Words that follow “drop” in common sayings\". That reading is the first one that explains the whole set without forcing any clue.",
+      "tiedClue": "Everything"
+    },
+    {
+      "intentType": "solve_strategy",
+      "question": "How do \"Everything\" and \"Anchor\" connect in LinkedIn Pinpoint #852?",
+      "answer": "The connection is a category board focused on words. The clues read more cleanly once they are tested under that same idea instead of as a loose theme.",
+      "tiedClue": "Everything"
+    },
+    {
+      "intentType": "clue_background",
+      "question": "Why is \"The ball\" the key clue in LinkedIn Pinpoint #852?",
+      "answer": "\"The ball\" is the turning point because it makes the answer concrete enough to test across all five clues.",
+      "tiedClue": "The ball"
+    }
+  ],
+  "uniquenessSignals": {
+    "angle": "a category board focused on words",
+    "relatedEntities": [
+      "Category example: Everything",
+      "Category example: Anchor",
+      "Category example: A hint",
+      "Category example: A line",
+      "Category example: The ball"
+    ],
+    "doNotRepeatPatterns": [
+      "a category board focused on words",
+      "Category example: Everything",
+      "Category example: Anchor",
+      "Category example: A hint",
+      "Category example: A line"
+    ]
+  },
+  "wrongGuessCandidates": [
+    {
+      "label": "a broader umbrella topic",
+      "whyPlausible": "Everything, Anchor can point toward several nearby themes before one clue makes the exact category level visible.",
+      "whyRejected": "The ball is the clue that narrows the board into one category with clearer boundaries."
+    },
+    {
+      "label": "a one-clue surface theme",
+      "whyPlausible": "Early clues often tempt you to overfit the board around one obvious surface similarity.",
+      "whyRejected": "The final answer works because it keeps every clue at the same level of specificity, not because one clue happens to fit first."
+    }
+  ],
+  "setValidationSummary": "A hint, A line, The ball keep the clues at the same category level, which is what makes the board feel like one exact set instead of a broad umbrella theme.",
+  "categoryPrecisionNote": "one concrete category with members that stay at the same level of specificity as Words that follow “drop” in common sayings"
+}

--- a/data/puzzles/registry.json
+++ b/data/puzzles/registry.json
@@ -1,9 +1,349 @@
 [
   {
+    "puzzleNumber": 852,
+    "slug": "pinpoint-answer-852",
+    "publishDate": "2026-08-30",
+    "status": "live",
+    "detailState": "fallback_full",
+    "clues": [
+      "Everything",
+      "Anchor",
+      "A hint",
+      "A line",
+      "The ball"
+    ],
+    "mainAnswer": "Words that follow “drop” in common sayings",
+    "category": "Words that follow “drop” in common sayings",
+    "difficultyLevel": "Moderate",
+    "seoTemplateVersion": "serp-v1",
+    "shortSummary": "Pinpoint Answer Today asks: what links Everything, Anchor, A hint, A line, The ball - and what story do they share? The set starts with a few plausible directions before one clue makes the clean reading hard to miss.",
+    "updatedAt": "2026-08-30T07:05:14.466Z"
+  },
+  {
+    "puzzleNumber": 851,
+    "slug": "pinpoint-answer-851",
+    "publishDate": "2026-08-29",
+    "status": "archived",
+    "detailState": "fallback_full",
+    "clues": [
+      "Tents",
+      "Skiers",
+      "Barber shops",
+      "Olympic vaulters",
+      "Flags (as attached here: 🏁)"
+    ],
+    "mainAnswer": "All associated with poles",
+    "category": "All associated with poles",
+    "difficultyLevel": "Moderate",
+    "seoTemplateVersion": "serp-v1",
+    "shortSummary": "Pinpoint Answer Today asks: what links Tents, Skiers, Barber shops, Olympic vaulters, Flags (as attached here: 🏁) - and what story do they share? The set starts with a few plausible directions before one clue makes the clean reading hard to miss.",
+    "updatedAt": "2026-08-30T07:05:14.466Z"
+  },
+  {
+    "puzzleNumber": 850,
+    "slug": "pinpoint-answer-850",
+    "publishDate": "2026-08-28",
+    "status": "archived",
+    "detailState": "fallback_full",
+    "clues": [
+      "Will",
+      "Trade",
+      "Rein",
+      "Speech",
+      "As a bird"
+    ],
+    "mainAnswer": "Words that come after “free”",
+    "category": "Words that come after “free”",
+    "difficultyLevel": "Moderate",
+    "seoTemplateVersion": "serp-v1",
+    "shortSummary": "Pinpoint Answer Today asks: what links Will, Trade, Rein, Speech, As a bird - and what story do they share? The set starts with a few plausible directions before one clue makes the clean reading hard to miss.",
+    "updatedAt": "2026-08-29T07:06:40.126Z"
+  },
+  {
+    "puzzleNumber": 849,
+    "slug": "pinpoint-answer-849",
+    "publishDate": "2026-08-27",
+    "status": "archived",
+    "detailState": "fallback_full",
+    "clues": [
+      "Octopuses",
+      "Arctic hares (twice a year)",
+      "Mood rings",
+      "Leaves (in autumn)",
+      "Chameleons"
+    ],
+    "mainAnswer": "Things that change colors",
+    "category": "Things that change colors",
+    "difficultyLevel": "Moderate",
+    "seoTemplateVersion": "serp-v1",
+    "shortSummary": "Pinpoint Answer Today asks: what links Octopuses, Arctic hares (twice a year), Mood rings, Leaves (in autumn), Chameleons - and what story do they share? The set starts with a few plausible directions before one clue makes the clean reading hard to miss.",
+    "updatedAt": "2026-08-28T07:04:17.989Z"
+  },
+  {
+    "puzzleNumber": 848,
+    "slug": "pinpoint-answer-848",
+    "publishDate": "2026-08-26",
+    "status": "archived",
+    "detailState": "fallback_full",
+    "clues": [
+      "Twist",
+      "Floss",
+      "Robot",
+      "Moonwalk",
+      "Macarena"
+    ],
+    "mainAnswer": "Names of dance crazes",
+    "category": "Names of dance crazes",
+    "difficultyLevel": "Moderate",
+    "seoTemplateVersion": "serp-v1",
+    "shortSummary": "Pinpoint Answer Today asks: what links Twist, Floss, Robot, Moonwalk, Macarena - and what story do they share? The set starts with a few plausible directions before one clue makes the clean reading hard to miss.",
+    "updatedAt": "2026-08-27T07:02:27.247Z"
+  },
+  {
+    "puzzleNumber": 847,
+    "slug": "pinpoint-answer-847",
+    "publishDate": "2026-08-25",
+    "status": "archived",
+    "detailState": "fallback_full",
+    "clues": [
+      "Impact",
+      "Courier",
+      "Wingdings",
+      "Lucida Handwriting",
+      "Calibri or Aptos (in MS Office)"
+    ],
+    "mainAnswer": "Names of fonts",
+    "category": "Names of fonts",
+    "difficultyLevel": "Moderate",
+    "seoTemplateVersion": "serp-v1",
+    "shortSummary": "Pinpoint Answer Today asks: what links Impact, Courier, Wingdings, Lucida Handwriting, Calibri or Aptos (in MS Office) - and what story do they share? The set starts with a few plausible directions before one clue makes the clean reading hard to miss.",
+    "updatedAt": "2026-08-26T07:02:49.183Z"
+  },
+  {
+    "puzzleNumber": 846,
+    "slug": "pinpoint-answer-846",
+    "publishDate": "2026-08-24",
+    "status": "archived",
+    "detailState": "fallback_full",
+    "clues": [
+      "Krait",
+      "Copperhead",
+      "Python",
+      "Viper",
+      "Boa constrictor"
+    ],
+    "mainAnswer": "Types of snakes",
+    "category": "Types of snakes",
+    "difficultyLevel": "Moderate",
+    "seoTemplateVersion": "serp-v1",
+    "shortSummary": "Pinpoint Answer Today asks: what links Krait, Copperhead, Python, Viper, Boa constrictor - and what story do they share? The set starts with a few plausible directions before one clue makes the clean reading hard to miss.",
+    "updatedAt": "2026-08-25T07:03:05.714Z"
+  },
+  {
+    "puzzleNumber": 845,
+    "slug": "pinpoint-answer-845",
+    "publishDate": "2026-08-23",
+    "status": "archived",
+    "detailState": "fallback_full",
+    "clues": [
+      "Tank",
+      "Piece",
+      "Twice",
+      "Out loud",
+      "Outside the box"
+    ],
+    "mainAnswer": "Words that come after “think”",
+    "category": "Words that come after “think”",
+    "difficultyLevel": "Moderate",
+    "seoTemplateVersion": "serp-v1",
+    "shortSummary": "Pinpoint Answer Today asks: what links Tank, Piece, Twice, Out loud, Outside the box - and what story do they share? The set starts with a few plausible directions before one clue makes the clean reading hard to miss.",
+    "updatedAt": "2026-08-24T07:04:36.934Z"
+  },
+  {
+    "puzzleNumber": 844,
+    "slug": "pinpoint-answer-844",
+    "publishDate": "2026-08-22",
+    "status": "archived",
+    "detailState": "fallback_full",
+    "clues": [
+      "Crushing ice",
+      "Removing nails",
+      "Tenderizing meat",
+      "Shaping metal (over an anvil)",
+      "Chiseling stone (hit with this)"
+    ],
+    "mainAnswer": "Different ways to use a hammer (besides the most common one)",
+    "category": "Different ways to use a hammer (besides the most common one)",
+    "difficultyLevel": "Moderate",
+    "seoTemplateVersion": "serp-v1",
+    "shortSummary": "Pinpoint Answer Today asks: what links Crushing ice, Removing nails, Tenderizing meat, Shaping metal (over an anvil), Chiseling stone (hit with this) - and what story do they share? The set starts with a few plausible directions before one clue makes the clean reading hard to miss.",
+    "updatedAt": "2026-08-23T07:07:34.383Z"
+  },
+  {
+    "puzzleNumber": 843,
+    "slug": "pinpoint-answer-843",
+    "publishDate": "2026-08-21",
+    "status": "archived",
+    "detailState": "published",
+    "clues": [
+      "A video",
+      "A glance",
+      "The messenger",
+      "Fish in a barrel",
+      "Oneself in the foot"
+    ],
+    "mainAnswer": "Things you might “shoot”",
+    "category": "Things you might “shoot”",
+    "difficultyLevel": "Moderate",
+    "seoTemplateVersion": "serp-v1",
+    "shortSummary": "At first glance, A video, A glance, The messenger do not look like one clean set. The solve only tightens once a later clue makes the shared category much harder to miss.",
+    "updatedAt": "2026-08-22T07:05:40.897Z"
+  },
+  {
+    "puzzleNumber": 842,
+    "slug": "pinpoint-answer-842",
+    "publishDate": "2026-08-20",
+    "status": "archived",
+    "detailState": "fallback_full",
+    "clues": [
+      "Nori",
+      "Jerky",
+      "Instant coffee",
+      "Prunes",
+      "Raisins"
+    ],
+    "mainAnswer": "Food items that are dehydrated",
+    "category": "Food items that are dehydrated",
+    "difficultyLevel": "Moderate",
+    "seoTemplateVersion": "serp-v1",
+    "shortSummary": "Pinpoint Answer Today asks: what links Nori, Jerky, Instant coffee, Prunes, Raisins - and what story do they share? The set starts with a few plausible directions before one clue makes the clean reading hard to miss.",
+    "updatedAt": "2026-08-21T07:01:57.435Z"
+  },
+  {
+    "puzzleNumber": 841,
+    "slug": "pinpoint-answer-841",
+    "publishDate": "2026-08-19",
+    "status": "archived",
+    "detailState": "fallback_full",
+    "clues": [
+      "William and Caroline Herschel",
+      "Tycho Brahe",
+      "Carl Sagan",
+      "Nicolaus Copernicus",
+      "Galileo Galilei"
+    ],
+    "mainAnswer": "Famous astronomers",
+    "category": "Famous astronomers",
+    "difficultyLevel": "Moderate",
+    "seoTemplateVersion": "serp-v1",
+    "shortSummary": "Pinpoint Answer Today asks: what links William and Caroline Herschel, Tycho Brahe, Carl Sagan, Nicolaus Copernicus, Galileo Galilei - and what story do they share? The set starts with a few plausible directions before one clue makes the clean reading hard to miss.",
+    "updatedAt": "2026-08-20T07:03:50.680Z"
+  },
+  {
+    "puzzleNumber": 840,
+    "slug": "pinpoint-answer-840",
+    "publishDate": "2026-08-18",
+    "status": "archived",
+    "detailState": "fallback_full",
+    "clues": [
+      "The Muppets",
+      "Star Wars",
+      "Marvel",
+      "Pixar",
+      "Mickey Mouse"
+    ],
+    "mainAnswer": "Properties of The Walt Disney Company",
+    "category": "Properties of The Walt Disney Company",
+    "difficultyLevel": "Moderate",
+    "seoTemplateVersion": "serp-v1",
+    "shortSummary": "Pinpoint Answer Today asks: what links The Muppets, Star Wars, Marvel, Pixar, Mickey Mouse - and what story do they share? The set starts with a few plausible directions before one clue makes the clean reading hard to miss.",
+    "updatedAt": "2026-08-19T07:01:55.796Z"
+  },
+  {
+    "puzzleNumber": 839,
+    "slug": "pinpoint-answer-839",
+    "publishDate": "2026-08-17",
+    "status": "archived",
+    "detailState": "fallback_full",
+    "clues": [
+      "Dram",
+      "Krone",
+      "Rupee",
+      "Peso",
+      "Euro (€)"
+    ],
+    "mainAnswer": "Names of world currencies",
+    "category": "Names of world currencies",
+    "difficultyLevel": "Moderate",
+    "seoTemplateVersion": "serp-v1",
+    "shortSummary": "Pinpoint Answer Today asks: what links Dram, Krone, Rupee, Peso, Euro (€) - and what story do they share? The set starts with a few plausible directions before one clue makes the clean reading hard to miss.",
+    "updatedAt": "2026-08-18T07:04:24.402Z"
+  },
+  {
+    "puzzleNumber": 838,
+    "slug": "pinpoint-answer-838",
+    "publishDate": "2026-08-16",
+    "status": "archived",
+    "detailState": "fallback_full",
+    "clues": [
+      "Freeze",
+      "Time",
+      "Bed",
+      "Door",
+      "Picture (🖼️)"
+    ],
+    "mainAnswer": "Words that come before “frame”",
+    "category": "Words that come before “frame”",
+    "difficultyLevel": "Moderate",
+    "seoTemplateVersion": "serp-v1",
+    "shortSummary": "Pinpoint Answer Today asks: what links Freeze, Time, Bed, Door, Picture (🖼️) - and what story do they share? The set starts with a few plausible directions before one clue makes the clean reading hard to miss.",
+    "updatedAt": "2026-08-17T07:06:07.817Z"
+  },
+  {
+    "puzzleNumber": 837,
+    "slug": "pinpoint-answer-837",
+    "publishDate": "2026-08-15",
+    "status": "archived",
+    "detailState": "fallback_full",
+    "clues": [
+      "A speech",
+      "The daily newspaper",
+      "The mail",
+      "A knockout blow",
+      "Restaurant food brought to you"
+    ],
+    "mainAnswer": "Things that are delivered",
+    "category": "Things that are delivered",
+    "difficultyLevel": "Moderate",
+    "seoTemplateVersion": "serp-v1",
+    "shortSummary": "Pinpoint Answer Today asks: what links A speech, The daily newspaper, The mail, A knockout blow, Restaurant food brought to you - and what story do they share? The set starts with a few plausible directions before one clue makes the clean reading hard to miss.",
+    "updatedAt": "2026-08-16T07:05:08.033Z"
+  },
+  {
+    "puzzleNumber": 836,
+    "slug": "pinpoint-answer-836",
+    "publishDate": "2026-08-14",
+    "status": "archived",
+    "detailState": "published",
+    "clues": [
+      "Odyssey",
+      "Galaxy",
+      "Kart",
+      "64",
+      "Bros. 3"
+    ],
+    "mainAnswer": "Terms that come after “Super Mario” in video game titles",
+    "category": "Terms that come after “Super Mario” in video game titles",
+    "difficultyLevel": "Moderate",
+    "seoTemplateVersion": "serp-v1",
+    "shortSummary": "At first glance, Odyssey, Galaxy, Kart do not look like one clean set. The solve only tightens once a later clue makes the shared category much harder to miss.",
+    "updatedAt": "2026-08-15T07:02:55.385Z"
+  },
+  {
     "puzzleNumber": 835,
     "slug": "pinpoint-answer-835",
     "publishDate": "2026-08-13",
-    "status": "live",
+    "status": "archived",
     "detailState": "fallback_full",
     "clues": [
       "The Sun",
@@ -17,7 +357,7 @@
     "difficultyLevel": "Moderate",
     "seoTemplateVersion": "serp-v1",
     "shortSummary": "Pinpoint Answer Today asks: what links The Sun, Dominoes, Leopards, Dalmations, Ladybirds / ladybugs (🐞) - and what story do they share? The set starts with a few plausible directions before one clue makes the clean reading hard to miss.",
-    "updatedAt": "2026-08-13T07:05:22.525Z"
+    "updatedAt": "2026-08-15T07:02:55.385Z"
   },
   {
     "puzzleNumber": 834,

--- a/docs/ITERATION.md
+++ b/docs/ITERATION.md
@@ -326,3 +326,14 @@
 未做：本记录写入时尚未提交、开 PR、合并或部署生产 Worker；本地 dry-run 不能代替生产部署和健康检查。
 复查日期：合并并部署生产 Worker 后立即复查 Worker 版本、健康状态、发布队列和线上 summary。
 下一步：提交独立分支并开 PR，等待 CI 和 Vercel Preview；合并后用 Node.js 22 部署生产 Worker 并完成线上验收。
+
+## 2026-08-30 #836-#852 发布断档恢复记录
+
+问题：正式站从 `#835` 后停止更新。最早的 `#836` 候选因为纯数字线索 `64` 在 JavaScript 对象中会自动排到其他键前面，被 `wordHints` 顺序校验误拦；后续候选每天都从仍停在 `#835` 的 `main` 创建，连续性缺口扩大到 `#836-#851`。
+证据：`#836` CI 报 `expected "Odyssey", received "64"`；`#837` 开始报缺少前序题号；`#852` 候选 CI 报缺少 `#836-#851`。生产 Worker 逐日历史接口和 17 个候选分支的日期、五条线索、`fetchedAt`、`sha256:` 来源校验均通过，详情文件保持候选原文。
+本轮边界：只恢复 `#836-#852`、修纯数字线索的顺序判定和本次恢复暴露的正式答案误报；不改首页固定 SEO 标题/描述、URL、canonical、sitemap 规则或原工作区未提交内容。
+修改：登记表连续补齐 `#836-#852`，只有 `#852` 为 live；页面始终使用 registry 数组保存的线索顺序，`wordHints` 只校验键集合，不再把对象键顺序当成线索顺序；语义检查会先移除正文中的准确正式答案，再查缩短版答案，避免把 `Food items that are dehydrated` 内部的 `Items that are dehydrated` 误判成另一答案，同时仍会拦住真正单独出现的缩短写法。
+验证：`validate:data` 通过 395 条 registry；lint、类型检查、Pinpoint 守卫和完整构建通过；395 个真实详情页渲染检查与 sitemap 覆盖检查通过；构建产物中的 `#836` 线索顺序为 `Odyssey / Galaxy / Kart / 64 / Bros. 3`；17 个恢复详情文件与原候选提交逐字一致。
+未做：本记录写入时尚未合并到 `main`，尚未完成 Vercel Production、线上 summary、详情页、sitemap 和候选分支清理验收。
+复查日期：本次合并和 Production 部署后立即复查。
+下一步：提交独立修复分支并开 PR；CI 通过后合并，等待准确 SHA 的 Production，再验证首页、summary、`#836/#851/#852`、sitemap 和候选分支数量。

--- a/lib/puzzles/data/detail.ts
+++ b/lib/puzzles/data/detail.ts
@@ -346,22 +346,6 @@ function resolveEvidenceUniquenessSignals(
   };
 }
 
-function resolveDetailClues(
-  registryClues: string[],
-  detailContent: PuzzleDetailContentRecord,
-): string[] {
-  const detailClues = Object.keys(detailContent.wordHints);
-
-  if (
-    detailClues.length === registryClues.length &&
-    detailClues.every((clue) => registryClues.includes(clue))
-  ) {
-    return detailClues;
-  }
-
-  return registryClues;
-}
-
 export async function toPuzzleDetail(
   entry: PuzzleRegistryEntryRecord & {
     mainAnswer: string;
@@ -370,7 +354,8 @@ export async function toPuzzleDetail(
   },
 ): Promise<PuzzleDetail> {
   const detailContent = await fetchPuzzleContent(entry.slug);
-  const detailClues = resolveDetailClues(entry.clues, detailContent);
+  // Integer-like object keys are enumerated first, so the registry array owns clue order.
+  const detailClues = entry.clues;
   const detailState = resolveFormalDetailState(entry, detailContent);
   const display = buildPuzzleDisplay(
     detailClues,

--- a/lib/puzzles/semantic-lint.ts
+++ b/lib/puzzles/semantic-lint.ts
@@ -312,7 +312,12 @@ function pushAnswerLogicIssues(
     );
   }
 
-  for (const candidate of extractAnswerLikeCandidates(text)) {
+  const answerScanText = text.replace(/["“”'`]/g, "");
+  const textWithoutOfficialAnswer = answerScanText.replace(
+    new RegExp(escapeForRegex(mainAnswer), "gi"),
+    " ",
+  );
+  for (const candidate of extractAnswerLikeCandidates(textWithoutOfficialAnswer)) {
     if (!looksLikeSameAnswerFamily(candidate, mainAnswer)) continue;
     pushIssue(
       issues,

--- a/scripts/check-pinpoint-guardrails.ts
+++ b/scripts/check-pinpoint-guardrails.ts
@@ -2043,6 +2043,23 @@ function checkContentContractRequiresThreeCompleteFaqsAndLessons() {
 }
 
 function checkGenericFalseStartWarningsDoNotBlockPublish() {
+  const exactAnswerCodes = collectSemanticLintIssues({
+    mainAnswer: "Food items that are dehydrated",
+    solutionEmergence: 'The answer was "Food items that are dehydrated".',
+  }).map((issue) => issue.code);
+  const alternateAnswerCodes = collectSemanticLintIssues({
+    mainAnswer: "Food items that are dehydrated",
+    solutionEmergence: 'The answer was "Items that are dehydrated".',
+  }).map((issue) => issue.code);
+  assert.ok(
+    !exactAnswerCodes.includes("answer.alternateRestatement"),
+    "semantic lint must not treat a substring inside the exact official answer as an alternate answer",
+  );
+  assert.ok(
+    alternateAnswerCodes.includes("answer.alternateRestatement"),
+    "semantic lint must still block a genuinely shortened alternate answer",
+  );
+
   const rawWords = ["White", "Pirate", "National", "Checkered", "Capture the"];
   const semanticCodes = collectSemanticLintIssues({
     mainAnswer: "Words that come before flag",

--- a/scripts/validate-data.ts
+++ b/scripts/validate-data.ts
@@ -446,12 +446,7 @@ function validateDetailContent(entry: PuzzleRegistryEntryRecord, detail: PuzzleD
     throw new Error(`wordHints clue mismatch for ${entry.slug}: ${parts.join("; ")}`);
   }
 
-  const orderMismatchIndex = entry.clues.findIndex((clue, index) => clue !== hintKeys[index]);
-  if (orderMismatchIndex !== -1) {
-    throw new Error(
-      `wordHints clue order mismatch for ${entry.slug}: expected "${entry.clues[orderMismatchIndex]}", received "${hintKeys[orderMismatchIndex]}" at position ${orderMismatchIndex + 1}`,
-    );
-  }
+  // wordHints is a record; numeric clues cannot preserve insertion order in JavaScript objects.
 
   const bodyWordCount = countWords(bodyParagraphs.join(" "));
   const minRequiredFullAnalysisWords =


### PR DESCRIPTION
## Summary
- restore the 17 real candidate details for Pinpoint #836-#852 and make #852 the only live registry entry
- treat registry clue arrays as the source of display order so numeric clue keys such as `64` cannot reorder `wordHints`
- prevent exact official answers from being misread as shortened alternate answers while retaining the real alternate-answer guard

## Evidence
- every recovered detail matches its original Worker-created candidate commit byte for byte
- every date and five-clue set was checked against production Worker history with valid `fetchedAt` and `sha256:` provenance
- #846 and #848 retain the candidate wording already generated by the Worker while their source clue sets match exactly

## Verification
- `npm run validate:data` (395 records)
- `npm run lint`
- `npm run typecheck`
- `npm run test:pinpoint-guardrails`
- `npm run build` (420 static pages)
- `npm run test:pinpoint-rendered` (395 detail pages and sitemap)
- #836 rendered clue order: Odyssey, Galaxy, Kart, 64, Bros. 3
