### PR TITLE
Fix evidence-v1 rendered checks and publish Pinpoint 858

### DIFF
--- a/data/puzzles/pinpoint-answer-858.json
+++ b/data/puzzles/pinpoint-answer-858.json
@@ -1,0 +1,219 @@
+{
+  "puzzleNumber": 858,
+  "slug": "pinpoint-answer-858",
+  "publishDate": "2026-09-05",
+  "isoDate": "2026-09-05",
+  "detailState": "fallback_full",
+  "bodyMode": "standard",
+  "pageExperienceMode": "full-analysis",
+  "questionType": "phrase",
+  "difficultyBand": "hard",
+  "clues": [
+    "Race",
+    "Cable",
+    "Muscle",
+    "Rental",
+    "Plug-in hybrid"
+  ],
+  "answer": "Words that come before “car”",
+  "category": "Words that come before “car”",
+  "wordHints": {
+    "Race": "\"Race car\" is a familiar phrase, so it helps reveal the shared word quickly.",
+    "Cable": "\"Cable car\" is common enough to confirm the same missing word without stretching the phrasing.",
+    "Muscle": "Once the shared word is in place, \"Muscle car\" reads like ordinary language instead of a forced compound.",
+    "Rental": "\"Rental car\" is a familiar phrase, so it helps reveal the shared word quickly.",
+    "Plug-in hybrid": "\"Plug-in hybrid car\" is common enough to confirm the same missing word without stretching the phrasing."
+  },
+  "spoilerHints": {
+    "Race": "Try reading Race as part of a familiar phrase in words that come before “car” instead of as a standalone word.",
+    "Cable": "Cable works better once you test a fixed phrase pattern rather than a broad topic.",
+    "Muscle": "Look for a natural expression that absorbs Muscle cleanly before locking the board.",
+    "Rental": "Try reading Rental as part of a familiar phrase in words that come before “car” instead of as a standalone word.",
+    "Plug-in hybrid": "Plug-in hybrid is the clue that makes the phrase pattern in words that come before “car” concrete enough to test."
+  },
+  "articleBlocks": [
+    "The first clues make it clear this is a shared-word phrase puzzle, but not which ending word belongs after every clue without forcing the read. A nearby read was \"Race and Cable phrase pairing\". Race, Cable can support more than one phrase read before Plug-in hybrid shows where the repeated word belongs. Plug-in hybrid behaves like a proof clue for one fixed phrase pattern, not just an early two-clue guess.",
+    "Another easy trap was \"Plug-in hybrid as an outlier clue\". Plug-in hybrid can look like the odd clue if the earlier words are read without a shared phrase slot. Once Plug-in hybrid locks the phrase position, the full board resolves under one repeated word instead of five separate definitions.",
+    "Once that phrase appears, examples like \"Race car\" and \"Cable car\" stop feeling guessed and start reading like ordinary language under familiar phrases completed by one shared ending word.",
+    "Muscle car, Rental car, Plug-in hybrid car show that the same shared word fits in the same slot across the whole board, so the answer behaves like one complete phrase family instead of a few lucky matches.",
+    "The answer was \"Words that come before “car”\". More precisely, the board resolves as one shared ending word placed after each clue, not a loose topic grouping, which is why \"Words that come before “car”\" fits better than \"Race and Cable phrase pairing\" or \"Plug-in hybrid as an outlier clue\" once the full set is checked."
+  ],
+  "solutionNarrative": [
+    "I started with Race and first tried Race and Cable phrase pairing. That was plausible for a moment, because the opening clues were broad enough to support a few loose phrase reads. But none of those guesses made \"Plug-in hybrid\" feel exact.",
+    "Once \"Plug-in hybrid\" clicked, I stopped treating it like an outlier and tested the phrase position directly. The missing word could fit after the earlier clues without forcing them, which changed the solve from a topic guess into a repeatable word-slot check.",
+    "Then I used Muscle and Rental as the confirmation round. The strong solve was not just that two clues worked; it was that Race, Cable, Muscle, Rental, Plug-in hybrid could all use the same slot and still sound like ordinary language.",
+    "The answer was \"Words that come before “car”\"."
+  ],
+  "lessons": [
+    {
+      "title": "A false start with \"Race\" and \"Cable\"",
+      "body": "\"Race\" and \"Cable\" each work in multiple phrase frames, so it is better to wait for a clue that forces one exact missing word before committing."
+    },
+    {
+      "title": "\"Plug-in hybrid\" changes the car pattern from guess to test",
+      "body": "Once \"Plug-in hybrid\" lands, place the same word after the other clues and make sure they read naturally right away."
+    },
+    {
+      "title": "For Pinpoint 858, the car phrase test has to work five times",
+      "body": "A good answer should create phrases people actually say, not just words that seem related from a distance."
+    }
+  ],
+  "display": {
+    "connectorSummary": "familiar phrases completed by one shared ending word",
+    "fastStrategy": "\"Race\" and \"Cable\" each work in multiple phrase frames, so it is better to wait for a clue that forces one exact missing word before committing.",
+    "clueTableRows": [
+      {
+        "clue": "Race",
+        "examplePhrase": "Race car",
+        "connectionExplained": "\"Race car\" is a familiar phrase, so it helps reveal the shared word quickly."
+      },
+      {
+        "clue": "Cable",
+        "examplePhrase": "Cable car",
+        "connectionExplained": "\"Cable car\" is common enough to confirm the same missing word without stretching the phrasing."
+      },
+      {
+        "clue": "Muscle",
+        "examplePhrase": "Muscle car",
+        "connectionExplained": "Once the shared word is in place, \"Muscle car\" reads like ordinary language instead of a forced compound."
+      },
+      {
+        "clue": "Rental",
+        "examplePhrase": "Rental car",
+        "connectionExplained": "\"Rental car\" is a familiar phrase, so it helps reveal the shared word quickly."
+      },
+      {
+        "clue": "Plug-in hybrid",
+        "examplePhrase": "Plug-in hybrid car",
+        "connectionExplained": "\"Plug-in hybrid car\" is common enough to confirm the same missing word without stretching the phrasing."
+      }
+    ]
+  },
+  "faqs": [
+    {
+      "question": "What shared word links \"Race\" and \"Cable\" in LinkedIn Pinpoint #858?",
+      "answer": "The answer is \"Words that come before “car”\". That reading is the first one that turns all five clues into familiar phrases or common terms."
+    },
+    {
+      "question": "How do \"Race\" and \"Cable\" connect in LinkedIn Pinpoint #858?",
+      "answer": "The connection is familiar phrases completed by one shared ending word. The same word fits after every clue to create familiar phrases or everyday terms."
+    },
+    {
+      "question": "Why is \"Plug-in hybrid\" the key clue in LinkedIn Pinpoint #858?",
+      "answer": "\"Plug-in hybrid\" is the strongest clue because \"Plug-in hybrid car\" points to one exact phrase much faster than the earlier clues do."
+    }
+  ],
+  "solvePath": {
+    "firstRead": "The first clues make it clear this is a shared-word phrase puzzle, but not which ending word belongs after every clue without forcing the read.",
+    "falseStarts": [
+      "Race and Cable phrase pairing",
+      "Plug-in hybrid as an outlier clue"
+    ],
+    "whyFalseStartPlausible": [
+      "Race, Cable can support more than one phrase read before Plug-in hybrid shows where the repeated word belongs.",
+      "Plug-in hybrid can look like the odd clue if the earlier words are read without a shared phrase slot."
+    ],
+    "breakingClue": "Plug-in hybrid",
+    "pivot": "I started with Race and first tried Race and Cable phrase pairing. That was plausible for a moment, because the opening clues were broad enough to support a few loose phrase reads. But none of those guesses made \"Plug-in hybrid\" feel exact.\n\nOnce \"Plug-in hybrid\" clicked, I stopped treating it like an outlier and tested the phrase position directly. The missing word could fit after the earlier clues without forcing them, which changed the solve from a topic guess into a repeatable word-slot check.\n\nThen I used Muscle and Rental as the confirmation round. The strong solve was not just that two clues worked; it was that Race, Cable, Muscle, Rental, Plug-in hybrid could all use the same slot and still sound like ordinary language.\n\nThe answer was \"Words that come before “car”\".",
+    "fullBoardConfirmation": "Another easy trap was \"Plug-in hybrid as an outlier clue\". Plug-in hybrid can look like the odd clue if the earlier words are read without a shared phrase slot. Once Plug-in hybrid locks the phrase position, the full board resolves under one repeated word instead of five separate definitions."
+  },
+  "turningPoint": {
+    "clue": "Plug-in hybrid",
+    "whyDecisive": "Plug-in hybrid is the clue that makes the shared answer concrete enough to test across the full board.",
+    "whatChangedAfterIt": "Once Plug-in hybrid lands, the earlier clues stop feeling broad and start reading under the same answer."
+  },
+  "clueRows": [
+    {
+      "clue": "Race",
+      "surfaceMisread": "Race and Cable phrase pairing",
+      "resolvedPhraseOrMember": "Race car",
+      "nonObviousWhy": "\"Race car\" is a familiar phrase, so it helps reveal the shared word quickly.",
+      "searchableContext": "Race car",
+      "phraseExample": "Race car"
+    },
+    {
+      "clue": "Cable",
+      "surfaceMisread": "Race and Cable phrase pairing",
+      "resolvedPhraseOrMember": "Cable car",
+      "nonObviousWhy": "\"Cable car\" is common enough to confirm the same missing word without stretching the phrasing.",
+      "searchableContext": "Cable car",
+      "phraseExample": "Cable car"
+    },
+    {
+      "clue": "Muscle",
+      "surfaceMisread": "Race and Cable phrase pairing",
+      "resolvedPhraseOrMember": "Muscle car",
+      "nonObviousWhy": "Once the shared word is in place, \"Muscle car\" reads like ordinary language instead of a forced compound.",
+      "searchableContext": "Muscle car",
+      "phraseExample": "Muscle car"
+    },
+    {
+      "clue": "Rental",
+      "surfaceMisread": "Race and Cable phrase pairing",
+      "resolvedPhraseOrMember": "Rental car",
+      "nonObviousWhy": "\"Rental car\" is a familiar phrase, so it helps reveal the shared word quickly.",
+      "searchableContext": "Rental car",
+      "phraseExample": "Rental car"
+    },
+    {
+      "clue": "Plug-in hybrid",
+      "surfaceMisread": "Race and Cable phrase pairing",
+      "resolvedPhraseOrMember": "Plug-in hybrid car",
+      "nonObviousWhy": "\"Plug-in hybrid car\" is common enough to confirm the same missing word without stretching the phrasing.",
+      "searchableContext": "Plug-in hybrid car",
+      "phraseExample": "Plug-in hybrid car"
+    }
+  ],
+  "faqItems": [
+    {
+      "intentType": "solve_strategy",
+      "question": "What shared word links \"Race\" and \"Cable\" in LinkedIn Pinpoint #858?",
+      "answer": "The answer is \"Words that come before “car”\". That reading is the first one that turns all five clues into familiar phrases or common terms.",
+      "tiedClue": "Race"
+    },
+    {
+      "intentType": "solve_strategy",
+      "question": "How do \"Race\" and \"Cable\" connect in LinkedIn Pinpoint #858?",
+      "answer": "The connection is familiar phrases completed by one shared ending word. The same word fits after every clue to create familiar phrases or everyday terms.",
+      "tiedClue": "Race"
+    },
+    {
+      "intentType": "clue_background",
+      "question": "Why is \"Plug-in hybrid\" the key clue in LinkedIn Pinpoint #858?",
+      "answer": "\"Plug-in hybrid\" is the strongest clue because \"Plug-in hybrid car\" points to one exact phrase much faster than the earlier clues do.",
+      "tiedClue": "Plug-in hybrid"
+    }
+  ],
+  "uniquenessSignals": {
+    "angle": "familiar phrases completed by one shared ending word",
+    "relatedEntities": [
+      "Race car",
+      "Cable car",
+      "Muscle car",
+      "Rental car",
+      "Plug-in hybrid car"
+    ],
+    "doNotRepeatPatterns": [
+      "familiar phrases completed by one shared ending word",
+      "Race car",
+      "Cable car",
+      "Muscle car",
+      "Rental car"
+    ]
+  },
+  "wrongGuessCandidates": [
+    {
+      "label": "Race and Cable phrase pairing",
+      "whyPlausible": "Race, Cable can support more than one phrase read before Plug-in hybrid shows where the repeated word belongs.",
+      "whyRejected": "Plug-in hybrid behaves like a proof clue for one fixed phrase pattern, not just an early two-clue guess."
+    },
+    {
+      "label": "Plug-in hybrid as an outlier clue",
+      "whyPlausible": "Plug-in hybrid can look like the odd clue if the earlier words are read without a shared phrase slot.",
+      "whyRejected": "Once Plug-in hybrid locks the phrase position, the full board resolves under one repeated word instead of five separate definitions."
+    }
+  ],
+  "setValidationSummary": "Muscle car, Rental car, Plug-in hybrid car show that the same shared word fits in the same slot across the whole board, so the answer behaves like one complete phrase family instead of a few lucky matches.",
+  "categoryPrecisionNote": "one shared ending word placed after each clue, not a loose topic grouping",
+  "contentTemplateVersion": "evidence-v1"
+}

