### PR TITLE
Complete clue evidence for Pinpoint three-page recovery trial

### DIFF
--- a/data/puzzles/pinpoint-answer-859.json
+++ b/data/puzzles/pinpoint-answer-859.json
@@ -18,11 +18,11 @@
   "answer": "Things that are composted",
   "category": "Things that are composted",
   "wordHints": {
-    "Cardboard": "\"composted cardboard\" fits more cleanly once the board is tested under the same answer as the other clues.",
-    "Leaves": "\"composted leaves\" helps confirm the same answer instead of pulling the board back toward a looser guess.",
-    "Banana peels": "\"composted banana peels\" belongs in the same set as the rest of the board, which is why the answer sharpens once this pattern becomes visible.",
-    "Eggshells and egg cartons": "\"composted eggshells and egg cartons\" fits more cleanly once the board is tested under the same answer as the other clues.",
-    "Grass clippings and twigs": "\"Grass clippings and twigs\" is the clue that makes the shared answer concrete enough to test across the full board."
+    "Cardboard": "Plain cardboard provides carbon for a compost pile. Shred it and remove tape; wax-coated packaging is not the intended example.",
+    "Leaves": "Dry leaves are carbon-rich compost ingredients, linking garden waste with the paper packaging in the first clue.",
+    "Banana peels": "Banana peels are fruit scraps that can go into compost. They connect the kitchen leftovers to the garden materials.",
+    "Eggshells and egg cartons": "Crushed eggshells and plain paper egg cartons can join compost. Plastic or foam cartons do not fit this reading.",
+    "Grass clippings and twigs": "Grass clippings supply nitrogen; twigs supply carbon. This pair combines two different ingredients used in the same compost pile."
   },
   "spoilerHints": {
     "Cardboard": "Cardboard should be tested as part of things that are composted, not as a standalone reference.",
@@ -64,27 +64,27 @@
       {
         "clue": "Cardboard",
         "examplePhrase": "composted cardboard",
-        "connectionExplained": "\"composted cardboard\" fits more cleanly once the board is tested under the same answer as the other clues."
+        "connectionExplained": "Plain cardboard provides carbon for a compost pile. Shred it and remove tape; wax-coated packaging is not the intended example."
       },
       {
         "clue": "Leaves",
         "examplePhrase": "composted leaves",
-        "connectionExplained": "\"composted leaves\" helps confirm the same answer instead of pulling the board back toward a looser guess."
+        "connectionExplained": "Dry leaves are carbon-rich compost ingredients, linking garden waste with the paper packaging in the first clue."
       },
       {
         "clue": "Banana peels",
         "examplePhrase": "composted banana peels",
-        "connectionExplained": "\"composted banana peels\" belongs in the same set as the rest of the board, which is why the answer sharpens once this pattern becomes visible."
+        "connectionExplained": "Banana peels are fruit scraps that can go into compost. They connect the kitchen leftovers to the garden materials."
       },
       {
         "clue": "Eggshells and egg cartons",
         "examplePhrase": "composted eggshells and egg cartons",
-        "connectionExplained": "\"composted eggshells and egg cartons\" fits more cleanly once the board is tested under the same answer as the other clues."
+        "connectionExplained": "Crushed eggshells and plain paper egg cartons can join compost. Plastic or foam cartons do not fit this reading."
       },
       {
         "clue": "Grass clippings and twigs",
         "examplePhrase": "composted grass clippings and twigs",
-        "connectionExplained": "\"Grass clippings and twigs\" is the clue that makes the shared answer concrete enough to test across the full board."
+        "connectionExplained": "Grass clippings supply nitrogen; twigs supply carbon. This pair combines two different ingredients used in the same compost pile."
       }
     ]
   },
@@ -126,7 +126,7 @@
       "clue": "Cardboard",
       "surfaceMisread": "a broader umbrella topic",
       "resolvedPhraseOrMember": "composted cardboard",
-      "nonObviousWhy": "\"composted cardboard\" fits more cleanly once the board is tested under the same answer as the other clues.",
+      "nonObviousWhy": "Plain cardboard provides carbon for a compost pile. Shred it and remove tape; wax-coated packaging is not the intended example.",
       "searchableContext": "composted cardboard",
       "phraseExample": "composted cardboard"
     },
@@ -134,7 +134,7 @@
       "clue": "Leaves",
       "surfaceMisread": "a broader umbrella topic",
       "resolvedPhraseOrMember": "composted leaves",
