### PR TITLE
Prevent Pinpoint candidate backlog accumulation

### DIFF
--- a/docs/ITERATION.md
+++ b/docs/ITERATION.md
@@ -337,3 +337,14 @@
 未做：本记录写入时尚未合并到 `main`，尚未完成 Vercel Production、线上 summary、详情页、sitemap 和候选分支清理验收。
 复查日期：本次合并和 Production 部署后立即复查。
 下一步：提交独立修复分支并开 PR；CI 通过后合并，等待准确 SHA 的 Production，再验证首页、summary、`#836/#851/#852`、sitemap 和候选分支数量。
+
+## 2026-08-31 候选分支积压防复发记录
+
+问题：`#836` 首个候选失败后，生产 Worker 仍每天创建一个新候选，最终积压 17 个分支。候选清理工具又只认“候选提交是否被 main 包含”，不能识别“内容已经通过恢复提交进入 main、但提交关系不同”的安全清理场景。
+证据：生产配置开启 `PINPOINT_CANDIDATE_BRANCH_ENABLED=true`，原发布路径只检查当天候选，不读取全部候选分支；原清理工具遇到候选不是当前 main 的后代时直接报 stuck，不比较目标题目的详情 JSON 和 registry 内容。
+本轮边界：只修改候选队列、候选清理、只读 dry-run 和守卫测试；不改首页固定 SEO 标题/描述、题目内容、URL、canonical 或 sitemap 规则。
+修改：Worker 在候选发布和 release queue 两条路径开始前读取完整候选列表；列表读不到、存在其他候选，或当天候选已经落后于 main 时都会停止，只报告最早待处理分支，不再创建第二个候选或继续给失效分支追加提交；停止会抛出明确错误，不写当天完成标记，后续运行仍可重试。清理工具对分叉候选使用结构化 JSON 比较，只忽略 registry 的 `status` 和 `updatedAt`；详情和其余 registry 内容完全一致、准确 main SHA 的 Production 验证与公开页面检查通过后，才删除旧候选。Production 缺失时禁止为分叉候选自动制造重试提交。
+验证：发布队列策略覆盖候选列表读取失败、较早候选拦截、重复分支去重和候选总数；结构化比较覆盖仅生命周期字段变化、详情正文变化和 registry 内容变化；Pinpoint 守卫、根目录类型检查和 Worker 类型检查通过。
+未做：本记录写入时尚未提交、合并或部署生产 Worker；本地检查不能代替真实候选、Worker 和 Production 验收。
+复查日期：合并并部署生产 Worker 后立即复查；下一次每日发布窗口再次确认候选分支不超过 1 个。
+下一步：提交独立 PR，CI 通过后合并并部署生产 Worker，再运行 release queue dry-run、Worker health 和 Production 状态检查。

--- a/lib/puzzles/candidate-payload-equivalence.shared.d.mts
+++ b/lib/puzzles/candidate-payload-equivalence.shared.d.mts
@@ -1,0 +1,17 @@
+export type CandidatePayloadEquivalenceInput = {
+  slug?: string;
+  publishDate?: string;
+  candidateDetail?: unknown;
+  mainDetail?: unknown;
+  candidateRegistry?: unknown;
+  mainRegistry?: unknown;
+};
+
+export type CandidatePayloadEquivalenceResult = {
+  equivalent: boolean;
+  reason: string;
+};
+
+export declare function assessCandidatePayloadOnMain(
+  input?: CandidatePayloadEquivalenceInput,
+): CandidatePayloadEquivalenceResult;