--- a/data/puzzles/pinpoint-answer-858.json
+++ b/data/puzzles/pinpoint-answer-858.json
@@ -18,11 +18,11 @@
   "answer": "Words that come before “car”",
   "category": "Words that come before “car”",
   "wordHints": {
-    "Race": "\"Race car\" is a familiar phrase, so it helps reveal the shared word quickly.",
-    "Cable": "\"Cable car\" is common enough to confirm the same missing word without stretching the phrasing.",
-    "Muscle": "Once the shared word is in place, \"Muscle car\" reads like ordinary language instead of a forced compound.",
-    "Rental": "\"Rental car\" is a familiar phrase, so it helps reveal the shared word quickly.",
-    "Plug-in hybrid": "\"Plug-in hybrid car\" is common enough to confirm the same missing word without stretching the phrasing."
+    "Race": "A race car is built or adapted for motor racing. Race describes the vehicle's competitive purpose, rather than an event that all five clues name.",
+    "Cable": "A cable car carries passengers using a moving cable. San Francisco's street-running cars grip a cable beneath the road, so car here need not mean a privately driven automobile.",
+    "Muscle": "A muscle car is a road car known for its powerful engine. Muscle refers to engine performance here, not a body part or a component fitted to every vehicle.",
+    "Rental": "A rental car is hired for temporary use instead of bought. Rental describes the arrangement for using the vehicle, not its engine, shape, or manufacturer.",
+    "Plug-in hybrid": "A plug-in hybrid car combines an electric motor and a fuel-burning engine, with a battery that can be charged from an external power supply. The full clue describes the powertrain and goes before car."
   },
   "spoilerHints": {
     "Race": "Try reading Race as part of a familiar phrase in words that come before “car” instead of as a standalone word.",
@@ -65,27 +65,27 @@
       {
         "clue": "Race",
         "examplePhrase": "Race car",
-        "connectionExplained": "\"Race car\" is a familiar phrase, so it helps reveal the shared word quickly."
+        "connectionExplained": "A race car is built or adapted for motor racing. Race describes the vehicle's competitive purpose, rather than an event that all five clues name."
       },
       {
         "clue": "Cable",
         "examplePhrase": "Cable car",
-        "connectionExplained": "\"Cable car\" is common enough to confirm the same missing word without stretching the phrasing."
+        "connectionExplained": "A cable car carries passengers using a moving cable. San Francisco's street-running cars grip a cable beneath the road, so car here need not mean a privately driven automobile."
       },
       {
         "clue": "Muscle",
         "examplePhrase": "Muscle car",
-        "connectionExplained": "Once the shared word is in place, \"Muscle car\" reads like ordinary language instead of a forced compound."
+        "connectionExplained": "A muscle car is a road car known for its powerful engine. Muscle refers to engine performance here, not a body part or a component fitted to every vehicle."
       },
       {
         "clue": "Rental",
         "examplePhrase": "Rental car",
-        "connectionExplained": "\"Rental car\" is a familiar phrase, so it helps reveal the shared word quickly."
+        "connectionExplained": "A rental car is hired for temporary use instead of bought. Rental describes the arrangement for using the vehicle, not its engine, shape, or manufacturer."
       },
       {
         "clue": "Plug-in hybrid",
         "examplePhrase": "Plug-in hybrid car",
-        "connectionExplained": "\"Plug-in hybrid car\" is common enough to confirm the same missing word without stretching the phrasing."
+        "connectionExplained": "A plug-in hybrid car combines an electric motor and a fuel-burning engine, with a battery that can be charged from an external power supply. The full clue describes the powertrain and goes before car."
       }
     ]
   },