-      "nonObviousWhy": "\"composted leaves\" helps confirm the same answer instead of pulling the board back toward a looser guess.",
+      "nonObviousWhy": "Dry leaves are carbon-rich compost ingredients, linking garden waste with the paper packaging in the first clue.",
       "searchableContext": "composted leaves",
       "phraseExample": "composted leaves"
     },
@@ -142,7 +142,7 @@
       "clue": "Banana peels",
       "surfaceMisread": "a broader umbrella topic",
       "resolvedPhraseOrMember": "composted banana peels",
-      "nonObviousWhy": "\"composted banana peels\" belongs in the same set as the rest of the board, which is why the answer sharpens once this pattern becomes visible.",
+      "nonObviousWhy": "Banana peels are fruit scraps that can go into compost. They connect the kitchen leftovers to the garden materials.",
       "searchableContext": "composted banana peels",
       "phraseExample": "composted banana peels"
     },
@@ -150,7 +150,7 @@
       "clue": "Eggshells and egg cartons",
       "surfaceMisread": "a broader umbrella topic",
       "resolvedPhraseOrMember": "composted eggshells and egg cartons",
-      "nonObviousWhy": "\"composted eggshells and egg cartons\" fits more cleanly once the board is tested under the same answer as the other clues.",
+      "nonObviousWhy": "Crushed eggshells and plain paper egg cartons can join compost. Plastic or foam cartons do not fit this reading.",
       "searchableContext": "composted eggshells and egg cartons",
       "phraseExample": "composted eggshells and egg cartons"
     },
@@ -158,7 +158,7 @@
       "clue": "Grass clippings and twigs",
       "surfaceMisread": "a broader umbrella topic",
       "resolvedPhraseOrMember": "composted grass clippings and twigs",
-      "nonObviousWhy": "\"Grass clippings and twigs\" is the clue that makes the shared answer concrete enough to test across the full board.",
+      "nonObviousWhy": "Grass clippings supply nitrogen; twigs supply carbon. This pair combines two different ingredients used in the same compost pile.",
       "searchableContext": "composted grass clippings and twigs",
       "phraseExample": "composted grass clippings and twigs"
     }
@@ -212,7 +212,7 @@
       "whyRejected": "The final answer works because it keeps every clue at the same level of specificity, not because one clue happens to fit first."
     }
   ],
-  "setValidationSummary": "Banana peels, Eggshells and egg cartons, Grass clippings and twigs keep the clues at the same category level, which is what makes the board feel like one exact set instead of a broad umbrella theme.",
-  "categoryPrecisionNote": "one concrete category with members that stay at the same level of specificity as Things that are composted",
+  "setValidationSummary": "A packing-material answer would miss the food scraps, while a garden-waste answer would miss the egg cartons. Composting is the shared destination that accounts for materials from all three sources.",
+  "categoryPrecisionNote": "The category describes a use for these discarded materials, not a word added before or after each clue. The carton clue assumes a paper version; the answer does not make every kind of packaging compostable.",
   "contentTemplateVersion": "evidence-v1"
 }

--- a/data/puzzles/pinpoint-answer-860.json
+++ b/data/puzzles/pinpoint-answer-860.json
@@ -234,7 +234,7 @@
       "whyRejected": "Once Continental breakfast lands, the final answer explains the board more cleanly than vacation amenities."
     }
   ],
-  "setValidationSummary": "Toiletries, Continental breakfast, Room service keep confirming the same answer, so the board reads like one exact set instead of a broad bucket.",
-  "categoryPrecisionNote": "one concrete category with members that stay at the same level of specificity as Things associated with hotels",
+  "setValidationSummary": "A packing list would not explain a room key issued at check-in or breakfast provided at the property. A restaurant alone would not explain bedroom appliances and bathroom supplies. A hotel stay brings those objects and services together.",
+  "categoryPrecisionNote": "The connection is association with a place, not a claim that every hotel includes all five amenities. Room service and breakfast may cost extra or be unavailable; they still belong to the hotel setting named by the answer.",
   "contentTemplateVersion": "evidence-v1"
 }

--- a/docs/ITERATION.md
+++ b/docs/ITERATION.md
@@ -1,5 +1,25 @@
 # Pinpoint Answer Today 迭代记录
 