--- a/lib/puzzles/candidate-payload-equivalence.shared.mjs
+++ b/lib/puzzles/candidate-payload-equivalence.shared.mjs
@@ -1,0 +1,52 @@
+import { isDeepStrictEqual } from "node:util";
+
+const REGISTRY_LIFECYCLE_FIELDS = new Set(["status", "updatedAt"]);
+
+function registryEntries(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function findRegistryEntry(registry, slug) {
+  return registryEntries(registry).find((entry) => String(entry?.slug || "") === slug) || null;
+}
+
+function withoutLifecycleFields(entry) {
+  return Object.fromEntries(
+    Object.entries(entry || {}).filter(([key]) => !REGISTRY_LIFECYCLE_FIELDS.has(key)),
+  );
+}
+
+export function assessCandidatePayloadOnMain({
+  slug,
+  publishDate,
+  candidateDetail,
+  mainDetail,
+  candidateRegistry,
+  mainRegistry,
+} = {}) {
+  const normalizedSlug = String(slug || "").trim();
+  const normalizedPublishDate = String(publishDate || "").trim();
+  if (!normalizedSlug || !normalizedPublishDate) {
+    return { equivalent: false, reason: "candidate identity is incomplete" };
+  }
+
+  const candidateEntry = findRegistryEntry(candidateRegistry, normalizedSlug);
+  const mainEntry = findRegistryEntry(mainRegistry, normalizedSlug);
+  if (!candidateEntry || !mainEntry) {
+    return { equivalent: false, reason: `registry entry missing for ${normalizedSlug}` };
+  }
+  if (
+    String(candidateEntry.publishDate || "") !== normalizedPublishDate ||
+    String(mainEntry.publishDate || "") !== normalizedPublishDate
+  ) {
+    return { equivalent: false, reason: `registry publishDate mismatch for ${normalizedSlug}` };
+  }
+  if (!isDeepStrictEqual(candidateDetail, mainDetail)) {
+    return { equivalent: false, reason: `detail JSON differs for ${normalizedSlug}` };
+  }
+  if (!isDeepStrictEqual(withoutLifecycleFields(candidateEntry), withoutLifecycleFields(mainEntry))) {
+    return { equivalent: false, reason: `registry content differs for ${normalizedSlug}` };
+  }
+
+  return { equivalent: true, reason: `candidate payload for ${normalizedSlug} is already on main` };
+}

--- a/lib/puzzles/release-queue-policy.shared.d.mts
+++ b/lib/puzzles/release-queue-policy.shared.d.mts
@@ -12,6 +12,8 @@ export type ReleaseQueuePolicyInput = {
   candidateBranch?: string;
   candidateBranchExists?: boolean;
   candidateIsCurrent?: boolean;
+  candidateInventoryAvailable?: boolean;
+  otherCandidateBranches?: string[];
   allowCandidatePromotion?: boolean;
   overrideSecondProductionPush?: boolean;
   localGatesPassed?: boolean;
@@ -30,6 +32,8 @@ export type ReleaseQueuePolicyDecision = {
     reasonCode: string;
     candidateBranch: string;
     remainingWindowMs?: number;
+    blockingCandidateBranch?: string;
+    candidateBranchCount?: number;
   };
 };
 

--- a/lib/puzzles/release-queue-policy.shared.mjs
+++ b/lib/puzzles/release-queue-policy.shared.mjs
@@ -16,6 +16,11 @@ function normalizeBoolean(value) {
   return value === true;
 }
 
+function normalizeStringArray(value) {
+  if (!Array.isArray(value)) return [];
+  return [...new Set(value.map((item) => normalizeString(item)).filter(Boolean))].sort();
+}
+
 function parseTimeMs(value) {
   if (value instanceof Date) return value.getTime();
   if (typeof value === "number" && Number.isFinite(value)) return value;
@@ -30,14 +35,21 @@ function normalizeWindowMinutes(value) {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_SLA_WINDOW_MINUTES;
 }
 
+function resolveCandidateBranch(input) {
+  const slug = normalizeString(input.slug);
+  const logicalGameDate = normalizeString(input.logicalGameDate);
+  return (
+    normalizeString(input.candidateBranch) ||
+    (slug && logicalGameDate ? `pinpoint/candidate/${logicalGameDate}-${slug}` : "")
+  );
+}
+
 function makeDecision(action, reasonCode, input, extra = {}) {
   const deploymentState = normalizeState(input.deploymentState);
   const slug = normalizeString(input.slug);
   const logicalGameDate = normalizeString(input.logicalGameDate);
   const publishMode = normalizeString(input.publishMode || "unknown");
-  const candidateBranch =
-    normalizeString(input.candidateBranch) ||
-    (slug && logicalGameDate ? `pinpoint/candidate/${logicalGameDate}-${slug}` : "");
+  const candidateBranch = resolveCandidateBranch(input);
 
   return {
     action,
@@ -52,6 +64,8 @@ function makeDecision(action, reasonCode, input, extra = {}) {
       reasonCode,
       candidateBranch,
       ...(extra.remainingWindowMs !== undefined ? { remainingWindowMs: extra.remainingWindowMs } : {}),
+      ...(extra.blockingCandidateBranch ? { blockingCandidateBranch: extra.blockingCandidateBranch } : {}),
+      ...(extra.candidateBranchCount !== undefined ? { candidateBranchCount: extra.candidateBranchCount } : {}),
     },
   };
 }
@@ -70,6 +84,38 @@ export function decidePinpointReleaseQueueAction(input = {}) {
 
   if (input.localGatesPassed === false) {
     return makeDecision("hold-review", "local-gates-failed", { ...input, deploymentState });
+  }
+
+  if (input.candidateInventoryAvailable === false) {
+    return makeDecision("hold-review", "candidate-inventory-unavailable", { ...input, deploymentState });
+  }
+
+  const otherCandidateBranches = normalizeStringArray(input.otherCandidateBranches);
+  if (otherCandidateBranches.length > 0) {
+    return makeDecision(
+      "hold-review",
+      "another-candidate-pending",
+      { ...input, deploymentState },
+      {
+        blockingCandidateBranch: otherCandidateBranches[0],
+        candidateBranchCount: otherCandidateBranches.length + (normalizeBoolean(input.candidateBranchExists) ? 1 : 0),
+      },
+    );
+  }
+
+  if (
+    normalizeBoolean(input.candidateBranchExists) &&
+    !normalizeBoolean(input.candidateIsCurrent)
+  ) {
+    return makeDecision(
+      "hold-review",
+      "candidate-branch-outdated",
+      { ...input, deploymentState },
+      {
+        blockingCandidateBranch: resolveCandidateBranch(input),
+        candidateBranchCount: 1,
+      },
+    );
   }
 
   if (deploymentState === "failed") {
@@ -91,14 +137,6 @@ export function decidePinpointReleaseQueueAction(input = {}) {
       { ...input, deploymentState },
       { remainingWindowMs },
     );
-  }
-
-  if (
-    deploymentState === "ready" &&
-    normalizeBoolean(input.candidateBranchExists) &&
-    !normalizeBoolean(input.candidateIsCurrent)
-  ) {
-    return makeDecision("write-candidate", "candidate-branch-outdated", { ...input, deploymentState });
   }
 
   if (

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -33,7 +33,7 @@ Prefer the `npm run ...` commands in `package.json` for routine work. Run indivi
 | `npm run release:production` | `release-production.mjs` | Orchestrates production release checks and release steps. |
 | `npm run generate:static-page-metadata` | `generate-static-page-metadata.mjs` | Regenerates static page metadata from git modification dates. |
 | `npm run pinpoint:prepublish-gate` | `check-pinpoint-prepublish-gate.ts` | Runs the one-command Pinpoint pre-publish gate and returns `AUTO_PUBLISH_ALLOWED`, `BLOCK_PUBLISH`, `DOWNGRADE_TO_ANSWER_FIRST_NOINDEX`, or `REVIEW_REQUIRED`. It also runs the detail keyword audit against rendered detail HTML. Complete generated clue explanations can pass now; `MISSING_EVIDENCE_REF` is info only under the current policy. See `docs/pinpoint-evidence-ref-policy-2026-05-31.md`. |
-| `npm run pinpoint:candidate-close` | `close-pinpoint-candidate-branches.mjs` | Closes safe Pinpoint candidate branches or opens a tracked issue when one is stuck. |
+| `npm run pinpoint:candidate-close` | `close-pinpoint-candidate-branches.mjs` | Closes promoted candidates, safely removes recovered candidates whose structured payload already matches `main`, or opens a tracked issue when one is stuck. |
 | `npm run pinpoint:main-recovery` | `recover-pinpoint-main-content.mjs` | After a failed `main` CI run, tries only known content auto-repair and pushes a safe candidate branch for automatic promotion. |
 | Vercel build hook | `vercel-ignore-build.mjs` | Determines whether Vercel can skip a build for a given change set. |
 | `npm run prepare` | `install-hooks.mjs` | Installs local git hooks. |

--- a/scripts/check-pinpoint-guardrails.ts
+++ b/scripts/check-pinpoint-guardrails.ts
@@ -20,6 +20,7 @@ import {
   countExactAnswerMentions,
   getExactAnswerUsageIssue,
 } from "../lib/puzzles/answer-usage.shared.mjs";
+import { assessCandidatePayloadOnMain } from "../lib/puzzles/candidate-payload-equivalence.shared.mjs";
 import {
   buildLightweightPublishFailureSummary,
   updateLightweightPublishFailureStreak,
@@ -2979,6 +2980,27 @@ function checkReleaseQueuePolicy() {
     nowMs: Date.parse("2026-05-22T08:30:00.000Z"),
   };
 
+  const unavailableInventory = decidePinpointReleaseQueueAction({
+    ...baseInput,
+    deploymentState: "ready",
+    candidateInventoryAvailable: false,
+  });
+  assert.equal(unavailableInventory.action, "hold-review", "unknown candidate inventory must fail closed");
+  assert.equal(unavailableInventory.reasonCode, "candidate-inventory-unavailable");
+
+  const earlierCandidate = "pinpoint/candidate/2026-05-21-pinpoint-answer-751";
+  const blockedByEarlierCandidate = decidePinpointReleaseQueueAction({
+    ...baseInput,
+    deploymentState: "ready",
+    candidateBranchExists: true,
+    candidateInventoryAvailable: true,
+    otherCandidateBranches: [earlierCandidate, earlierCandidate],
+  });
+  assert.equal(blockedByEarlierCandidate.action, "hold-review", "an earlier candidate must block a new candidate");
+  assert.equal(blockedByEarlierCandidate.reasonCode, "another-candidate-pending");
+  assert.equal(blockedByEarlierCandidate.notificationFields.blockingCandidateBranch, earlierCandidate);
+  assert.equal(blockedByEarlierCandidate.notificationFields.candidateBranchCount, 2);
+
   const queued = decidePinpointReleaseQueueAction({
     ...baseInput,
     deploymentState: "queued",
@@ -3023,12 +3045,16 @@ function checkReleaseQueuePolicy() {
 
   const staleCandidate = decidePinpointReleaseQueueAction({
     ...baseInput,
-    deploymentState: "ready",
+    deploymentState: "queued",
     candidateBranchExists: true,
     candidateIsCurrent: false,
   });
-  assert.equal(staleCandidate.action, "write-candidate", "stale candidate should be updated before production push");
+  assert.equal(staleCandidate.action, "hold-review", "stale candidate must stop instead of receiving another bad commit");
   assert.equal(staleCandidate.reasonCode, "candidate-branch-outdated");
+  assert.equal(
+    staleCandidate.notificationFields.blockingCandidateBranch,
+    "pinpoint/candidate/2026-05-22-pinpoint-answer-752",
+  );
 
   const currentCandidateAwaitingPromotion = decidePinpointReleaseQueueAction({
     ...baseInput,
@@ -3069,6 +3095,59 @@ function checkReleaseQueuePolicy() {
   );
 
   console.log("ok: release queue policy blocks duplicate production pushes and unsafe deployment states");
+}
+
+function checkRecoveredCandidatePayloadEquivalence() {
+  const slug = "pinpoint-answer-836";
+  const publishDate = "2026-08-14";
+  const detail = {
+    wordHints: { "64": "A title clue", Odyssey: "A title clue" },
+    articleBlocks: ["Verified recovery content."],
+  };
+  const registryContent = {
+    puzzleNumber: 836,
+    slug,
+    publishDate,
+    detailState: "published",
+    clues: ["Odyssey", "64"],
+    mainAnswer: "Terms that come after Super Mario",
+  };
+  const candidateRegistry = [{ ...registryContent, status: "live", updatedAt: "2026-08-14T07:00:00.000Z" }];
+  const mainRegistry = [{ ...registryContent, status: "archived", updatedAt: "2026-08-15T07:00:00.000Z" }];
+
+  const equivalent = assessCandidatePayloadOnMain({
+    slug,
+    publishDate,
+    candidateDetail: detail,
+    mainDetail: JSON.parse(JSON.stringify(detail)),
+    candidateRegistry,
+    mainRegistry,
+  });
+  assert.equal(equivalent.equivalent, true, "lifecycle-only registry differences should be safe to close");
+
+  const changedDetail = assessCandidatePayloadOnMain({
+    slug,
+    publishDate,
+    candidateDetail: detail,
+    mainDetail: { ...detail, articleBlocks: ["Different content."] },
+    candidateRegistry,
+    mainRegistry,
+  });
+  assert.equal(changedDetail.equivalent, false, "different detail content must keep the candidate branch");
+  assert.match(changedDetail.reason, /detail JSON differs/);
+
+  const changedRegistry = assessCandidatePayloadOnMain({
+    slug,
+    publishDate,
+    candidateDetail: detail,
+    mainDetail: detail,
+    candidateRegistry,
+    mainRegistry: [{ ...mainRegistry[0], mainAnswer: "Different answer" }],
+  });
+  assert.equal(changedRegistry.equivalent, false, "different registry content must keep the candidate branch");
+  assert.match(changedRegistry.reason, /registry content differs/);
+
+  console.log("ok: recovered candidate cleanup compares structured payloads and ignores lifecycle-only fields");
 }
 
 function checkWorkerRouteDispatchResolver() {
@@ -3213,6 +3292,9 @@ async function checkReleaseQueueDryRunOpsScript() {
     "worker ops script must simulate the primary queue path without changing Worker config",
   );
   for (const expectedReason of [
+    "candidate-inventory-unavailable",
+    "another-candidate-pending",
+    "candidate-branch-outdated",
     "production-deployment-queued",
     "production-deployment-building",
     "production-deployment-unknown",
@@ -3734,6 +3816,9 @@ async function checkCandidateBranchWatchdogClosesStuckBranches() {
       watchdogSource.includes("verify-pinpoint-candidate-release.mjs") &&
       watchdogSource.includes("--production-sha") &&
       watchdogSource.includes("--repair-missing-production") &&
+      watchdogSource.includes("assessRecoveredCandidatePayload") &&
+      watchdogSource.includes("content-equivalent-verified-and-deleted") &&
+      watchdogSource.includes("repairMissingProduction: false") &&
       watchdogSource.includes('git(["merge", "--no-ff", "--no-edit", branchRef]') &&
       watchdogSource.includes('git(["push", "origin", "HEAD:main"]') &&
       watchdogSource.includes('git(["push", "origin", "--delete", branch]') &&
@@ -3741,7 +3826,7 @@ async function checkCandidateBranchWatchdogClosesStuckBranches() {
       watchdogSource.includes("candidate branch count returns to 0") &&
       watchdogSource.includes("GITHUB_STEP_SUMMARY") &&
       watchdogSource.includes("pending candidates have not updated production yet"),
-    "candidate watchdog must promote verified branches, delete closed branches, and create a tracked issue when it cannot close one",
+    "candidate watchdog must promote verified branches, close content-equivalent recovered branches, and track anything unsafe",
   );
   assert.ok(
     workerSource.includes("retryable LLM/validation errors exhausted; switched to fallback_full") &&
@@ -4512,8 +4597,14 @@ async function checkReleaseQueueWorkerIntegration() {
   assert.ok(
     workerSource.includes("decidePinpointReleaseQueueAction({") &&
       workerSource.includes("lastProductionPushAt") &&
-      workerSource.includes("candidateIsCurrent"),
-    "worker publish path must pass deployment state, production push budget, and candidate freshness to the queue policy",
+      workerSource.includes("candidateIsCurrent") &&
+      workerSource.includes("listCandidateBranchNames") &&
+      workerSource.includes("if (forceCandidateBranch || releaseQueueEnabled)") &&
+      workerSource.includes("candidate queue held") &&
+      workerSource.includes("throw new CandidateQueueBlockedError") &&
+      workerSource.includes("candidateInventoryAvailable") &&
+      workerSource.includes("otherCandidateBranches"),
+    "worker publish path must pass deployment state, production push budget, and the complete candidate inventory to the queue policy",
   );
   assert.ok(
     workerSource.includes("inspectNewSiteBaseDeploymentStatus") &&
@@ -4558,6 +4649,7 @@ async function main() {
   checkIntermediateStateCommitDetection();
   await checkWorkerEnrichCommitsOnlyFinalPublicPayload();
   checkReleaseQueuePolicy();
+  checkRecoveredCandidatePayloadEquivalence();
   checkWorkerRouteDispatchResolver();
   await checkCandidateBranchDryRunRouteSafety();
   await checkReleaseQueueDryRunRouteSafety();

--- a/scripts/close-pinpoint-candidate-branches.mjs
+++ b/scripts/close-pinpoint-candidate-branches.mjs
@@ -1,6 +1,7 @@
 import { spawnSync } from "node:child_process";
 import { appendFileSync } from "node:fs";
 import process from "node:process";
+import { assessCandidatePayloadOnMain } from "../lib/puzzles/candidate-payload-equivalence.shared.mjs";
 
 const DEFAULT_REPO = "elng12/pinpoint-answer-today-new";
 const CANDIDATE_PREFIX = "pinpoint/candidate/";
@@ -107,6 +108,28 @@ function commitAgeMinutes(ref) {
   const timestamp = Date.parse(committedAt);
   if (!Number.isFinite(timestamp)) return Number.POSITIVE_INFINITY;
   return Math.max(0, Math.floor((Date.now() - timestamp) / 60000));
+}
+
+function readGitJson(ref, path) {
+  return JSON.parse(git(["show", `${ref}:${path}`]));
+}
+
+function assessRecoveredCandidatePayload({ candidateRef, slug, publishDate }) {
+  try {
+    return assessCandidatePayloadOnMain({
+      slug,
+      publishDate,
+      candidateDetail: readGitJson(candidateRef, `data/puzzles/${slug}.json`),
+      mainDetail: readGitJson("origin/main", `data/puzzles/${slug}.json`),
+      candidateRegistry: readGitJson(candidateRef, "data/puzzles/registry.json"),
+      mainRegistry: readGitJson("origin/main", "data/puzzles/registry.json"),
+    });
+  } catch (error) {
+    return {
+      equivalent: false,
+      reason: error instanceof Error ? error.message : String(error),
+    };
+  }
 }
 
 function parseActionsRunId(run) {
@@ -218,12 +241,12 @@ function promoteCandidate({ branchRef, dryRun }) {
   return git(["rev-parse", "HEAD"]);
 }
 
-function verifyCandidateRelease({ branch, candidateSha, productionSha, dryRun }) {
+function verifyCandidateRelease({ branch, candidateSha, productionSha, dryRun, repairMissingProduction = true }) {
   if (dryRun) {
     console.log(`[dry-run] would verify Production release for ${branch} ${productionSha}`);
     return;
   }
-  run("node", [
+  const args = [
     "scripts/verify-pinpoint-candidate-release.mjs",
     "--candidate-branch",
     branch,
@@ -231,12 +254,13 @@ function verifyCandidateRelease({ branch, candidateSha, productionSha, dryRun })
     candidateSha,
     "--production-sha",
     productionSha,
-    "--repair-missing-production",
-  ], { inherit: true });
+    ...(repairMissingProduction ? ["--repair-missing-production"] : []),
+  ];
+  run("node", args, { inherit: true });
 }
 
 async function closeCandidateBranch({ branch, repo, token, maxPendingMinutes, dryRun }) {
-  parseCandidateBranch(branch);
+  const { publishDate, slug } = parseCandidateBranch(branch);
   fetchMain();
   fetchBranch(branch);
 
@@ -254,12 +278,31 @@ async function closeCandidateBranch({ branch, repo, token, maxPendingMinutes, dr
 
   const baseIsAncestor = isAncestor("origin/main", candidateRef);
   if (!baseIsAncestor) {
+    const recoveredPayload = assessRecoveredCandidatePayload({ candidateRef, slug, publishDate });
+    if (recoveredPayload.equivalent) {
+      const productionSha = git(["rev-parse", "origin/main"]);
+      verifyCandidateRelease({
+        branch,
+        candidateSha,
+        productionSha,
+        dryRun,
+        repairMissingProduction: false,
+      });
+      deleteRemoteBranch(branch, dryRun);
+      return {
+        branch,
+        sha: candidateSha,
+        productionSha,
+        closed: true,
+        action: "content-equivalent-verified-and-deleted",
+      };
+    }
     return {
       branch,
       sha: candidateSha,
       closed: false,
       severity: ageMinutes >= maxPendingMinutes ? "failure" : "pending",
-      reason: `candidate is not based on current main; age=${ageMinutes}m`,
+      reason: `candidate is not based on current main; ${recoveredPayload.reason}; age=${ageMinutes}m`,
     };
   }
 

--- a/scripts/worker-ops.mjs
+++ b/scripts/worker-ops.mjs
@@ -405,6 +405,33 @@ function buildPublishWindowDiagnosis(report) {
 function getReleaseQueueDryRunScenarios(nowIso) {
   return [
     {
+      name: "candidate-inventory-unavailable",
+      params: { deploymentState: "ready", candidateInventoryAvailable: "0" },
+      expectedAction: "hold-review",
+      expectedReasonCode: "candidate-inventory-unavailable",
+    },
+    {
+      name: "earlier-candidate-pending",
+      params: {
+        deploymentState: "ready",
+        candidateInventoryAvailable: "1",
+        otherCandidateBranches: "pinpoint/candidate/2026-05-21-pinpoint-answer-751",
+      },
+      expectedAction: "hold-review",
+      expectedReasonCode: "another-candidate-pending",
+    },
+    {
+      name: "candidate-branch-outdated",
+      params: {
+        deploymentState: "ready",
+        candidateInventoryAvailable: "1",
+        candidateBranchExists: "1",
+        candidateIsCurrent: "0",
+      },
+      expectedAction: "hold-review",
+      expectedReasonCode: "candidate-branch-outdated",
+    },
+    {
       name: "queued",
       params: { deploymentState: "queued" },
       expectedAction: "write-candidate",

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -236,6 +236,8 @@ class PublishEligibilityBlockedError extends Error {
   }
 }
 
+class CandidateQueueBlockedError extends Error {}
+
 type GraphQLOperation = {
   isPrimary?: boolean;
   operationName?: string;
@@ -646,14 +648,18 @@ function sanitizeGitBranchSegment(input: string, fallback: string): string {
   return safe || fallback;
 }
 
-function buildPinpointCandidateBranchName(env: Env, puzzleDate: string, slug: string): string {
+function getPinpointCandidateBranchPrefix(env: Env): string {
   const rawPrefix = String(env.PINPOINT_CANDIDATE_BRANCH_PREFIX || "pinpoint/candidate").trim();
-  const prefix = rawPrefix
+  return rawPrefix
     .replace(/^refs\/heads\//, "")
     .split("/")
     .map((segment) => sanitizeGitBranchSegment(segment, "candidate"))
     .filter(Boolean)
     .join("/") || "pinpoint/candidate";
+}
+
+function buildPinpointCandidateBranchName(env: Env, puzzleDate: string, slug: string): string {
+  const prefix = getPinpointCandidateBranchPrefix(env);
   const dateSegment = sanitizeGitBranchSegment(puzzleDate, "unknown-date");
   const slugSegment = sanitizeGitBranchSegment(slug, "pinpoint-answer");
   return `${prefix}/${dateSegment}-${slugSegment}`;
@@ -883,6 +889,8 @@ async function notifyPinpointReleaseQueueDecision(
     `动作: ${getReleaseQueueActionLabel(fields.action)}`,
     `原因: ${getReleaseQueueReasonLabel(fields.reasonCode)}`,
     `候选分支: ${fields.candidateBranch || "无"}`,
+    ...(fields.blockingCandidateBranch ? [`最早待处理分支: ${fields.blockingCandidateBranch}`] : []),
+    ...(typeof fields.candidateBranchCount === "number" ? [`候选分支总数: ${fields.candidateBranchCount}`] : []),
     `跳过正式站推送: ${getYesNoLabel(decision.productionPushSkipped)}`,
     ...(remainingMinutes !== undefined ? [`上线保护窗口剩余分钟: ${remainingMinutes}`] : []),
   ]);
@@ -972,12 +980,14 @@ function getReleaseQueueReasonLabel(value: unknown): string {
   const raw = String(value || "").trim();
   const map: Record<string, string> = {
     "local-gates-failed": "本地检查没通过",
+    "candidate-inventory-unavailable": "候选分支列表读取失败，为了避免重复排队先停止发布",
+    "another-candidate-pending": "已有更早的候选分支未处理，今天不再创建新候选",
     "production-deployment-failed": "正式站部署失败",
     "production-deployment-queued": "正式站还有部署在排队",
     "production-deployment-building": "正式站正在部署中",
     "production-deployment-unknown": "正式站部署状态不清楚，为了安全先不推正式站",
     "production-push-budget-exhausted": "短时间内已经推过一次正式站，为了安全先写候选分支",
-    "candidate-branch-outdated": "候选分支不是最新，需要先更新",
+    "candidate-branch-outdated": "候选分支落后于 main，必须先清理或重建，不能继续追加提交",
     "candidate-branch-awaiting-promotion": "候选分支已准备好，等待机器检查通过后自动上线",
     "candidate-branch-enabled": "已开启只写候选分支",
     "production-push-allowed": "允许推到正式站",
@@ -4310,6 +4320,25 @@ async function publishToNewSiteGitHub(
     return (asRecord(await res.json()) ?? {}) as JsonRecord;
   };
 
+  const listCandidateBranchNames = async (): Promise<string[]> => {
+    const candidatePrefix = getPinpointCandidateBranchPrefix(env);
+    const res = await fetch(
+      `https://api.github.com/repos/${repo}/git/matching-refs/heads/${encodeGitHubBranchRef(candidatePrefix)}`,
+      { headers },
+    );
+    if (!res.ok) {
+      throw new Error(`GitHub GET candidate refs ${candidatePrefix}: ${res.status} ${await res.text()}`);
+    }
+    const rows = await res.json();
+    if (!Array.isArray(rows)) {
+      throw new Error(`GitHub candidate refs ${candidatePrefix} returned a non-array response`);
+    }
+    return rows
+      .map((item) => String(asRecord(item)?.ref || "").replace(/^refs\/heads\//, "").trim())
+      .filter((name) => name.startsWith(`${candidatePrefix}/`))
+      .sort();
+  };
+
   const isCandidateBranchCurrentWithBase = async (targetBranch: string): Promise<boolean> => {
     const encodedBase = encodeURIComponent(baseBranch);
     const encodedHead = encodeURIComponent(targetBranch);
@@ -4521,8 +4550,63 @@ async function publishToNewSiteGitHub(
     isPublicState &&
     isPrimaryBranch &&
     !forceCandidateBranch;
+  let candidateInventoryAvailable = true;
+  let candidateBranchNames: string[] = [];
+  if (forceCandidateBranch || releaseQueueEnabled) {
+    try {
+      candidateBranchNames = await listCandidateBranchNames();
+    } catch (error) {
+      candidateInventoryAvailable = false;
+      console.warn("[new-site] candidate queue could not list branches; holding publish", error);
+    }
+  }
+  const candidateBranchExistsInInventory = candidateBranchNames.includes(candidateBranch);
+  const otherCandidateBranches = candidateBranchNames.filter((name) => name !== candidateBranch);
+  let candidateBranchIsCurrent = false;
+  if (candidateInventoryAvailable && candidateBranchExistsInInventory) {
+    try {
+      candidateBranchIsCurrent = await isCandidateBranchCurrentWithBase(candidateBranch);
+    } catch (error) {
+      candidateInventoryAvailable = false;
+      console.warn(`[new-site] candidate queue could not compare ${candidateBranch}; holding publish`, error);
+    }
+  }
 
   if (forceCandidateBranch) {
+    if (
+      !candidateInventoryAvailable ||
+      otherCandidateBranches.length > 0 ||
+      (candidateBranchExistsInInventory && !candidateBranchIsCurrent)
+    ) {
+      releaseQueueDecision = decidePinpointReleaseQueueAction({
+        slug,
+        logicalGameDate: puzzleDate,
+        publishMode: "full-analysis",
+        deploymentState: "unknown",
+        candidateBranch,
+        candidateBranchExists: candidateBranchExistsInInventory,
+        candidateIsCurrent: candidateBranchIsCurrent,
+        candidateInventoryAvailable,
+        otherCandidateBranches,
+      });
+      console.warn(
+        `[new-site] candidate queue held #${puzzleNumber}: ${releaseQueueDecision.reasonCode}`,
+      );
+      await notifyPinpointReleaseQueueDecision(env, releaseQueueDecision);
+      await notifyDailyPublishStatusReport(env, {
+        date: puzzleDate,
+        status: "needs_review",
+        puzzleNumber,
+        slug,
+        answer,
+        clues: words,
+        reason: releaseQueueDecision.reasonCode,
+        nextAction: "先处理最早的候选分支，清零后再发布今天内容。",
+      });
+      throw new CandidateQueueBlockedError(
+        `[new-site] candidate queue blocked ${slug}: ${releaseQueueDecision.reasonCode}`,
+      );
+    }
     branch = candidateBranch;
     isCandidateBranch = branch !== baseBranch;
     isPrimaryBranch = isPrimaryNewSiteBranch(branch);
@@ -4547,17 +4631,8 @@ async function publishToNewSiteGitHub(
     }
 
     const lastProductionPushAt = await env.PP_DATA.get(releaseQueueLastProductionPushKeyOf(slug)).catch(() => null);
-    const candidateRef = await getBranchRef(candidateBranch).catch((error) => {
-      console.warn(`[new-site] release queue could not read candidate branch ${candidateBranch}`, error);
-      return null;
-    });
-    const candidateBranchExists = Boolean(candidateRef);
-    const candidateIsCurrent = candidateBranchExists
-      ? await isCandidateBranchCurrentWithBase(candidateBranch).catch((error) => {
-        console.warn(`[new-site] release queue could not compare candidate branch ${candidateBranch}`, error);
-        return false;
-      })
-      : false;
+    const candidateBranchExists = candidateBranchExistsInInventory;
+    const candidateIsCurrent = candidateBranchIsCurrent;
 
     releaseQueueDecision = decidePinpointReleaseQueueAction({
       slug,
@@ -4569,6 +4644,8 @@ async function publishToNewSiteGitHub(
       candidateBranch,
       candidateBranchExists,
       candidateIsCurrent,
+      candidateInventoryAvailable,
+      otherCandidateBranches,
       overrideSecondProductionPush: envFlag(env.PINPOINT_RELEASE_QUEUE_OVERRIDE_SECOND_PUSH, false),
     });
 
@@ -4587,7 +4664,9 @@ async function publishToNewSiteGitHub(
         reason: releaseQueueDecision.reasonCode,
         nextAction: "检查 release queue 状态，确认正式站部署或候选分支是否需要处理。",
       });
-      return;
+      throw new CandidateQueueBlockedError(
+        `[new-site] release queue blocked ${slug}: ${releaseQueueDecision.reasonCode}`,
+      );
     }
 
     if (releaseQueueDecision.action === "write-candidate") {
@@ -7608,6 +7687,11 @@ export default {
       const allowCandidatePromotion = parseOptionalBooleanParam(params, "allowCandidatePromotion");
       const candidateBranchExists = parseOptionalBooleanParam(params, "candidateBranchExists");
       const candidateIsCurrent = parseOptionalBooleanParam(params, "candidateIsCurrent");
+      const candidateInventoryAvailable = parseOptionalBooleanParam(params, "candidateInventoryAvailable");
+      const otherCandidateBranches = String(params.get("otherCandidateBranches") || "")
+        .split(",")
+        .map((value) => value.trim())
+        .filter(Boolean);
       const lastProductionPushAt = String(params.get("lastProductionPushAt") || "").trim() || undefined;
       const nowMs = String(params.get("now") || "").trim() || undefined;
       const publishMode = String(params.get("publishMode") || "full-analysis").trim() || "full-analysis";
@@ -7622,6 +7706,8 @@ export default {
         candidateBranch,
         candidateBranchExists,
         candidateIsCurrent,
+        candidateInventoryAvailable,
+        otherCandidateBranches,
         overrideSecondProductionPush,
         allowCandidatePromotion,
         localGatesPassed,
@@ -7655,6 +7741,8 @@ export default {
           allowCandidatePromotion,
           candidateBranchExists,
           candidateIsCurrent,
+          candidateInventoryAvailable,
+          otherCandidateBranches,
           localGatesPassed,
           nowMs,
         },


### PR DESCRIPTION
## Summary
- block daily publishing when another candidate already exists or candidate inventory cannot be verified
- stop appending commits to a candidate that has fallen behind main
- safely remove recovered divergent candidates only when their structured detail and registry payload already match main and Production verification passes
- add release queue dry-run coverage, guardrails, runbook text, and an iteration record

## Verification
- npm run validate:data
- npm run lint
- npm run typecheck
- npm run test:pinpoint-guardrails
- npm run build
- npm run test:pinpoint-rendered
- npm run typecheck (worker)
- npm run deploy:dry (worker)
- divergent content-equivalent candidate cleanup dry-run in an isolated local repository

## Scope
No homepage SEO copy, puzzle content, routes, canonical rules, or sitemap rules were changed.