### PR TITLE
fix: use official DeepSeek API for generation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,7 +56,7 @@ FALLBACK_WEBHOOK_SECRET=
 PINPOINT_WORKER_HEALTH_URL=
 
 # AI generation defaults
-# Example with OpenRouter:
-# OPENAI_API_KEY=sk-or-v1-...
-# OPENAI_BASE_URL=https://openrouter.ai/api/v1
-# AI_MODEL=google/gemini-2.0-flash-001
+# DeepSeek official API:
+# OPENAI_API_KEY=<DeepSeek API key>
+# OPENAI_BASE_URL=https://api.deepseek.com
+# AI_MODEL=deepseek-v4-flash

--- a/app/api/admin/generate-draft/route.ts
+++ b/app/api/admin/generate-draft/route.ts
@@ -23,6 +23,7 @@ import {
 } from "@/lib/puzzles/slot-contract";
 import { authenticateAdmin } from "@/lib/site/admin-auth";
 import { enforceAdminRateLimit } from "@/lib/site/admin-rate-limit";
+import { resolveDefaultModel as resolveProviderDefaultModel } from "@/lib/puzzle-generation/provider-client";
 
 const DISALLOWED_LANGUAGE_PATTERN = /[\u3400-\u9FFF\uF900-\uFAFF\u3040-\u30FF\uAC00-\uD7AF]/;
 const LOCALIZE_LABELS: Record<string, string> = {
@@ -57,7 +58,7 @@ function resolveDefaultModel(
   if (provider === "azure") {
     return process.env.AI_MODEL || "gpt-4.1-mini";
   }
-  return process.env.OPENAI_BASE_URL ? "meta-llama/llama-3.3-70b-instruct" : "gpt-4.1-mini";
+  return resolveProviderDefaultModel(provider, process.env.OPENAI_BASE_URL);
 }
 
 function asRecord(value: unknown): DraftRecord | null {

--- a/data/puzzles/pinpoint-answer-854.json
+++ b/data/puzzles/pinpoint-answer-854.json
@@ -1,0 +1,234 @@
+{
+  "puzzleNumber": 854,
+  "slug": "pinpoint-answer-854",
+  "publishDate": "2026-09-01",
+  "isoDate": "2026-09-01",
+  "detailState": "published",
+  "bodyMode": "standard",
+  "pageExperienceMode": "full-analysis",
+  "questionType": "category",
+  "difficultyBand": "hard",
+  "clues": [
+    "Espresso",
+    "Renaissance art",
+    "Vespa scooters",
+    "Fashion houses (Gucci, Prada, …)",
+    "Pizza and pasta"
+  ],
+  "answer": "Things associated with Italy (🇮🇹)",
+  "category": "Things associated with Italy (🇮🇹)",
+  "wordHints": {
+    "Espresso": "Espresso originated in Italy and is a staple of Italian coffee culture, making it a direct cultural export.",
+    "Renaissance art": "The Renaissance began in Italy, and its greatest artists—like Leonardo, Michelangelo, and Raphael—were Italian, making the art deeply tied to the country.",
+    "Vespa scooters": "Vespa is an iconic Italian brand, and its scooters are a symbol of Italian style and post-war mobility.",
+    "Fashion houses (Gucci, Prada, …)": "Gucci, Prada, and many other top fashion houses are based in Italy, making Italian fashion a global standard.",
+    "Pizza and pasta": "Pizza and pasta are quintessential Italian dishes that have become global comfort foods, directly tied to Italy's culinary heritage."
+  },
+  "spoilerHints": {
+    "Espresso": "Think about one shared setting or theme in things associated with italy (🇮🇹) that can absorb Espresso naturally.",
+    "Renaissance art": "Renaissance art points to the same world as the others once the frame gets specific enough toward things associated with italy (🇮🇹).",
+    "Vespa scooters": "Treat Vespa scooters as one part of things associated with italy (🇮🇹) rather than as an isolated reference.",
+    "Fashion houses (Gucci, Prada, …)": "Fashion houses (Gucci, Prada, …) is the clue that turns a loose board into things associated with italy (🇮🇹).",
+    "Pizza and pasta": "Pizza and pasta points to the same world as the others once the frame gets specific enough toward things associated with italy (🇮🇹)."
+  },
+  "articleBlocks": [
+    "At first, this looked more like european icons than the real category.",
+    "Espresso pushed me in that direction immediately.",
+    "Renaissance art kept that theory alive for a moment, but vespa scooters still did not quite fit.",
+    "That was the moment the first idea stopped working.",
+    "Then Vespa scooters made me stop thinking about european icons and start thinking about the real category.",
+    "Espresso made sense as an espresso is an Italian coffee.",
+    "Renaissance art made sense as an italian Renaissance masters.",
+    "The answer was Things associated with Italy (🇮🇹).",
+    "Fashion houses (Gucci, Prada, …) and Pizza and pasta then felt less surprising and more like the last pieces falling into place.",
+    "Looking back, the answer feels obvious in the best way."
+  ],
+  "solutionNarrative": [
+    "I first read Espresso and Renaissance art too literally and drifted toward european icons. Espresso could be read as \"espresso is an Italian coffee\", while Renaissance art could be read as \"Italian Renaissance masters\", so the board still felt open instead of solved.",
+    "Vespa scooters changed the direction because \"Vespa is an Italian scooter\" gave me a testable phrase, not just a loose topic. Once that line worked, I had a fixed place to put the repeated word and could go back through the earlier clues with a clearer target.",
+    "I then checked \"espresso is an Italian coffee\", \"Italian Renaissance masters\", \"Italian luxury fashion\", and \"Italian cuisine staples\". Those checks mattered because each one landed as ordinary wording on its own, so I was not forcing five separate hints into one bag. The board started to behave like one phrase pattern across Espresso, Renaissance art, Vespa scooters, Fashion houses (Gucci, Prada, …), and Pizza and pasta.",
+    "That left very little room for the earlier false start. The answer was \"Things associated with Italy (🇮🇹)\", and the last step was simply making sure every clue used that same reading cleanly before treating the solve as finished."
+  ],
+  "lessons": [
+    {
+      "title": "\"Espresso\" and \"Renaissance art\" can look like they belong to different categories at first",
+      "body": "\"Espresso\" and \"Renaissance art\" both fit several loose themes, so it is often better to wait for a more specific word before locking in a category."
+    },
+    {
+      "title": "\"Vespa scooters\" anchors a shared category board with one concrete theme",
+      "body": "Vespa scooters organizes this board. Once one clue produces a precise natural reading, re-check the earlier clues under that same frame."
+    },
+    {
+      "title": "Use \"Vespa scooters\" to re-check \"Espresso\" under a shared category board with one concrete theme",
+      "body": "When clues seem unrelated, look for a shared origin or national identity—sometimes the answer is a place, not a topic."
+    }
+  ],
+  "display": {
+    "connectorSummary": "a board centered on the theme of Italy (🇮🇹)",
+    "fastStrategy": "\"Espresso\" and \"Renaissance art\" both fit several loose themes, so it is often better to wait for a more specific word before locking in a category.",
+    "clueTableRows": [
+      {
+        "clue": "Espresso",
+        "examplePhrase": "espresso is an Italian coffee",
+        "connectionExplained": "Espresso originated in Italy and is a staple of Italian coffee culture, making it a direct cultural export."
+      },
+      {
+        "clue": "Renaissance art",
+        "examplePhrase": "Italian Renaissance masters",
+        "connectionExplained": "The Renaissance began in Italy, and its greatest artists—like Leonardo, Michelangelo, and Raphael—were Italian, making the art deeply tied to the country."
+      },
+      {
+        "clue": "Vespa scooters",
+        "examplePhrase": "Vespa is an Italian scooter",
+        "connectionExplained": "Vespa is an iconic Italian brand, and its scooters are a symbol of Italian style and post-war mobility."
+      },
+      {
+        "clue": "Fashion houses (Gucci, Prada, …)",
+        "examplePhrase": "Italian luxury fashion",
+        "connectionExplained": "Gucci, Prada, and many other top fashion houses are based in Italy, making Italian fashion a global standard."
+      },
+      {
+        "clue": "Pizza and pasta",
+        "examplePhrase": "Italian cuisine staples",
+        "connectionExplained": "Pizza and pasta are quintessential Italian dishes that have become global comfort foods, directly tied to Italy's culinary heritage."
+      }
+    ]
+  },
+  "faqs": [
+    {
+      "question": "What final category connects \"Espresso\" and \"Renaissance art\" in LinkedIn Pinpoint #854?",
+      "answer": "The answer is \"Things associated with Italy (🇮🇹)\" because that reading explains the full set cleanly, including the final clue."
+    },
+    {
+      "question": "How do \"Espresso\" and \"Renaissance art\" connect in LinkedIn Pinpoint #854?",
+      "answer": "The connection is that all 5 clues point back to one specific category instead of a loose umbrella theme. Vespa scooters is what keeps the category reading precise instead of broad."
+    },
+    {
+      "question": "Why is \"Vespa scooters\" the key clue in LinkedIn Pinpoint #854?",
+      "answer": "Vespa scooters is the turning clue because \"Vespa is an Italian scooter\" makes the shared category frame explicit. It also makes Espresso read cleanly as \"espresso is an Italian coffee\". The board feels tricky because the clues are so iconic that they could each point to a different category—coffee, art, transportation, fashion, food—but they all funnel into one country. The challenge is seeing the common thread without overthinking it."
+    },
+    {
+      "question": "How does \"Espresso\" fit the same category as \"Vespa scooters\" in LinkedIn Pinpoint #854?",
+      "answer": "\"Espresso\" reads as \"espresso is an Italian coffee\" under the same answer, so it supports the category instead of pulling toward a broader guess."
+    }
+  ],
+  "solvePath": {
+    "firstRead": "Espresso, Renaissance art, and Vespa scooters do not immediately look like the same kind of thing, so the first read can wander in the wrong direction. That is why a first read like \"caffeine culture\" can feel plausible before one clue makes the answer feel concrete. Vespa scooters is the clue that finally breaks that first read and makes the real category feel concrete.",
+    "falseStarts": [
+      "caffeine culture",
+      "european icons"
+    ],
+    "whyFalseStartPlausible": [
+      "While all these items are European, they are all specifically Italian—Europe would also include croissants, beer, or other non-Italian items, so the set is too narrow for Europe.",
+      "caffeine culture feels plausible early on, but it falls apart once vespa scooters demands a more exact reading."
+    ],
+    "breakingClue": "Vespa scooters",
+    "pivot": "I first read Espresso and Renaissance art too literally and drifted toward european icons. Espresso could be read as \"espresso is an Italian coffee\", while Renaissance art could be read as \"Italian Renaissance masters\", so the board still felt open instead of solved.\n\nVespa scooters changed the direction because \"Vespa is an Italian scooter\" gave me a testable phrase, not just a loose topic. Once that line worked, I had a fixed place to put the repeated word and could go back through the earlier clues with a clearer target.\n\nI then checked \"espresso is an Italian coffee\", \"Italian Renaissance masters\", \"Italian luxury fashion\", and \"Italian cuisine staples\". Those checks mattered because each one landed as ordinary wording on its own, so I was not forcing five separate hints into one bag. The board started to behave like one phrase pattern across Espresso, Renaissance art, Vespa scooters, Fashion houses (Gucci, Prada, …), and Pizza and pasta.\n\nThat left very little room for the earlier false start. The answer was \"Things associated with Italy (🇮🇹)\", and the last step was simply making sure every clue used that same reading cleanly before treating the solve as finished.",
+    "fullBoardConfirmation": "From there, reading them through one specific category frame explains the board much more cleanly. Entries like Espresso, Renaissance art, and Vespa scooters stop feeling disconnected and start looking like they belong together. Once vespa scooters is read the right way, the earlier clues stop pulling in different directions and start behaving like parts of the same answer. The board feels tricky because the clues are so iconic that they could each point to a different category—coffee, art, transportation, fashion, food—but they all funnel into one country. The challenge is seeing the common thread without overthinking it."
+  },
+  "turningPoint": {
+    "clue": "Vespa scooters",
+    "whyDecisive": "The clue 'Vespa scooters' was the turning point because it's so specific to Italy that it ruled out broader guesses like caffeine or European culture.",
+    "whatChangedAfterIt": "Once Vespa scooters landed, the earlier clues stopped pulling in different directions and started reinforcing the same answer."
+  },
+  "clueRows": [
+    {
+      "clue": "Espresso",
+      "surfaceMisread": "european icons",
+      "resolvedPhraseOrMember": "espresso is an Italian coffee",
+      "nonObviousWhy": "Espresso originated in Italy and is a staple of Italian coffee culture, making it a direct cultural export.",
+      "searchableContext": "The word 'espresso' comes from Italian, meaning 'pressed out,' referring to the brewing method.",
+      "phraseExample": "The word 'espresso' comes from Italian, meaning 'pressed out,' referring to the brewing method."
+    },
+    {
+      "clue": "Renaissance art",
+      "surfaceMisread": "european icons",
+      "resolvedPhraseOrMember": "Italian Renaissance masters",
+      "nonObviousWhy": "The Renaissance began in Italy, and its greatest artists—like Leonardo, Michelangelo, and Raphael—were Italian, making the art deeply tied to the country.",
+      "searchableContext": "'Renaissance' is French for 'rebirth,' but the movement is strongly identified with Italy.",
+      "phraseExample": "'Renaissance' is French for 'rebirth,' but the movement is strongly identified with Italy."
+    },
+    {
+      "clue": "Vespa scooters",
+      "surfaceMisread": "european icons",
+      "resolvedPhraseOrMember": "Vespa is an Italian scooter",
+      "nonObviousWhy": "Vespa is an iconic Italian brand, and its scooters are a symbol of Italian style and post-war mobility.",
+      "searchableContext": "'Vespa' means 'wasp' in Italian, named for its shape and sound.",
+      "phraseExample": "'Vespa' means 'wasp' in Italian, named for its shape and sound."
+    },
+    {
+      "clue": "Fashion houses (Gucci, Prada, …)",
+      "surfaceMisread": "european icons",
+      "resolvedPhraseOrMember": "Italian luxury fashion",
+      "nonObviousWhy": "Gucci, Prada, and many other top fashion houses are based in Italy, making Italian fashion a global standard.",
+      "searchableContext": "Gucci and Prada are family names of Italian founders.",
+      "phraseExample": "Gucci and Prada are family names of Italian founders."
+    },
+    {
+      "clue": "Pizza and pasta",
+      "surfaceMisread": "european icons",
+      "resolvedPhraseOrMember": "Italian cuisine staples",
+      "nonObviousWhy": "Pizza and pasta are quintessential Italian dishes that have become global comfort foods, directly tied to Italy's culinary heritage.",
+      "searchableContext": "Both words are Italian: 'pizza' and 'pasta' (meaning dough/paste).",
+      "phraseExample": "Both words are Italian: 'pizza' and 'pasta' (meaning dough/paste)."
+    }
+  ],
+  "faqItems": [
+    {
+      "intentType": "solve_strategy",
+      "question": "What final category connects \"Espresso\" and \"Renaissance art\" in LinkedIn Pinpoint #854?",
+      "answer": "The answer is \"Things associated with Italy (🇮🇹)\" because that reading explains the full set cleanly, including the final clue.",
+      "tiedClue": "Espresso"
+    },
+    {
+      "intentType": "solve_strategy",
+      "question": "How do \"Espresso\" and \"Renaissance art\" connect in LinkedIn Pinpoint #854?",
+      "answer": "The connection is that all 5 clues point back to one specific category instead of a loose umbrella theme. Vespa scooters is what keeps the category reading precise instead of broad.",
+      "tiedClue": "Espresso"
+    },
+    {
+      "intentType": "clue_background",
+      "question": "Why is \"Vespa scooters\" the key clue in LinkedIn Pinpoint #854?",
+      "answer": "Vespa scooters is the turning clue because \"Vespa is an Italian scooter\" makes the shared category frame explicit. It also makes Espresso read cleanly as \"espresso is an Italian coffee\". The board feels tricky because the clues are so iconic that they could each point to a different category—coffee, art, transportation, fashion, food—but they all funnel into one country. The challenge is seeing the common thread without overthinking it.",
+      "tiedClue": "Vespa scooters"
+    },
+    {
+      "intentType": "solve_strategy",
+      "question": "How does \"Espresso\" fit the same category as \"Vespa scooters\" in LinkedIn Pinpoint #854?",
+      "answer": "\"Espresso\" reads as \"espresso is an Italian coffee\" under the same answer, so it supports the category instead of pulling toward a broader guess.",
+      "tiedClue": "Espresso"
+    }
+  ],
+  "uniquenessSignals": {
+    "angle": "a shared category board with one concrete theme",
+    "relatedEntities": [
+      "espresso is an Italian coffee",
+      "Italian Renaissance masters",
+      "Vespa is an Italian scooter",
+      "Italian luxury fashion",
+      "Italian cuisine staples"
+    ],
+    "doNotRepeatPatterns": [
+      "a shared category board with one concrete theme",
+      "\"Espresso\" and \"Renaissance art\" can look like they belong to different categories at first",
+      "\"Vespa scooters\" anchors a shared category board with one concrete theme",
+      "Use \"Vespa scooters\" to re-check \"Espresso\" under a shared category board with one concrete theme",
+      "The word 'espresso' comes from Italian, meaning 'pressed out,' referring to the brewing method.",
+      "'Renaissance' is French for 'rebirth,' but the movement is strongly identified with Italy."
+    ]
+  },
+  "wrongGuessCandidates": [
+    {
+      "label": "european icons",
+      "whyPlausible": "While all these items are European, they are all specifically Italian—Europe would also include croissants, beer, or other non-Italian items, so the set is too narrow for Europe.",
+      "whyRejected": "Once Vespa scooters lands, the final answer explains the board more cleanly than european icons."
+    },
+    {
+      "label": "caffeine culture",
+      "whyPlausible": "caffeine culture feels plausible early on, but it falls apart once vespa scooters demands a more exact reading.",
+      "whyRejected": "Once Vespa scooters lands, the final answer explains the board more cleanly than caffeine culture."
+    }
+  ],
+  "setValidationSummary": "Vespa scooters, Fashion houses (Gucci, Prada, …), Pizza and pasta keep confirming the same answer, so the board reads like one exact set instead of a broad bucket.",
+  "categoryPrecisionNote": "one concrete category with members that stay at the same level of specificity as Things associated with Italy (🇮🇹)"
+}

--- a/data/puzzles/registry.json
+++ b/data/puzzles/registry.json
@@ -1,9 +1,29 @@
 [
   {
+    "puzzleNumber": 854,
+    "slug": "pinpoint-answer-854",
+    "publishDate": "2026-09-01",
+    "status": "live",
+    "detailState": "published",
+    "clues": [
+      "Espresso",
+      "Renaissance art",
+      "Vespa scooters",
+      "Fashion houses (Gucci, Prada, …)",
+      "Pizza and pasta"
+    ],
+    "mainAnswer": "Things associated with Italy (🇮🇹)",
+    "category": "Things associated with Italy (🇮🇹)",
+    "difficultyLevel": "Moderate",
+    "seoTemplateVersion": "serp-v1",
+    "shortSummary": "At first glance, Espresso, Renaissance art, Vespa scooters do not look like one clean set. The solve only tightens once a later clue makes the shared category much harder to miss.",
+    "updatedAt": "2026-09-02T01:07:50.996Z"
+  },
+  {
     "puzzleNumber": 853,
     "slug": "pinpoint-answer-853",
     "publishDate": "2026-08-31",
-    "status": "live",
+    "status": "archived",
     "detailState": "fallback_full",
     "clues": [
       "Risk",
@@ -17,7 +37,7 @@
     "difficultyLevel": "Moderate",
     "seoTemplateVersion": "serp-v1",
     "shortSummary": "Pinpoint Answer Today asks: what links Risk, Taboo, Boggle, Cluedo (Clue in N. America), Jenga - and what story do they share? The set starts with a few plausible directions before one clue makes the clean reading hard to miss.",
-    "updatedAt": "2026-08-31T07:06:11.917Z"
+    "updatedAt": "2026-09-02T01:07:50.996Z"
   },
   {
     "puzzleNumber": 852,

--- a/lib/puzzle-generation/provider-client.ts
+++ b/lib/puzzle-generation/provider-client.ts
@@ -17,6 +17,7 @@ type RequestAIResponseArgs = {
 const AI_MAX_RETRIES = 3;
 const AI_RETRY_BASE_DELAY_MS = 800;
 const AI_REQUEST_TIMEOUT_MS = 45_000;
+export const AI_MAX_OUTPUT_TOKENS = 8_192;
 
 function normalizeProviderText(value: string | null | undefined): string {
   return (value ?? "").replace(/\s+/g, " ").trim();
@@ -137,7 +138,23 @@ export function resolveDefaultModel(provider: PuzzleProvider, endpoint?: string)
   if (provider === "azure") {
     return "gpt-4.1-mini";
   }
+  if (isDeepSeekEndpoint(endpoint)) {
+    return "deepseek-v4-flash";
+  }
   return endpoint ? "meta-llama/llama-3.3-70b-instruct" : "gpt-4.1-mini";
+}
+
+function isDeepSeekEndpoint(endpoint?: string): boolean {
+  if (!endpoint) return false;
+  try {
+    return new URL(endpoint).hostname.toLowerCase() === "api.deepseek.com";
+  } catch {
+    return false;
+  }
+}
+
+function isDeepSeekV4Model(model: string): boolean {
+  return /^deepseek-v4-(?:flash|pro)(?:$|-)/i.test(model.trim());
 }
 
 export function ensureProviderModelCompatibility(
@@ -200,29 +217,12 @@ async function requestOpenAICompatibleContent({
     }
   }
 
-  const requestBody: Record<string, unknown> = {
-    messages: [
-      {
-        role: "system",
-        content: systemPrompt,
-      },
-      {
-        role: "user",
-        content: prompt,
-      },
-    ],
-    temperature: 0.7,
-  };
-
-  if (provider !== "azure") {
-    requestBody.model = model;
-  }
-  if (
-    (provider === "openai" || provider === "zhipu") &&
-    (model.includes("gpt-") || model.includes("glm-") || model.includes("llama"))
-  ) {
-    requestBody.response_format = { type: "json_object" };
-  }
+  const requestBody = buildOpenAICompatibleRequestBody({
+    prompt,
+    provider,
+    model,
+    systemPrompt,
+  });
 
   debugInfo?.("AI API request", { provider, model, apiUrl });
   const responseText = await fetchTextWithRetry(
@@ -237,21 +237,75 @@ async function requestOpenAICompatibleContent({
     debugError,
   );
 
-  let data: { choices?: Array<{ message?: { content?: string } }> };
+  let data: {
+    choices?: Array<{
+      finish_reason?: string | null;
+      message?: { content?: string };
+    }>;
+  };
   try {
-    data = JSON.parse(responseText) as { choices?: Array<{ message?: { content?: string } }> };
+    data = JSON.parse(responseText) as typeof data;
   } catch (error) {
     throw new Error(
       `Failed to parse AI API response as JSON: ${(error as Error)?.message ?? "unknown"}. First 500 chars: ${responseText.slice(0, 500)}`,
     );
   }
 
-  const content = data.choices?.[0]?.message?.content;
+  const choice = data.choices?.[0];
+  if (choice?.finish_reason === "length") {
+    throw new Error(
+      `AI response was truncated at max_tokens=${AI_MAX_OUTPUT_TOKENS}`,
+    );
+  }
+
+  const content = choice?.message?.content;
   if (!content) {
     throw new Error("No content returned from AI");
   }
 
   return content;
+}
+
+export function buildOpenAICompatibleRequestBody({
+  prompt,
+  provider,
+  model,
+  systemPrompt,
+}: Pick<RequestAIResponseArgs, "prompt" | "provider" | "model" | "systemPrompt">): Record<string, unknown> {
+  const requestBody: Record<string, unknown> = {
+    messages: [
+      {
+        role: "system",
+        content: systemPrompt,
+      },
+      {
+        role: "user",
+        content: prompt,
+      },
+    ],
+    max_tokens: AI_MAX_OUTPUT_TOKENS,
+    temperature: 0.7,
+    stream: false,
+  };
+
+  if (provider !== "azure") {
+    requestBody.model = model;
+  }
+  if (
+    (provider === "openai" || provider === "zhipu") &&
+    (model.includes("gpt-") ||
+      model.includes("glm-") ||
+      model.includes("llama") ||
+      isDeepSeekV4Model(model))
+  ) {
+    requestBody.response_format = { type: "json_object" };
+  }
+
+  if (provider === "openai" && isDeepSeekV4Model(model)) {
+    requestBody.thinking = { type: "disabled" };
+  }
+
+  return requestBody;
 }
 
 async function requestAnthropicContent({

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "test:pinpoint-routing": "tsx scripts/check-routing-regressions.ts",
     "test:pinpoint-rendered": "tsx scripts/check-pinpoint-rendered-content.ts",
     "test:pinpoint-reasoning-article": "tsx scripts/check-pinpoint-reasoning-article.ts",
+    "test:deepseek-api": "tsx scripts/check-deepseek-api-config.ts",
     "test:pinpoint-guardrails": "npm run test:pinpoint-seo && npm run test:pinpoint-routing && tsx scripts/check-pinpoint-guardrails.ts",
     "test:pinpoint-regression": "npm run test:pinpoint-guardrails && node scripts/run-pinpoint-regression.mjs",
     "test:pinpoint-regression:core": "npm run test:pinpoint-guardrails && node scripts/run-pinpoint-regression.mjs --set core",

--- a/scripts/check-deepseek-api-config.ts
+++ b/scripts/check-deepseek-api-config.ts
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import {
+  AI_MAX_OUTPUT_TOKENS,
+  buildOpenAICompatibleRequestBody,
+  requestAIResponseContent,
+  resolveDefaultModel,
+} from "../lib/puzzle-generation/provider-client";
+import {
+  buildLLMRequestBody,
+  callLLM,
+  LLM_MAX_OUTPUT_TOKENS,
+} from "../worker/src/enrich-llm";
+
+const model = "deepseek-v4-flash";
+const workerBody = buildLLMRequestBody("Return JSON", model);
+
+assert.equal(LLM_MAX_OUTPUT_TOKENS, 8_192);
+assert.equal(workerBody.model, model);
+assert.equal(workerBody.max_tokens, 8_192);
+assert.equal(workerBody.stream, false);
+assert.deepEqual(workerBody.response_format, { type: "json_object" });
+assert.deepEqual(workerBody.thinking, { type: "disabled" });
+
+const siteBody = buildOpenAICompatibleRequestBody({
+  prompt: "Return JSON",
+  provider: "openai",
+  model,
+  systemPrompt: "Return JSON only",
+});
+
+assert.equal(AI_MAX_OUTPUT_TOKENS, 8_192);
+assert.equal(siteBody.model, model);
+assert.equal(siteBody.max_tokens, 8_192);
+assert.equal(siteBody.stream, false);
+assert.deepEqual(siteBody.response_format, { type: "json_object" });
+assert.deepEqual(siteBody.thinking, { type: "disabled" });
+assert.equal(
+  resolveDefaultModel("openai", "https://api.deepseek.com"),
+  model,
+);
+assert.equal(
+  resolveDefaultModel("openai", "https://openrouter.ai/api/v1"),
+  "meta-llama/llama-3.3-70b-instruct",
+);
+
+const root = fileURLToPath(new URL("..", import.meta.url));
+const wranglerConfig = readFileSync(`${root}/worker/wrangler.toml`, "utf8");
+assert.equal(
+  (wranglerConfig.match(/LLM_BASE_URL\s+=\s+"https:\/\/api\.deepseek\.com"/g) ?? []).length,
+  3,
+);
+assert.equal(
+  (wranglerConfig.match(/AUTO_ENRICH_MODEL\s+=\s+"deepseek-v4-flash"/g) ?? []).length,
+  3,
+);
+assert.doesNotMatch(wranglerConfig, /openrouter\.ai\/api\/v1/i);
+
+async function checkTruncatedResponses(): Promise<void> {
+  const originalFetch = globalThis.fetch;
+  try {
+    globalThis.fetch = async () =>
+      new Response(
+        JSON.stringify({
+          choices: [
+            {
+              finish_reason: "length",
+              message: { content: '{"partial":true' },
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      );
+
+    await assert.rejects(
+      () =>
+        callLLM("Return JSON", {
+          apiKey: "test-key",
+          baseUrl: "https://api.deepseek.com",
+          model,
+        }),
+      /truncated at max_tokens=8192/,
+    );
+    await assert.rejects(
+      () =>
+        requestAIResponseContent({
+          prompt: "Return JSON",
+          apiKey: "test-key",
+          provider: "openai",
+          model,
+          endpoint: "https://api.deepseek.com",
+          systemPrompt: "Return JSON only",
+        }),
+      /truncated at max_tokens=8192/,
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+}
+
+checkTruncatedResponses()
+  .then(() => console.log("DeepSeek API configuration checks passed."))
+  .catch((error: unknown) => {
+    console.error(error);
+    process.exitCode = 1;
+  });

--- a/worker/README.md
+++ b/worker/README.md
@@ -65,10 +65,11 @@ wrangler deploy --env staging --name pinpoint-worker-staging  # 受控演练（�
 - `GITHUB_TOKEN_NEW_SITE` 长期应使用 fine-grained PAT，并限制到 `elng12/pinpoint-answer-today-new` 的 `contents:write`；临时复用本机 `gh auth token` 只适合一次性演练，不适合长期保留
 - 站点 enrichment 走的是站点自己的 `/api/admin/generate-draft`，所以除了 Cloudflare Worker secret 以外，Vercel 站点侧也要有可用的 `API_SECRET_TOKEN` / `ADMIN_PASSPHRASE` / `OPENAI_API_KEY` / `OPENAI_BASE_URL` / `AI_MODEL`
 - `shadow` 默认写演练分支 `worker-shadow`，`staging` 默认写演练分支 `worker-staging`；非 `main` 分支不会触发正式站 `revalidate`、页面探活或发布通知
-- 如果用 OpenRouter，推荐统一口径为：
-  - `OPENAI_API_KEY=<OpenRouter key>`
-  - `OPENAI_BASE_URL=https://openrouter.ai/api/v1`
-  - `AI_MODEL=meta-llama/llama-3.3-70b-instruct` 或你实际在用的模型
+- 当前生产推荐统一使用 DeepSeek 官方接口：
+  - `OPENAI_API_KEY=<DeepSeek API key>`
+  - `OPENAI_BASE_URL=https://api.deepseek.com`
+  - `AI_MODEL=deepseek-v4-flash`
+  - Worker secret `LLM_API_KEY` 也必须使用独立的 DeepSeek Key，不要与其他项目共用
 
 ---
 

--- a/worker/src/enrich-llm.ts
+++ b/worker/src/enrich-llm.ts
@@ -25,6 +25,8 @@ export interface LLMOptions {
   baseUrl?: string;
 }
 
+export const LLM_MAX_OUTPUT_TOKENS = 8_192;
+
 // ---------------------------------------------------------------------------
 // Inlined from lib/puzzle-generation/answer-pattern.ts
 // ---------------------------------------------------------------------------
@@ -395,25 +397,7 @@ export async function callLLM(
     apiUrl = "https://api.openai.com/v1/chat/completions";
   }
 
-  const requestBody: Record<string, unknown> = {
-    messages: [
-      { role: "system", content: LLM_SYSTEM_PROMPT },
-      { role: "user", content: prompt },
-    ],
-    temperature: 0.7,
-    model,
-  };
-
-  // OpenAI-compatible models that we use in production support JSON object mode.
-  if (
-    model.includes("gpt-") ||
-    model.includes("glm-") ||
-    model.includes("gemini") ||
-    model.includes("deepseek/") ||
-    model.includes("llama")
-  ) {
-    requestBody.response_format = { type: "json_object" };
-  }
+  const requestBody = buildLLMRequestBody(prompt, model);
 
   for (let contentAttempt = 1; contentAttempt <= AI_EMPTY_CONTENT_MAX_ATTEMPTS; contentAttempt += 1) {
     debugLog?.(
@@ -433,9 +417,14 @@ export async function callLLM(
       debugLog,
     );
 
-    let data: { choices?: Array<{ message?: { content?: string } }> };
+    let data: {
+      choices?: Array<{
+        finish_reason?: string | null;
+        message?: { content?: string };
+      }>;
+    };
     try {
-      data = JSON.parse(responseText) as { choices?: Array<{ message?: { content?: string } }> };
+      data = JSON.parse(responseText) as typeof data;
     } catch (error) {
       throw new Error(
         `Failed to parse AI API response as JSON: ${
@@ -444,7 +433,14 @@ export async function callLLM(
       );
     }
 
-    const content = data.choices?.[0]?.message?.content;
+    const choice = data.choices?.[0];
+    if (choice?.finish_reason === "length") {
+      throw new Error(
+        `AI response was truncated at max_tokens=${LLM_MAX_OUTPUT_TOKENS}`,
+      );
+    }
+
+    const content = choice?.message?.content;
     if (content && content.trim()) {
       return content;
     }
@@ -457,6 +453,44 @@ export async function callLLM(
   }
 
   throw new Error("No content returned from AI");
+}
+
+function isDeepSeekV4Model(model: string): boolean {
+  return /^deepseek-v4-(?:flash|pro)(?:$|-)/i.test(model.trim());
+}
+
+export function buildLLMRequestBody(
+  prompt: string,
+  model: string,
+): Record<string, unknown> {
+  const requestBody: Record<string, unknown> = {
+    messages: [
+      { role: "system", content: LLM_SYSTEM_PROMPT },
+      { role: "user", content: prompt },
+    ],
+    max_tokens: LLM_MAX_OUTPUT_TOKENS,
+    temperature: 0.7,
+    model,
+    stream: false,
+  };
+
+  // OpenAI-compatible models that we use in production support JSON object mode.
+  if (
+    model.includes("gpt-") ||
+    model.includes("glm-") ||
+    model.includes("gemini") ||
+    model.includes("deepseek/") ||
+    isDeepSeekV4Model(model) ||
+    model.includes("llama")
+  ) {
+    requestBody.response_format = { type: "json_object" };
+  }
+
+  if (isDeepSeekV4Model(model)) {
+    requestBody.thinking = { type: "disabled" };
+  }
+
+  return requestBody;
 }
 
 // ---------------------------------------------------------------------------

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -57,14 +57,14 @@ AUTO_ENRICH_DRAFT_ATTEMPTS  = "2"
 AUTO_I18N_TIMEOUT_MS        = "90000"
 
 # Models
-AUTO_ENRICH_MODEL           = "meta-llama/llama-3.3-70b-instruct"
-AUTO_I18N_MODEL             = "meta-llama/llama-3.3-70b-instruct"
+AUTO_ENRICH_MODEL           = "deepseek-v4-flash"
+AUTO_I18N_MODEL             = "deepseek-v4-flash"
 
 # Legacy publish base — leave empty; old publish API no longer exists
 SITE_BASE_URL               = ""
 
 # Worker-side LLM (avoids Vercel Fluid CPU for enrichment)
-LLM_BASE_URL                = "https://openrouter.ai/api/v1"
+LLM_BASE_URL                = "https://api.deepseek.com"
 
 # ---------------------------------------------------------------------------
 # Secrets — set via Cloudflare Dashboard or `wrangler secret put <NAME>`
@@ -128,10 +128,10 @@ AUTO_PUBLISH_TIMEOUT_MS     = "15000"
 AUTO_ENRICH_TIMEOUT_MS      = "55000"
 AUTO_ENRICH_DRAFT_ATTEMPTS  = "1"
 AUTO_I18N_TIMEOUT_MS        = "90000"
-AUTO_ENRICH_MODEL           = "meta-llama/llama-3.3-70b-instruct"
-AUTO_I18N_MODEL             = "meta-llama/llama-3.3-70b-instruct"
+AUTO_ENRICH_MODEL           = "deepseek-v4-flash"
+AUTO_I18N_MODEL             = "deepseek-v4-flash"
 SITE_BASE_URL               = ""
-LLM_BASE_URL                = "https://openrouter.ai/api/v1"
+LLM_BASE_URL                = "https://api.deepseek.com"
 
 [[env.shadow.kv_namespaces]]
 binding = "PP_DATA"
@@ -174,10 +174,10 @@ AUTO_PUBLISH_TIMEOUT_MS     = "15000"
 AUTO_ENRICH_TIMEOUT_MS      = "55000"
 AUTO_ENRICH_DRAFT_ATTEMPTS  = "1"
 AUTO_I18N_TIMEOUT_MS        = "90000"
-AUTO_ENRICH_MODEL           = "meta-llama/llama-3.3-70b-instruct"
-AUTO_I18N_MODEL             = "meta-llama/llama-3.3-70b-instruct"
+AUTO_ENRICH_MODEL           = "deepseek-v4-flash"
+AUTO_I18N_MODEL             = "deepseek-v4-flash"
 SITE_BASE_URL               = ""
-LLM_BASE_URL                = "https://openrouter.ai/api/v1"
+LLM_BASE_URL                = "https://api.deepseek.com"
 
 [[env.staging.kv_namespaces]]
 binding = "PP_DATA"


### PR DESCRIPTION
## Summary
- switch Worker and site generation from OpenRouter to the official DeepSeek API
- use `deepseek-v4-flash` JSON mode with an explicit 8192-token output cap
- fail clearly when a response is truncated instead of parsing partial JSON

## Verification
- `npm run test:deepseek-api`
- `npm run typecheck`
- `npm run lint`
- `npm run test:pinpoint-guardrails`
- `cd worker && npm run typecheck`
- `cd worker && npm run deploy:dry`
- staging Worker version `a2a9d0a0-0954-4716-bbc0-c94f19653bc0` generated #854 as `enriched / published` with the official DeepSeek API

## Boundaries
- no homepage SEO copy changes
- no puzzle source data changes
- no unrelated main-worktree changes