+## 2026-09-09 三页恢复试验补齐
+
+授权：用户要求完成 #858、#859、#860 三页恢复试验。只补试验页解释并完成正常 PR、CI、生产验收和后续观察；不改变全站模板、首页 SEO、Worker、校验门槛、其他题目或索引设置。
+
+起点：独立 worktree `/Users/elng/web/pinpoint-answer-today-new-recovery`，分支 `codex/pinpoint-three-page-recovery`，基于远程 main `e473d1c0934b565a6983948e7f7273f8771eec4a`。原目录所有未提交改动保留。#858 已有具体五条解释，不再修改。#860 已正式上线，不沿用历史 404 判断。
+
+修改：#859 的 wordHints、display.clueTableRows、clueRows 同步写入五条实际堆肥解释，区分干叶/纸板、果皮、蛋壳/纸蛋盒、草屑/树枝，并补充整组范围。#860 只替换 setValidationSummary 和 categoryPrecisionNote，说明酒店把物品和服务联系起来，但不是每家酒店都提供所有项目。答案、线索、发布时间、registry、URL 和 contentTemplateVersion=evidence-v1 不变。保留不渲染的旧数据字段，避免把本轮扩大为生成器清理。
+
+内容依据：EPA https://www.epa.gov/recycle/composting-home 与 https://www.epa.gov/system/files/documents/2022-12/130-137.pdf 。解释为编辑整理，不冒充真人解题或人工审核凭证。
+
+当前已验证：validate:data（404 条）、lint、typecheck、test:pinpoint-guardrails、build（429 页）、test:pinpoint-rendered（404 详情页及首页/归档/sitemap）、git diff --check 全通过。三页构建 HTML 解码后均实际含五条对应解释，没有旧第一人称解题区和教学卡；临时字符串检查曾因 HTML 的 &#x27; 转义误报，修正解码后通过，未修改产品或门槛。生产生效仍须以 PR 合并后的部署及公开 HTML 为准，不能用本段本地结果替代。
+
+GSC 起始状态（2026-09-09 本任务实时查询）：#858、#860 为 URL is unknown to Google；#859 为 Discovered - currently not indexed；三页 lastCrawlTime 均为空。8 月 10 日至 9 月 6 日的完整全站 page 查询没有这三页的记录；#860 发布时间晚于这个窗口，不能算它在发布后零展示。没有提交收录请求。
+
+观察安排：旧自动化 pinpoint-858-860 经 App update 确认不存在，不把 view 卡片当成有效运行证明。新建当前任务 heartbeat `pinpoint`，每天北京时间 17:00 检查是否到了原检查点。#858：9 月 12/19 日；#859：9 月 13/20 日；#860：9 月 10/14/21 日。9 月 9 日补稿为中途调整，记录真实生产时间，不重置或延长 9 月 21 日终点。错过检查点只能补查并标实际日期。无变化保持安静；收录变化、故障、检查点结论及工具/权限失败才通知。本机和 Codex 须可运行，尚未验收未来触发和通知送达。
+
+最终判断：9 月 21 日按各页真实上线/修订时间、抓取时间、收录和完整日期展示判断；多页收录且多日持续展示才算初步恢复，单页或稀疏数据不足。仍无改善则建议停止主动 SEO 投入；证据缺失标未验证，不宣判域名永久无救。最终报告后暂停自动化，不自动删除网站、归档任务或继续加码。
+
+依赖提示：npm ci 按既有锁文件安装，报告 8 项漏洞（含 1 critical）；本轮未升级依赖或运行 audit fix，不能宣称已解决既有依赖风险。
+
 这个文件是 `new-pinpoint-site` 的长期优化记录。  
 以后每次改发布链、内容模板、SEO、页面结构、Worker 运维，都要在这里留下记录。
 


### PR DESCRIPTION
## Scope
- Keep #858 unchanged; improve five clue explanations on #859 and board summaries on #859/#860.
- Preserve answers, dates, registry, homepage SEO, templates, Worker and existing gates.
- Record the interrupted experiment and fixed September 21 review; future GSC recovery is not yet verified.

## Verification
- validate:data: 404 records
- lint, typecheck, Pinpoint guardrails: passed
- build: 429 pages
- rendered content: 404 detail pages plus sitemap/home/archive passed
- Three trial pages contain exact clue evidence in decoded server HTML, without legacy narrative/teaching sections

## Evidence
EPA composting guidance: https://www.epa.gov/recycle/composting-home and https://www.epa.gov/system/files/documents/2022-12/130-137.pdf

## Remaining
Production HTML verification after merge; GSC observation through September 21. Existing npm audit warnings are outside this content-only change.