@@ -127,7 +127,7 @@
       "clue": "Race",
       "surfaceMisread": "Race and Cable phrase pairing",
       "resolvedPhraseOrMember": "Race car",
-      "nonObviousWhy": "\"Race car\" is a familiar phrase, so it helps reveal the shared word quickly.",
+      "nonObviousWhy": "A race car is built or adapted for motor racing. Race describes the vehicle's competitive purpose, rather than an event that all five clues name.",
       "searchableContext": "Race car",
       "phraseExample": "Race car"
     },
@@ -135,7 +135,7 @@
       "clue": "Cable",
       "surfaceMisread": "Race and Cable phrase pairing",
       "resolvedPhraseOrMember": "Cable car",
-      "nonObviousWhy": "\"Cable car\" is common enough to confirm the same missing word without stretching the phrasing.",
+      "nonObviousWhy": "A cable car carries passengers using a moving cable. San Francisco's street-running cars grip a cable beneath the road, so car here need not mean a privately driven automobile.",
       "searchableContext": "Cable car",
       "phraseExample": "Cable car"
     },
@@ -143,7 +143,7 @@
       "clue": "Muscle",
       "surfaceMisread": "Race and Cable phrase pairing",
       "resolvedPhraseOrMember": "Muscle car",
-      "nonObviousWhy": "Once the shared word is in place, \"Muscle car\" reads like ordinary language instead of a forced compound.",
+      "nonObviousWhy": "A muscle car is a road car known for its powerful engine. Muscle refers to engine performance here, not a body part or a component fitted to every vehicle.",
       "searchableContext": "Muscle car",
       "phraseExample": "Muscle car"
     },
