### PR TITLE
Fix production release queue dry-run simulation

### DIFF
--- a/scripts/check-pinpoint-guardrails.ts
+++ b/scripts/check-pinpoint-guardrails.ts
@@ -3287,9 +3287,10 @@ async function checkReleaseQueueDryRunOpsScript() {
   );
   assert.ok(
     opsSource.includes("simulatePrimary") &&
+      opsSource.includes('url.searchParams.set("candidateBranchEnabled", "0")') &&
       opsSource.includes("releaseQueueEnabled") &&
       opsSource.includes("queueEligible"),
-    "worker ops script must simulate the primary queue path without changing Worker config",
+    "worker ops script must simulate the primary queue path even when production forces candidate branches",
   );
   for (const expectedReason of [
     "candidate-inventory-unavailable",

--- a/scripts/worker-ops.mjs
+++ b/scripts/worker-ops.mjs
@@ -652,6 +652,7 @@ async function main() {
       const url = new URL(`${baseUrl}/admin/release-queue-dry-run`);
       url.searchParams.set("secret", secret);
       url.searchParams.set("simulatePrimary", "1");
+      url.searchParams.set("candidateBranchEnabled", "0");
       url.searchParams.set("releaseQueueEnabled", "1");
       url.searchParams.set("date", date);
       if (puzzleNumber) url.searchParams.set("puzzleNumber", puzzleNumber);


### PR DESCRIPTION
## Summary
- explicitly disable forced candidate mode inside the read-only release queue simulation
- keep production configuration unchanged while making the nine-scenario matrix deterministic
- add a guardrail for the simulation setup

## Verification
- production Worker dry-run matrix passed all 9 scenarios
- npm run test:pinpoint-guardrails
- npm run typecheck

No production write, puzzle content, page behavior, or SEO copy is changed by this follow-up.