### PR TITLE
Fix association fallback publishing for #857

### DIFF
--- a/docs/ITERATION.md
+++ b/docs/ITERATION.md
@@ -361,3 +361,14 @@
 剩余提示：详情页结构与发布检查通过，但关键词审计仍把三词第一名是 `linkedin pinpoint answer` 而不是线索短语标为 P1；本轮没有为词频提示改正文，也没有触发自动回滚。
 复查日期：`2026-09-02` 的正常发布窗口再次复查 DeepSeek 生产生成链路。
 下一步：观察 `2026-09-02` 15:00 发布窗口，确认新题能由生产 Worker 直接通过 DeepSeek 生成并正常进入 Production。
+
+## 2026-09-04 #857 关联类保底内容发布修复记录
+
+问题：生产 Worker 已抓到 #857 的五条真实线索和答案 `Things associated with tracks`，但 `Things associated with ...` 题型的保底生成会把每条线索原样写回 `phraseExample`。最终全文门槛因此报 `clueRows[0] phrase repeats the clue`，候选分支没有创建，正式站停在 #856。
+证据：生产 Worker 记录的抓取时间为 `2026-09-04T12:13:59.530Z`，来源校验哈希为 `sha256:76e7bb03370a8c7fd7a3261519dcd5bb3aef8ed37345635fb600e71a5658981b`；15:05 后的计划任务和 20:13 的手动重试都命中同一门槛。
+本轮边界：只修 Worker 的关联类保底短语、增加 #857 真实样本回归并准备补发；不改首页固定 SEO 标题/描述、URL、canonical、sitemap 规则、页面组件或原工作区未提交内容。
+修改：关联类保底短语现在明确写出线索与主题的连接，不再把裸线索冒充短语；原有最终全文门槛保持开启。回归覆盖 #857 五条真实线索、`fallback_full` 状态和最终公开发布资格。
+验证：#857 真实样本从原来的确定性失败变为通过；399 条 registry 数据校验、根目录与 Worker 类型检查、lint、Pinpoint 守卫、424 个静态页面完整构建和 Worker dry-run 全部通过。
+未做：本记录写入时尚未推送、合并、部署生产 Worker 或补发 #857；本地通过不能代替 Production 验收。
+复查日期：修复合并、Worker 部署和 #857 补发后立即复查。
+下一步：推送独立修复分支，经 CI 合并到 `main`，再部署生产 Worker 并用今天保存的真实来源补发 #857；最后核对 candidate、准确 Production SHA、summary、详情页、sitemap 和候选分支数量。

--- a/scripts/check-pinpoint-guardrails.ts
+++ b/scripts/check-pinpoint-guardrails.ts
@@ -4044,6 +4044,78 @@ async function checkWorkerFinalGuardRegeneratesAndUsesValidatedFallback() {
   });
   assert.equal(eligibility.ok, true, "#826 validated fallback must pass the final shared publish gate");
 
+  const associationWords = [
+    "Trains",
+    "Music albums",
+    "Adjustable ceiling lights",
+    "Olympic stadiums for running",
+    "Mud after animals walk in it",
+  ];
+  const associationDoc = {
+    version: 1,
+    puzzleDate: "2026-09-04",
+    answers: associationWords.map((word, index) => ({ rank: index + 1, word })),
+    source: "fallback-local",
+    fetchedAt: "2026-09-04T12:13:59.530Z",
+    checksum: "sha256:76e7bb03370a8c7fd7a3261519dcd5bb3aef8ed37345635fb600e71a5658981b",
+    theme: "Things associated with tracks",
+    mainAnswer: "Things associated with tracks",
+  };
+  const associationDetail = workerModule.buildTemplateFallbackDetailRecord(
+    "https://pinpointanswertoday.app",
+    "2026-09-04",
+    associationDoc,
+    857,
+    associationWords,
+  );
+  const associationDecision = workerModule.resolvePublicDetailExperienceDecision({
+    incoming: associationDetail,
+    existingBranchSummary: null,
+    primaryBranchSummary: null,
+  });
+  assert.equal(
+    associationDecision.action,
+    "use-full-analysis",
+    "association fallback must stay full-analysis instead of repeating bare clues",
+  );
+  assert.deepEqual(
+    associationDetail.clueRows.map((row) => row.phraseExample),
+    associationWords.map((clue) => `${clue} connected to tracks`),
+    "association fallback clue rows must state the clue-to-theme relationship",
+  );
+  const associationPayload = workerModule.buildValidatedTemplateFallbackPayload(
+    "https://pinpointanswertoday.app",
+    "2026-09-04",
+    associationDoc,
+    857,
+    associationWords,
+  );
+  assert.equal(
+    associationPayload.detailState,
+    "fallback_full",
+    "validated association fallback must remain publishable full content",
+  );
+  const associationEligibility = workerModule.validateWorkerPublishEligibility({
+    slug: "pinpoint-answer-857",
+    detail: associationDecision.record ?? associationDetail,
+    registryEntry: {
+      puzzleNumber: 857,
+      slug: "pinpoint-answer-857",
+      publishDate: "2026-09-04",
+      status: "live",
+      detailState: "fallback_full",
+      clues: associationWords,
+      mainAnswer: associationDoc.mainAnswer,
+    },
+    expectedMode: "full-analysis",
+    answerFirstPublicEnabled: false,
+  });
+  assert.equal(
+    associationEligibility.ok,
+    true,
+    "association fallback must pass the final shared publish gate",
+  );
+
   assert.throws(
     () => workerModule.buildValidatedTemplateFallbackPayload(
       "https://pinpointanswertoday.app",

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1510,6 +1510,9 @@ function buildWorkerFallbackPhrase(clue: string, answer: string): string {
     if (nounLoose && baseLoose.includes(nounLoose)) return normalizedBase;
     return `${normalizedBase} ${pattern.singularNoun}`.trim();
   }
+  if (pattern.kind === "association") {
+    return `${normalizedBase} connected to ${pattern.subject}`.trim();
+  }
   if (pattern.kind === "category") {
     const thingsThatAre = pattern.label.match(/^Things that are\s+(.+)$/i);
     const descriptor = thingsThatAre?.[1]?.trim();


### PR DESCRIPTION
## Summary
- generate non-repeating clue-to-theme phrases for association fallback puzzles
- add a regression using the real 2026-09-04 #857 Worker record
- document the incident and local verification

## Verification
- npm run validate:data
- npm run typecheck
- npm run lint
- npm run test:pinpoint-guardrails
- npm run build
- cd worker && npm run typecheck
- cd worker && npm run deploy:dry

## Scope
No homepage SEO, routes, sitemap rules, page components, or puzzle registry data changed.