@@ -151,7 +151,7 @@
       "clue": "Rental",
       "surfaceMisread": "Race and Cable phrase pairing",
       "resolvedPhraseOrMember": "Rental car",
-      "nonObviousWhy": "\"Rental car\" is a familiar phrase, so it helps reveal the shared word quickly.",
+      "nonObviousWhy": "A rental car is hired for temporary use instead of bought. Rental describes the arrangement for using the vehicle, not its engine, shape, or manufacturer.",
       "searchableContext": "Rental car",
       "phraseExample": "Rental car"
     },
@@ -159,7 +159,7 @@
       "clue": "Plug-in hybrid",
       "surfaceMisread": "Race and Cable phrase pairing",
       "resolvedPhraseOrMember": "Plug-in hybrid car",
-      "nonObviousWhy": "\"Plug-in hybrid car\" is common enough to confirm the same missing word without stretching the phrasing.",
+      "nonObviousWhy": "A plug-in hybrid car combines an electric motor and a fuel-burning engine, with a battery that can be charged from an external power supply. The full clue describes the powertrain and goes before car.",
       "searchableContext": "Plug-in hybrid car",
       "phraseExample": "Plug-in hybrid car"
     }
@@ -213,7 +213,7 @@
       "whyRejected": "Once Plug-in hybrid locks the phrase position, the full board resolves under one repeated word instead of five separate definitions."
     }
   ],
-  "setValidationSummary": "Muscle car, Rental car, Plug-in hybrid car show that the same shared word fits in the same slot across the whole board, so the answer behaves like one complete phrase family instead of a few lucky matches.",
-  "categoryPrecisionNote": "one shared ending word placed after each clue, not a loose topic grouping",
+  "setValidationSummary": "Race and Muscle describe purpose or performance; Rental describes temporary use; Cable and Plug-in hybrid describe different ways of moving a vehicle. Their meanings differ, but each clue forms a complete term when car follows it.",
+  "categoryPrecisionNote": "The link is a word placed after every clue, not five interchangeable types of road automobile. Cable car is the useful distinction: a passenger vehicle pulled by a cable still completes the same word pattern.",
   "contentTemplateVersion": "evidence-v1"
 }

--- a/data/puzzles/registry.json
+++ b/data/puzzles/registry.json
@@ -18,7 +18,7 @@
     "seoTemplateVersion": "serp-v1",
     "contentTemplateVersion": "evidence-v1",
     "shortSummary": "Pinpoint Answer Today asks: what links Race, Cable, Muscle, Rental, Plug-in hybrid - and what story do they share? The set starts with a few plausible directions before one clue makes the clean reading hard to miss.",
-    "updatedAt": "2026-09-05T07:01:44.603Z"
+    "updatedAt": "2026-09-05T14:22:50.000Z"
   },
   {
     "puzzleNumber": 857,

--- a/data/puzzles/registry.json
+++ b/data/puzzles/registry.json
@@ -1,9 +1,30 @@
 [
   {
+    "puzzleNumber": 858,
+    "slug": "pinpoint-answer-858",
+    "publishDate": "2026-09-05",
+    "status": "live",
+    "detailState": "fallback_full",
+    "clues": [
+      "Race",
+      "Cable",
+      "Muscle",
+      "Rental",
+      "Plug-in hybrid"
+    ],
+    "mainAnswer": "Words that come before “car”",
+    "category": "Words that come before “car”",
+    "difficultyLevel": "Moderate",
+    "seoTemplateVersion": "serp-v1",
+    "contentTemplateVersion": "evidence-v1",
+    "shortSummary": "Pinpoint Answer Today asks: what links Race, Cable, Muscle, Rental, Plug-in hybrid - and what story do they share? The set starts with a few plausible directions before one clue makes the clean reading hard to miss.",
+    "updatedAt": "2026-09-05T07:01:44.603Z"
+  },
+  {
     "puzzleNumber": 857,
     "slug": "pinpoint-answer-857",
     "publishDate": "2026-09-04",
-    "status": "live",
+    "status": "archived",
     "detailState": "fallback_full",
     "clues": [
       "Trains",
@@ -17,7 +38,7 @@
     "difficultyLevel": "Moderate",
     "seoTemplateVersion": "serp-v1",
     "shortSummary": "Pinpoint Answer Today asks: what links Trains, Music albums, Adjustable ceiling lights, Olympic stadiums for running, Mud after animals walk in it - and what story do they share? The set starts with a few plausible directions before one clue makes the clean reading hard to miss.",
-    "updatedAt": "2026-09-04T13:37:35.137Z"
+    "updatedAt": "2026-09-05T07:01:44.603Z"
   },
   {
     "puzzleNumber": 856,

--- a/docs/ITERATION.md
+++ b/docs/ITERATION.md
@@ -400,3 +400,14 @@
 生产配置：`PINPOINT_CONTENT_TEMPLATE_MODE=canary`，名单准确为 `pinpoint-answer-858,pinpoint-answer-859,pinpoint-answer-860`；搜索描述实验仍为 `off`。生产 Worker 保持自动发布开启、未暂停、候选分支和 release queue 保护开启。
 线上验证：release queue 读取准确 `main=78575c8`、Production 状态为 `ready`；Worker health 仍返回 `#857` 的真实题目；正式 summary 仍为 `pinpoint-answer-857 live`，`#857` 详情 HTTP 200 且继续显示旧正文，sitemap 仍包含 `#857`。这证明代码和开关已上线，但没有回写旧页。
 尚未发生：`#858-#860` 都是未来页面，当前尚未生成，不能提前宣称正文页面或 GSC 收录结果成功。下一次正常发布先核对 `#858` 的详情 JSON、页面正文、candidate、Production 和 sitemap，再从发布日起按第 3、7、14 天检查 URL Inspection。
+
+## 2026-09-05 #858 新正文发布检查兼容修复
+
+问题：#858 已生成 `evidence-v1` 候选，但 CI `33951419592` 的真实 HTML 检查仍要求旧教学区至少 3 项，导致候选未发布。新正文有意不显示该区域，前次实现漏掉了这条检查的兼容。
+本轮边界：只修现有渲染检查及其回归，补实 #858 的五条线索解释，并恢复该页发布；不改首页固定 SEO、页面组件、旧页正文、URL、canonical、sitemap 规则、Worker 或三页试验名单。
+修改：旧正文保留原来的 3/2 项教学区要求；`evidence-v1` 改为验证五条线索、对应短语和解释真实出现在指定正文区，拒绝只在脚本数据中出现的内容、旧教学卡片及虚构第一人称解题，并保留最终答案确认。#858 同步更新 `wordHints`、`display.clueTableRows`、`clueRows` 和集合说明，registry 仅更新该页正文修改时间；旧题的正常 live/archived 转换沿用原候选。
+内容依据：Cable 的运行方式核对 [SFMTA](https://www.sfmta.com/blog/how-1906-earthquake-transformed-our-public-transit-system)，Plug-in hybrid 的动力和外部充电方式核对 [美国能源部 AFDC](https://afdc.energy.gov/vehicles/electric-basics-phev)。候选真实五条线索、正式答案和题目日期保持不变；没有将编辑后的解释伪装为 Worker 自动生成的新版本。
+验证：401 条数据校验、lint、类型检查、Pinpoint 守卫和 426 页完整构建通过；401 个真实详情页 HTML、sitemap 和首页最新链接检查通过。回归明确覆盖新旧正文正常输出，以及缺少解释、正文只在 script 中出现、错误区域、旧教学卡片、虚构解题和缺少最终答案等失败情况。
+发布路径：使用包含原候选提交的独立修复 PR，把检查修复和 #858 最终内容一起送入 CI；通过后以保留提交历史的 merge 合并。准确 Production SHA 和公开页面验收完成后，再通过现有候选关闭工具清理已包含的旧候选，不绕过检查直接推 main。
+尚未完成：本记录写入时还未提交、合并或部署；本地通过不代表正式页面已经上线或 Google 已收录。
+下一步：完成 PR、Production 和线上验收；每页从实际上线日起按第 3、7、14 天复查 GSC。14 天是投入复查点，不是 Google 必须恢复的期限。

--- a/scripts/check-pinpoint-guardrails.ts
+++ b/scripts/check-pinpoint-guardrails.ts
@@ -42,6 +42,7 @@ import {
 import { getPuzzleBySlug } from "../lib/puzzles/data";
 import { buildReasoningArticleDraft } from "../lib/puzzles/reasoning-article";
 import { resolveWorkerFetchRoute } from "../worker/src/routes/dispatch";
+import { checkRenderedContentTemplate } from "./check-pinpoint-rendered-content";
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(SCRIPT_DIR, "..");
@@ -4359,6 +4360,42 @@ async function checkEvidenceContentCanaryAssignment() {
     "answer",
     "evidence-v1 must keep the answer confirmation as the final block",
   );
+
+  // HTML fixtures exercise the same template check used on actual build output in CI.
+  const escapeHtml = (value: string) => value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  const fixtureHtml = draft.blocks.map((block) =>
+    `<article class="legacy-reasoning-block${block.variant === "answer" ? " legacy-reasoning-block-answer" : ""}">` +
+    `<h3>${escapeHtml(block.title ?? "")}</h3>${block.body.map((copy) => `<p>${escapeHtml(copy)}</p>`).join("")}` +
+    `<ul>${(block.bullets ?? []).map((copy) => `<li>${escapeHtml(copy)}</li>`).join("")}</ul></article>`,
+  ).join("");
+  const evidenceDetail = { ...puzzle, contentTemplateVersion: "evidence-v1" };
+  assert.deepEqual(checkRenderedContentTemplate(evidenceDetail, fixtureHtml), []);
+  assert.deepEqual(checkRenderedContentTemplate({
+    ...evidenceDetail,
+    clueRows: evidenceDetail.clueRows.map((row, index) => index === 0
+      ? { ...row, nonObviousWhy: `${row.nonObviousWhy} Use the table below to check the answer.` }
+      : row),
+  }, fixtureHtml), [], "render checks must respect the renderer's existing copy cleanup");
+  const teachingCards = '<div class="legacy-teaches-item"></div>'.repeat(3);
+  assert.deepEqual(checkRenderedContentTemplate({ pageExperienceMode: "full-analysis" }, teachingCards), []);
+  assert.deepEqual(checkRenderedContentTemplate({ bodyMode: "short" }, teachingCards.replace(/<div[^>]*><\/div>/, "")), []);
+  assert.ok(checkRenderedContentTemplate({ pageExperienceMode: "full-analysis" }, "").length > 0,
+    "legacy pages must still require their teaching cards");
+  assert.ok(checkRenderedContentTemplate(evidenceDetail, fixtureHtml.replace(/<li>[\s\S]*?<\/li>/, "")).length > 0,
+    "evidence pages must fail if a clue explanation is removed");
+  const missingExplanation = fixtureHtml.replace(/<li>[\s\S]*?<\/li>/, `<li>${escapeHtml(puzzle.clueRows[0].clue)}: ${escapeHtml(puzzle.clueRows[0].resolvedPhraseOrMember)}</li>`);
+  assert.ok(checkRenderedContentTemplate(evidenceDetail, missingExplanation).length > 0,
+    "a clue and phrase without their explanation must fail");
+  assert.ok(checkRenderedContentTemplate(evidenceDetail, `<script>${fixtureHtml}</script>`).length > 0,
+    "serialized data must never count as rendered evidence");
+  assert.ok(checkRenderedContentTemplate(evidenceDetail, fixtureHtml.replace("How Each Clue Fits", "Other section")).length > 0,
+    "clues elsewhere on the page must not replace the evidence block");
+  assert.ok(checkRenderedContentTemplate(evidenceDetail, fixtureHtml + teachingCards).length > 0,
+    "evidence pages must reject legacy teaching cards");
+  assert.ok(checkRenderedContentTemplate(evidenceDetail, fixtureHtml.replace("<p>", "<p>I started with a guess. ")).length > 0,
+    "evidence pages must reject fabricated solve copy");
+  assert.ok(checkRenderedContentTemplate(evidenceDetail, fixtureHtml.replace(" legacy-reasoning-block-answer", "")).length > 0,
+    "the final answer block must remain present");
 
   const detailSource = await readFile(resolve(ROOT, "components/detail/PuzzleFullAnalysis.tsx"), "utf8");
   const wranglerSource = await readFile(resolve(ROOT, "worker/wrangler.toml"), "utf8");

--- a/scripts/check-pinpoint-rendered-content.ts
+++ b/scripts/check-pinpoint-rendered-content.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { puzzleDetailContentSchema, registrySchema } from "../lib/puzzles/schema.shared.mjs";
+import { cleanReasoningText } from "../lib/puzzles/reasoning-article";
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(SCRIPT_DIR, "..");
@@ -25,6 +26,9 @@ type DetailRecord = {
   pageExperienceMode?: string;
   detailState?: string;
   bodyMode?: string;
+  contentTemplateVersion?: string;
+  answer?: string;
+  clueRows?: { clue: string; resolvedPhraseOrMember: string; nonObviousWhy: string }[];
 };
 
 type Issue = {
@@ -144,6 +148,54 @@ function countClass(markup: string, className: string): number {
 function extractTagText(markup: string, tagName: string): string[] {
   const matches = markup.matchAll(new RegExp(`<${tagName}\\b[^>]*>([\\s\\S]*?)<\\/${tagName}>`, "gi"));
   return Array.from(matches, (match) => stripTags(match[1] ?? ""));
+}
+
+export function checkRenderedContentTemplate(detail: DetailRecord, html: string): string[] {
+  const markup = stripScripts(html);
+  const teachingCardCount = countClass(markup, "legacy-teaches-item");
+  const pageMode = detail.pageExperienceMode ?? (detail.bodyMode === "short" ? "light-explainer" : "full-analysis");
+  const requiredFaqCount = pageMode === "full-analysis" ? 3 : 2;
+  if (detail.contentTemplateVersion !== "evidence-v1") {
+    return teachingCardCount < requiredFaqCount
+      ? [`Rendered teaching item count ${teachingCardCount} is below required ${requiredFaqCount} for ${pageMode}.`]
+      : [];
+  }
+
+  const errors: string[] = [];
+  const blocks = Array.from(markup.matchAll(/<article\b[^>]*>[\s\S]*?<\/article>/gi), (match) => match[0])
+    .filter((block) => countClass(block, "legacy-reasoning-block") > 0);
+  const evidenceBlocks = blocks.filter((block) =>
+    extractTagText(block, "h3").includes("How Each Clue Fits"),
+  );
+  const bullets = extractTagText(evidenceBlocks[0] ?? "", "li");
+  const rows = detail.clueRows ?? [];
+  if (evidenceBlocks.length !== 1 || bullets.length !== 5 || rows.length !== 5) {
+    errors.push("Evidence-v1 must render exactly one How Each Clue Fits block with five clue explanations.");
+  }
+  for (const [index, row] of rows.entries()) {
+    const bullet = normalizeForMatch(bullets[index] ?? "");
+    for (const label of ["clue", "resolvedPhraseOrMember", "nonObviousWhy"] as const) {
+      const value = row[label] ?? "";
+      const expected = normalizeForMatch(label === "clue" ? value : cleanReasoningText(value));
+      if (!expected || !` ${bullet} `.includes(` ${expected} `)) {
+        errors.push(`Evidence-v1 clue ${index + 1} is missing its rendered ${label}.`);
+      }
+    }
+  }
+  const reasoningText = stripTags(blocks.join(" "));
+  if (/\b(?:My first|I first|I started|first guess|the trap)\b/i.test(reasoningText)) {
+    errors.push("Evidence-v1 must not render fabricated first-person solving or false-start copy.");
+  }
+  if (teachingCardCount > 0 || stripTags(markup).includes("What This Pinpoint Teaches")) {
+    errors.push("Evidence-v1 must not render the legacy teaching section.");
+  }
+  const lastBlock = blocks.at(-1) ?? "";
+  const answer = normalizeForMatch(detail.answer ?? "");
+  if (countClass(lastBlock, "legacy-reasoning-block-answer") !== 1 || !answer ||
+      !normalizeForMatch(stripTags(lastBlock)).includes(answer)) {
+    errors.push("Evidence-v1 must end its reasoning with the answer confirmation.");
+  }
+  return errors;
 }
 
 function extractHrefValues(markup: string): string[] {
@@ -334,9 +386,6 @@ function checkDetailRendered(entry: RegistryEntry, allEntries: RegistryEntry[]) 
     bodyMarkup.matchAll(/<span class="legacy-reveal-clue-word">([\s\S]*?)<\/span>/g),
     (match) => stripTags(match[1] ?? ""),
   );
-  const teachingCardCount = countClass(bodyMarkup, "legacy-teaches-item");
-  const pageMode = detail.pageExperienceMode ?? (detail.bodyMode === "short" ? "light-explainer" : "full-analysis");
-  const requiredFaqCount = pageMode === "full-analysis" ? 3 : 2;
   const hrefs = new Set(extractHrefValues(bodyMarkup));
   const recentDetailLinkCount = allEntries
     .filter((candidate) => candidate.slug !== entry.slug)
@@ -389,8 +438,8 @@ function checkDetailRendered(entry: RegistryEntry, allEntries: RegistryEntry[]) 
       addIssue(entry.slug, `Rendered page still exposes old template label: ${legacyLabel}.`);
     }
   }
-  if (teachingCardCount < requiredFaqCount) {
-    addIssue(entry.slug, `Rendered teaching item count ${teachingCardCount} is below required ${requiredFaqCount} for ${pageMode}.`);
+  for (const message of checkRenderedContentTemplate({ ...detail, answer: entry.mainAnswer }, html)) {
+    addIssue(entry.slug, message);
   }
   if (!hrefs.has("/puzzles")) {
     addIssue(entry.slug, "Rendered detail page does not link back to /puzzles.");
@@ -458,4 +507,6 @@ function main() {
   console.log("ok: home page links to the latest public Pinpoint detail page");
 }
 
-main();
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main();
+}


### PR DESCRIPTION
## Summary
- Fix the existing rendered-content check to validate five evidence explanations and final answer for evidence-v1, while keeping legacy teaching-card checks intact.
- Improve the real #858 candidate explanations for Race, Cable, Muscle, Rental and Plug-in hybrid, keeping the official clues and answer unchanged.
- Include the original candidate commit so its branch can be closed after a merge commit and exact Production verification.
- No homepage SEO, older detail JSON, Worker, route, canonical, sitemap rules or experiment allowlist changes.

## Verification
- 401 registry records validated.
- Lint, TypeScript and Pinpoint guardrails passed, including positive and negative rendered-template fixtures.
- Full Next build: 426 pages. Actual rendered-content check: all 401 public detail pages, sitemap and homepage links passed.
- Production Worker still returns the matching real 2026-09-05 clues and answer.

## Release
Merge without squashing after CI passes. Then verify exact main SHA Production, #858 HTTP/HTML, summary and sitemap; close the already-contained candidate through the existing verification tool. Indexing results remain unverified until the scheduled GSC checkpoints.